### PR TITLE
Const cmp

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -115,8 +115,8 @@ impl PartialEq for ConstantVariant {
                     (FwAny, _) | (_, FwAny) | (Fw32, Fw32) | (Fw64, Fw64) => true,
                     _ => false,
                 } {
-                    match (ls.parse::<f64>(), rs.parse()) {
-                        (Ok(l), Ok(r)) => l == r,
+                    match (ls.parse::<f64>(), rs.parse::<f64>()) {
+                        (Ok(l), Ok(r)) => l.eq(&r),
                         _ => false,
                     }
                 } else { false },

--- a/tests/consts.rs
+++ b/tests/consts.rs
@@ -8,6 +8,7 @@ extern crate rustc;
 use clippy::consts::{constant, ConstantVariant};
 use clippy::consts::ConstantVariant::*;
 use syntax::ast::*;
+use syntax::parse::token::InternedString;
 use syntax::ptr::P;
 use syntax::codemap::{Spanned, COMMAND_LINE_SP};
 use std::mem;
@@ -39,5 +40,8 @@ fn check(expect: ConstantVariant, expr: &Expr) {
 fn test_lit() {
     check(ConstantBool(true), &lit(LitBool(true)));
     check(ConstantBool(false), &lit(LitBool(false)));
-
+    check(ConstantInt(0, UnsuffixedIntLit(Plus)),
+            &lit(LitInt(0, UnsuffixedIntLit(Plus))));
+    check(ConstantStr("cool!".into(), CookedStr), &lit(LitStr(
+        InternedString::new("cool!"), CookedStr)));
 }


### PR DESCRIPTION
This implements `PartialEq` and `PartialOrd` on Constants unifying the diverse Int- and Float-types. Could be used on #38, among others.