### PR TITLE
[RFC] new lint: type complexity (fixes #93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ string_add               | allow   | using `x + ..` where x is a `String`; sugge
 string_add_assign        | allow   | using `x = x + ..` where x is a `String`; suggests using `push_str()` instead
 string_to_string         | warn    | calling `String.to_string()` which is a no-op
 toplevel_ref_arg         | warn    | a function argument is declared `ref` (i.e. `fn foo(ref x: u8)`, but not `fn foo((ref x, ref y): (u8, u8))`)
+type_complexity          | warn    | usage of very complex types; recommends factoring out parts into `type` definitions
 unit_cmp                 | warn    | comparing unit values (which is always `true` or `false`, respectively)
 zero_width_space         | deny    | using a zero-width space in a string literal, which is confusing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_lint_pass(box lifetimes::LifetimePass as LintPassObject);
     reg.register_lint_pass(box ranges::StepByZero as LintPassObject);
     reg.register_lint_pass(box types::CastPass as LintPassObject);
+    reg.register_lint_pass(box types::TypeComplexityPass as LintPassObject);
 
     reg.register_lint_group("clippy", vec![
         approx_const::APPROX_CONSTANT,
@@ -111,6 +112,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         types::CAST_SIGN_LOSS,
         types::LET_UNIT_VALUE,
         types::LINKEDLIST,
+        types::TYPE_COMPLEXITY,
         types::UNIT_CMP,
         unicode::NON_ASCII_LITERAL,
         unicode::ZERO_WIDTH_SPACE,

--- a/tests/compile-fail/complex_types.rs
+++ b/tests/compile-fail/complex_types.rs
@@ -1,0 +1,44 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+#![deny(clippy)]
+#![allow(unused)]
+#![feature(associated_consts, associated_type_defaults)]
+
+type Alias = Vec<Vec<Box<(u32, u32, u32, u32)>>>; // no warning here
+
+const CST: (u32, (u32, (u32, (u32, u32)))) = (0, (0, (0, (0, 0)))); //~ERROR very complex type
+static ST: (u32, (u32, (u32, (u32, u32)))) = (0, (0, (0, (0, 0)))); //~ERROR very complex type
+
+struct S {
+    f: Vec<Vec<Box<(u32, u32, u32, u32)>>>, //~ERROR very complex type
+}
+
+struct TS(Vec<Vec<Box<(u32, u32, u32, u32)>>>); //~ERROR very complex type
+
+enum E {
+    V1(Vec<Vec<Box<(u32, u32, u32, u32)>>>), //~ERROR very complex type
+    V2 { f: Vec<Vec<Box<(u32, u32, u32, u32)>>> }, //~ERROR very complex type
+}
+
+impl S {
+    const A: (u32, (u32, (u32, (u32, u32)))) = (0, (0, (0, (0, 0)))); //~ERROR very complex type
+    fn impl_method(&self, p: Vec<Vec<Box<(u32, u32, u32, u32)>>>) { } //~ERROR very complex type
+}
+
+trait T {
+    const A: Vec<Vec<Box<(u32, u32, u32, u32)>>>; //~ERROR very complex type
+    type B = Vec<Vec<Box<(u32, u32, u32, u32)>>>; //~ERROR very complex type
+    fn method(&self, p: Vec<Vec<Box<(u32, u32, u32, u32)>>>); //~ERROR very complex type
+    fn def_method(&self, p: Vec<Vec<Box<(u32, u32, u32, u32)>>>) { } //~ERROR very complex type
+}
+
+fn test1() -> Vec<Vec<Box<(u32, u32, u32, u32)>>> { vec![] } //~ERROR very complex type
+
+fn test2(_x: Vec<Vec<Box<(u32, u32, u32, u32)>>>) { } //~ERROR very complex type
+
+fn test3() {
+    let _y: Vec<Vec<Box<(u32, u32, u32, u32)>>> = vec![]; //~ERROR very complex type
+}
+
+fn main() {
+}


### PR DESCRIPTION
So for this one I introduced a state to the lint pass struct, this has precedent in some rustc builtin lints so I think it's OK. The idea is that `check_ty` will be called for *all* sub-Tys, so by only walking "toplevel" types (which we want anyway) and adding the ids of all children to the set we avoid re-walking all sub-Tys.

The scoring method and the threshold obviously need to be tweaked a lot, but what I think should stay is that levels of nesting are penalized (i.e. `A<A<A<B>>>` is scored as more complex than `(A, A, A, B)`.  This could even be done in a quadratic fashion.