### PR TITLE
fixed issue #88 in bit_mask

### DIFF
--- a/src/bit_mask.rs
+++ b/src/bit_mask.rs
@@ -89,20 +89,26 @@ fn check_compare(cx: &Context, bit_op: &Expr, cmp_op: BinOp_, cmp_value: u64, sp
 	}
 }
 
-fn check_bit_mask(cx: &Context, bit_op: BinOp_, cmp_op: BinOp_, mask_value: u64, cmp_value: u64, span: &Span) {
+fn check_bit_mask(cx: &Context, bit_op: BinOp_, cmp_op: BinOp_, 
+		mask_value: u64, cmp_value: u64, span: &Span) {
 	match cmp_op {
 		BiEq | BiNe => match bit_op {
 			BiBitAnd => if mask_value & cmp_value != mask_value {
-				cx.span_lint(BAD_BIT_MASK, *span, &format!("incompatible bit mask: _ & {} can never be equal to {}", mask_value,
-					cmp_value));
+				if cmp_value != 0 {
+					cx.span_lint(BAD_BIT_MASK, *span, &format!(
+						"incompatible bit mask: _ & {} can never be equal to {}", 
+						mask_value, cmp_value));
+				}
 			} else { 
 				if mask_value == 0 {
-					cx.span_lint(BAD_BIT_MASK, *span, &format!("&-masking with zero"));
+					cx.span_lint(BAD_BIT_MASK, *span, 
+						&format!("&-masking with zero"));
 				}
 			},
 			BiBitOr => if mask_value | cmp_value != cmp_value {
-				cx.span_lint(BAD_BIT_MASK, *span, &format!("incompatible bit mask: _ | {} can never be equal to {}", mask_value,
-					cmp_value));
+				cx.span_lint(BAD_BIT_MASK, *span, &format!(
+					"incompatible bit mask: _ | {} can never be equal to {}", 
+					mask_value, cmp_value));
 			},
 			_ => ()
 		},
@@ -113,7 +119,8 @@ fn check_bit_mask(cx: &Context, bit_op: BinOp_, cmp_op: BinOp_, mask_value: u64,
 					mask_value, cmp_value));
 			} else { 
 				if mask_value == 0 {
-					cx.span_lint(BAD_BIT_MASK, *span, &format!("&-masking with zero"));
+					cx.span_lint(BAD_BIT_MASK, *span, 
+						&format!("&-masking with zero"));
 				}
 			},
 			BiBitOr => if mask_value >= cmp_value {
@@ -136,7 +143,8 @@ fn check_bit_mask(cx: &Context, bit_op: BinOp_, cmp_op: BinOp_, mask_value: u64,
 					mask_value, cmp_value));
 			} else { 
 				if mask_value == 0 {
-					cx.span_lint(BAD_BIT_MASK, *span, &format!("&-masking with zero"));
+					cx.span_lint(BAD_BIT_MASK, *span, 
+						&format!("&-masking with zero"));
 				}
 			},
 			BiBitOr => if mask_value > cmp_value {

--- a/tests/compile-fail/bit_masks.rs
+++ b/tests/compile-fail/bit_masks.rs
@@ -11,6 +11,7 @@ fn main() {
 	
 	x & 0 == 0; //~ERROR &-masking with zero
 	x & 1 == 1; //ok, distinguishes bit 0
+	x & 1 == 0; //ok, compared with zero
 	x & 2 == 1; //~ERROR
 	x | 0 == 0; //ok, equals x == 0 (maybe warn?)
 	x | 1 == 3; //ok, equals x == 2 || x == 3


### PR DESCRIPTION
The problem was that the check for `_ & m == c` did not rule out the case `c == 0` which was a false positive. While at it, I also improved formatting a bit.