### PR TITLE
Fix build with rustc 1.2.0-nightly (20d23d8e5 2015-06-18)

### DIFF
--- a/src/mut_mut.rs
+++ b/src/mut_mut.rs
@@ -2,7 +2,7 @@ use syntax::ptr::P;
 use syntax::ast::*;
 use rustc::lint::{Context, LintPass, LintArray, Lint};
 use rustc::middle::ty::{expr_ty, TypeVariants, mt, TyRef};
-use syntax::codemap::{BytePos, ExpnInfo, MacroFormat, Span};
+use syntax::codemap::{BytePos, ExpnInfo, Span};
 use utils::in_macro;
 
 declare_lint!(pub MUT_MUT, Warn,


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/26347, MacroFormat was
renamed to ExpnFormat. MacroFormat wasn't being used in
src/mut_mut.rs, so I removed it.