### PR TITLE
collapsible_if: remove extraneous note output

### DIFF
--- a/src/collapsible_if.rs
+++ b/src/collapsible_if.rs
@@ -48,7 +48,6 @@ fn check_expr_expd(cx: &Context, e: &Expr, info: Option<&ExpnInfo>) {
                 if e.span.expn_id != sp.expn_id {
                     return;
                 }
-                cx.sess().note(&format!("{:?} -- {:?}", e.span, sp));
                 span_help_and_lint(cx, COLLAPSIBLE_IF, e.span,
                     "this if statement can be collapsed",
                     &format!("try\nif {} && {} {}",


### PR DESCRIPTION
This was probably a debug addition.