### PR TITLE
new 'snippet' utils method, used where applicable

### DIFF
--- a/src/identity_op.rs
+++ b/src/identity_op.rs
@@ -7,6 +7,8 @@ use syntax::ast_util::{is_comparison_binop, binop_to_string};
 use syntax::ptr::P;
 use syntax::codemap::Span;
 
+use utils::snippet;
+
 declare_lint! { pub IDENTITY_OP, Warn,
     "Warn on identity operations, e.g. '_ + 0'"}
     
@@ -46,10 +48,9 @@ impl LintPass for IdentityOp {
 
 fn check(cx: &Context, e: &Expr, m: i8, span: Span, arg: Span) {
     if have_lit(cx, e, m) {
-        let map = cx.sess().codemap();
         cx.span_lint(IDENTITY_OP, span, &format!(
             "The operation is ineffective. Consider reducing it to '{}'", 
-            &*map.span_to_snippet(arg).unwrap_or("..".to_string())));
+           snippet(cx, arg, "..")));
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,8 @@ use rustc::lint::Context;
 use syntax::ast::{DefId, Name, Path};
 use syntax::codemap::{ExpnInfo, Span};
 use rustc::middle::ty;
+use std::borrow::{Cow, IntoCow};
+use std::convert::From;
 
 /// returns true if the macro that expanded the crate was outside of
 /// the current crate or was a compiler plugin
@@ -39,4 +41,10 @@ pub fn match_def_path(cx: &Context, def_id: DefId, path: &[&str]) -> bool {
 pub fn match_path(path: &Path, segments: &[&str]) -> bool {
 	path.segments.iter().rev().zip(segments.iter().rev()).all(
 		|(a,b)| a.identifier.as_str() == *b)
+}
+
+/// convert a span to a code snippet if available, otherwise use default, e.g.
+/// `snippet(cx, expr.span, "..")`
+pub fn snippet<'a>(cx: &Context, span: Span, default: &'a str) -> Cow<'a, str> {
+	cx.sess().codemap().span_to_snippet(span).map(From::from).unwrap_or(Cow::Borrowed(default))
 }


### PR DESCRIPTION
This makes use of `Cow<'a str>` (:cow:) to get rid of the String clones we get whenever a snippet isn't found, also it makes the code much more readable: 

Instead of `cx.sess().codemap().span_to_snippet(span).unwrap_or("..".to_string())))`, we get `snippet(cx, span, "..")`. Yay!

Finally, I'm a Rust Cow-boy :smile: