### PR TITLE
Fix build for rustc 1.3.0-nightly (bf3c979ec 2015-06-30)

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -4,7 +4,7 @@ use syntax::ast::*;
 use syntax::ast_util::{is_comparison_binop, binop_to_string};
 use syntax::visit::{FnKind};
 use rustc::lint::{Context, LintPass, LintArray, Lint, Level};
-use rustc::middle::ty::{self, expr_ty};
+use rustc::middle::ty;
 use syntax::codemap::{Span, Spanned};
 
 use types::span_note_and_lint;
@@ -79,7 +79,7 @@ impl LintPass for StrToStringPass {
         }
 
         fn is_str(cx: &Context, expr: &ast::Expr) -> bool {
-            match walk_ty(expr_ty(cx.tcx, expr)).sty { 
+            match walk_ty(cx.tcx.expr_ty(expr)).sty { 
 				ty::TyStr => true,
 				_ => false
 			}
@@ -167,7 +167,7 @@ impl LintPass for FloatCmp {
 }
 
 fn is_float(cx: &Context, expr: &Expr) -> bool {
-	if let ty::TyFloat(_) = walk_ty(expr_ty(cx.tcx, expr)).sty { 
+	if let ty::TyFloat(_) = walk_ty(cx.tcx.expr_ty(expr)).sty { 
 		true
 	} else { 
 		false 
@@ -268,5 +268,5 @@ fn check_to_owned(cx: &Context, expr: &Expr, other_span: Span) {
 
 fn is_str_arg(cx: &Context, args: &[P<Expr>]) -> bool {
 	args.len() == 1 && if let ty::TyStr = 
-		walk_ty(expr_ty(cx.tcx, &*args[0])).sty { true } else { false }
+		walk_ty(cx.tcx.expr_ty(&*args[0])).sty { true } else { false }
 }

--- a/src/mut_mut.rs
+++ b/src/mut_mut.rs
@@ -1,7 +1,7 @@
 use syntax::ptr::P;
 use syntax::ast::*;
 use rustc::lint::{Context, LintPass, LintArray, Lint};
-use rustc::middle::ty::{expr_ty, TypeVariants, mt, TyRef};
+use rustc::middle::ty::{TypeVariants, mt, TyRef};
 use syntax::codemap::{BytePos, ExpnInfo, Span};
 use utils::in_macro;
 
@@ -43,7 +43,7 @@ fn check_expr_expd(cx: &Context, expr: &Expr, info: Option<&ExpnInfo>) {
 				"Generally you want to avoid &mut &mut _ if possible.")
 		}).unwrap_or_else(|| {
 			if let TyRef(_, mt{ty: _, mutbl: MutMutable}) = 
-					expr_ty(cx.tcx, e).sty {
+					cx.tcx.expr_ty(e).sty {
 				cx.span_lint(MUT_MUT, expr.span,
 					"This expression mutably borrows a mutable reference. \
 					Consider reborrowing")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,7 @@ pub fn in_external_macro(cx: &Context, span: Span) -> bool {
 /// usage e.g. with
 /// `match_def_path(cx, id, &["core", "option", "Option"])`
 pub fn match_def_path(cx: &Context, def_id: DefId, path: &[&str]) -> bool {
-	ty::with_path(cx.tcx, def_id, |iter| iter.map(|elem| elem.name())
+	cx.tcx.with_path(def_id, |iter| iter.map(|elem| elem.name())
 		.zip(path.iter()).all(|(nm, p)| &nm.as_str() == p))
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/commit/ad66c215aa2b20cf42968915571886e6ce8e9dd4 changed most of the `middle::ty` functions to methods.