### PR TITLE
Added new 'float_cmp' lint (see issue #46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Lints included in this crate:
  - `needless_bool` : Warns on if-statements with plain booleans in the then- and else-clause, e.g. `if p { true } else { false }`
  - `ptr_arg`: Warns on fn arguments of the type `&Vec<...>` or `&String`, suggesting to use `&[...]` or `&str` instead, respectively
  - `approx_constant`: Warns if the approximate of a known float constant (in `std::f64::consts` or `std::f32::consts`) is found and suggests to use the constant
+ - `cmp_nan`: Denies comparisons to NAN (which will always return false, which is probably not intended)
+ - `float_cmp`: Warns on `==` or `!=` comparisons of floaty typed values. As floating-point operations usually involve rounding errors, it is always better to check for approximate equality within some small bounds
+
+To use, add the following lines to your Cargo.toml:
+
+```
+[dev-dependencies.rust-clippy]
+git = "https://github.com/Manishearth/rust-clippy"
+```
 
 In your code, you may add `#![plugin(clippy)]` to use it (you may also need to include a `#![feature(plugin)]` line)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_lint_pass(box ptr_arg::PtrArg as LintPassObject);
     reg.register_lint_pass(box needless_bool::NeedlessBool as LintPassObject);
     reg.register_lint_pass(box approx_const::ApproxConstant as LintPassObject);
+    reg.register_lint_pass(box misc::FloatCmp as LintPassObject);
     
     reg.register_lint_group("clippy", vec![types::BOX_VEC, types::LINKEDLIST,
                                            misc::SINGLE_MATCH, misc::STR_TO_STRING,
@@ -41,6 +42,6 @@ pub fn plugin_registrar(reg: &mut Registry) {
                                            bit_mask::BAD_BIT_MASK, ptr_arg::PTR_ARG,
                                            needless_bool::NEEDLESS_BOOL,
                                            approx_const::APPROX_CONSTANT,
-                                           misc::CMP_NAN
+                                           misc::CMP_NAN, misc::FLOAT_CMP,
                                            ]);
 }

--- a/tests/compile-fail/cmp_nan.rs
+++ b/tests/compile-fail/cmp_nan.rs
@@ -2,6 +2,7 @@
 #![plugin(clippy)]
 
 #[deny(cmp_nan)]
+#[allow(float_cmp)]
 fn main() {
 	let x = 5f32;
 	x == std::f32::NAN; //~ERROR

--- a/tests/compile-fail/float_cmp.rs
+++ b/tests/compile-fail/float_cmp.rs
@@ -1,0 +1,35 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+use std::ops::Add;
+
+const ZERO : f32 = 0.0;
+const ONE : f32 = ZERO + 1.0;
+
+fn twice<T>(x : T) -> T where T : Add<T, Output = T>, T : Copy {
+	x + x
+}
+
+#[deny(float_cmp)]
+#[allow(unused)]
+fn main() {
+	ZERO == 0f32; //~ERROR
+	ZERO == 0.0; //~ERROR
+	ZERO + ZERO != 1.0; //~ERROR
+	
+	ONE != 0.0; //~ERROR
+	twice(ONE) != ONE; //~ERROR
+	ONE as f64 != 0.0; //~ERROR
+	
+	let x : f64 = 1.0;
+	
+	x == 1.0; //~ERROR
+	x != 0f64; //~ERROR
+	
+	twice(x) != twice(ONE as f64); //~ERROR
+	
+	x < 0.0;
+	x > 0.0;
+	x <= 0.0;
+	x >= 0.0;	
+}


### PR DESCRIPTION
I also updated the README a bit. Again, the code lives in `misc.rs` (because I reuse the walk_ty method, which I've pulled out of is_str).