### PR TITLE
macro expn detection in mut_mut.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ plugin = true
 compiletest_rs = "*"
 regex = "*"
 regex_macros = "*"
+lazy_static = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ plugin = true
 
 [dev-dependencies]
 compiletest_rs = "*"
+regex = "*"
+regex_macros = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(plugin_registrar, box_syntax)]
 #![feature(rustc_private, collections)]
-
 #![allow(unused_imports)]
 
 #[macro_use]

--- a/src/mut_mut.rs
+++ b/src/mut_mut.rs
@@ -27,7 +27,7 @@ impl LintPass for MutMut {
 }
 
 fn check_expr_expd(cx: &Context, expr: &Expr, info: Option<&ExpnInfo>) {
-	if in_external_macro(info) { return; }
+	if in_macro(info) { return; }
 
 	fn unwrap_addr(expr : &Expr) -> Option<&Expr> {
 		match expr.node {
@@ -51,8 +51,8 @@ fn check_expr_expd(cx: &Context, expr: &Expr, info: Option<&ExpnInfo>) {
 	})
 }
 
-fn in_external_macro(info: Option<&ExpnInfo>) -> bool {
-	info.map_or(false, |i| i.callee.span.is_some())
+fn in_macro(info: Option<&ExpnInfo>) -> bool {
+	info.is_some()
 }
 
 fn unwrap_mut(ty : &Ty) -> Option<&Ty> {

--- a/src/ptr_arg.rs
+++ b/src/ptr_arg.rs
@@ -27,7 +27,7 @@ impl LintPass for PtrArg {
     }
     
     fn check_item(&mut self, cx: &Context, item: &Item) {
-		if let &ItemFn(ref decl, _, _, _, _) = &item.node {
+		if let &ItemFn(ref decl, _, _, _, _, _) = &item.node {
 			check_fn(cx, decl);
 		}
 	}

--- a/tests/compile-fail/mut_mut.rs
+++ b/tests/compile-fail/mut_mut.rs
@@ -1,10 +1,17 @@
 #![feature(plugin)]
 #![plugin(clippy)]
 
+//#![plugin(regex_macros)]
+//extern crate regex;
+
 #[deny(mut_mut)]
 fn fun(x : &mut &mut u32) -> bool { //~ERROR
 	**x > 0
 }
+
+macro_rules! mut_ptr {
+	($p:expr) => { &mut $p }
+} 
 
 #[deny(mut_mut)]
 #[allow(unused_mut, unused_variables)]
@@ -22,4 +29,6 @@ fn main() {
 									   //~^^^^ ERROR
 		***y + **x;
 	}
+	
+	let mut z = mut_ptr!(&mut 3u32); //~ERROR
 }

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 fn run_mode(mode: &'static str) {
     let mut config = compiletest::default_config();
     let cfg_mode = mode.parse().ok().expect("Invalid mode");
-    config.target_rustcflags = Some("-L target/debug/".to_string());
+    config.target_rustcflags = Some("-l regex_macros -L target/debug/".to_string());
 
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));

--- a/tests/run-pass.rs
+++ b/tests/run-pass.rs
@@ -1,11 +1,31 @@
 #![feature(plugin)]
 #![plugin(clippy, regex_macros)]
 
+#[macro_use]
+extern crate lazy_static;
 extern crate regex;
+
+use std::collections::HashMap;
 
 #[test]
 #[deny(mut_mut)]
 fn test_regex() {
 	let pattern = regex!(r"^(?P<level>[#]+)\s(?P<title>.+)$");
 	assert!(pattern.is_match("# headline"));
+}
+
+#[test]
+#[deny(mut_mut)]
+#[allow(unused_variables, unused_mut)]
+fn test_lazy_static() {
+	lazy_static! {
+		static ref MUT_MAP : HashMap<usize, &'static str> = {
+			let mut m = HashMap::new();
+			let mut zero = &mut &mut "zero";
+			m.insert(0, "zero");
+			m
+		};
+		static ref MUT_COUNT : usize = MUT_MAP.len();
+	}
+	assert!(*MUT_COUNT == 1);
 }

--- a/tests/run-pass.rs
+++ b/tests/run-pass.rs
@@ -1,0 +1,11 @@
+#![feature(plugin)]
+#![plugin(clippy, regex_macros)]
+
+extern crate regex;
+
+#[test]
+#[deny(mut_mut)]
+fn test_regex() {
+	let pattern = regex!(r"^(?P<level>[#]+)\s(?P<title>.+)$");
+	assert!(pattern.is_match("# headline"));
+}


### PR DESCRIPTION
This relates to issue #67. We should add more tests, but I'm not too versed in macros, I'll have to learn them first.

1. `&mut &mut` by internal macro should warn
2. `&mut &mut' by external macro should not warn