### PR TITLE
extended compile-test.rs to actually observe TESTNAME ...

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -1,11 +1,17 @@
 extern crate compiletest_rs as compiletest;
 
 use std::path::PathBuf;
+use std::env::var;
 
 fn run_mode(mode: &'static str) {
     let mut config = compiletest::default_config();
+    
     let cfg_mode = mode.parse().ok().expect("Invalid mode");
-    config.target_rustcflags = Some("-L target/debug/".to_string());
+    config.target_rustcflags = Some("-L target/debug/".to_owned());
+	if let Ok(name) = var::<&str>("TESTNAME") {
+		let s : String = name.to_owned();
+		config.filter = Some(s)
+	}
 
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));


### PR DESCRIPTION
environment variable and filter tests if available.