### PR TITLE
Fix doubleborrow of refcell in consts.rs

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -330,8 +330,13 @@ impl<'c, 'cc> ConstEvalContext<'c, 'cc> {
     /// lookup a possibly constant expression from a ExprPath
     fn fetch_path(&mut self, e: &Expr) -> Option<Constant> {
         if let Some(lcx) = self.lcx {
+            let mut maybe_id = None;
             if let Some(&PathResolution { base_def: DefConst(id), ..}) =
                 lcx.tcx.def_map.borrow().get(&e.id) {
+                maybe_id = Some(id);
+            }
+            // separate if lets to avoid doubleborrowing the defmap
+            if let Some(id) = maybe_id {
                 if let Some(const_expr) = lookup_const_by_id(lcx.tcx, id, None) {
                     let ret = self.expr(const_expr);
                     if ret.is_some() {


### PR DESCRIPTION
This causes a crash on refcell when there are nested const evals lookups.

r? @llogiq