### PR TITLE
better help text for "match -> if let" lint

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -43,13 +43,20 @@ impl LintPass for MiscPass {
                     // an enum is extended. So we only consider cases where a `_` wildcard is used
                     if arms[1].pats[0].node == PatWild(PatWildSingle) && 
                             arms[0].pats.len() == 1 {
+                        let body_code = snippet(cx, arms[0].body.span, "..");
+                        let suggestion = if let ExprBlock(_) = arms[0].body.node {
+                            body_code.into_owned()
+                        } else {
+                            format!("{{ {} }}", body_code)
+                        };
                         span_help_and_lint(cx, SINGLE_MATCH, expr.span,
                               "You seem to be trying to use match for \
-                              destructuring a single type. Did you mean to \
+                              destructuring a single pattern. Did you mean to \
                               use `if let`?",
-                              &*format!("Try if let {} = {} {{ ... }}",
-                                      snippet(cx, arms[0].pats[0].span, ".."),
-                                      snippet(cx, ex.span, ".."))
+                              &*format!("Try\nif let {} = {} {}",
+                                        snippet(cx, arms[0].pats[0].span, ".."),
+                                        snippet(cx, ex.span, ".."),
+                                        suggestion)
                         );
                     }
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,10 +77,10 @@ pub fn span_lint(cx: &Context, lint: &'static Lint, sp: Span, msg: &str) {
     cx.span_lint(lint, sp, msg);
 }
 
-pub fn span_help_and_lint(cx: &Context, lint: &'static Lint, span: Span, 
+pub fn span_help_and_lint(cx: &Context, lint: &'static Lint, span: Span,
         msg: &str, help: &str) {
     span_lint(cx, lint, span, msg);
     if cx.current_level(lint) != Level::Allow {
-        cx.sess().span_help(span, help);
+        cx.sess().fileline_help(span, help);
     }
 }

--- a/tests/compile-fail/match_if_let.rs
+++ b/tests/compile-fail/match_if_let.rs
@@ -6,8 +6,10 @@
 fn main(){
     let x = Some(1u8);
     match x {  //~ ERROR You seem to be trying to use match
-               //~^ HELP Try if let Some(y) = x { ... }
-        Some(y) => println!("{:?}", y),
+               //~^ HELP Try
+        Some(y) => {
+            println!("{:?}", y);
+        }
         _ => ()
     }
     // Not linted
@@ -17,7 +19,7 @@ fn main(){
     }
     let z = (1u8,1u8);
     match z { //~ ERROR You seem to be trying to use match
-              //~^ HELP Try if let (2...3, 7...9) = z { ... }
+              //~^ HELP Try
         (2...3, 7...9) => println!("{:?}", z),
         _ => {}
     }


### PR DESCRIPTION
Implements the suggestion from #87.

Changes span_help_and_lint(), which is only used for this lint,
to use fileline_help() instead of span_help() to avoid printing
the span twice.

Also adds complete suggested new code. I had to distinguish
between blocks, which need no additionals braces, and other exprs.