### PR TITLE
new lint: warn if let-binding has unit value (fixes #74)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_lint_pass(box strings::StringAdd as LintPassObject);
     reg.register_lint_pass(box returns::ReturnPass as LintPassObject);
     reg.register_lint_pass(box methods::MethodsPass as LintPassObject);
+    reg.register_lint_pass(box types::LetPass as LintPassObject);
 
     reg.register_lint_group("clippy", vec![types::BOX_VEC, types::LINKEDLIST,
                                            misc::SINGLE_MATCH, misc::STR_TO_STRING,
@@ -83,5 +84,6 @@ pub fn plugin_registrar(reg: &mut Registry) {
                                            misc::MODULO_ONE,
                                            methods::OPTION_UNWRAP_USED,
                                            methods::RESULT_UNWRAP_USED,
+                                           types::LET_UNIT_VALUE,
                                            ]);
 }

--- a/tests/compile-fail/let_unit.rs
+++ b/tests/compile-fail/let_unit.rs
@@ -1,0 +1,13 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+#![deny(let_unit_value)]
+
+fn main() {
+    let _x = println!("x");  //~ERROR this let-binding has unit value
+    let _y = 1;   // this is fine
+    let _z = ((), 1);  // this as well
+    if true {
+        let _a = ();  //~ERROR
+    }
+}


### PR DESCRIPTION
NOTE: as alluded to in the ticket, I added an `in_macro()` check.

I don't fully understand why it's necessary, but without it we get warnings in `regex!` macros during running `cargo test`.