### PR TITLE
correct scoping for shadow lints

### DIFF
--- a/src/shadow.rs
+++ b/src/shadow.rs
@@ -81,8 +81,9 @@ fn check_pat<T>(cx: &Context, pat: &Pat, init: &Option<T>, span: Span,
             if is_binding(cx, pat) {
                 if bindings.contains(&name) {
                     lint_shadow(cx, name, span, pat.span, init);
+                } else {
+                    bindings.push(name);
                 }
-                bindings.push(name);
             }
             if let Some(ref p) = *inner { check_pat(cx, p, init, span, bindings); }
         },
@@ -161,6 +162,7 @@ fn check_expr(cx: &Context, expr: &Expr, bindings: &mut Vec<Name>) {
         },
         ExprMatch(ref init, ref arms, _) => {
             check_expr(cx, init, bindings);
+            let len = bindings.len();
             for ref arm in arms {
                 for ref pat in &arm.pats {
                     check_pat(cx, &pat, &Some(&**init), pat.span, bindings);
@@ -170,6 +172,7 @@ fn check_expr(cx: &Context, expr: &Expr, bindings: &mut Vec<Name>) {
                     check_expr(cx, guard, bindings);
                 }
                 check_expr(cx, &arm.body, bindings);
+                bindings.truncate(len);
             }
         },
         _ => ()

--- a/tests/compile-fail/shadow.rs
+++ b/tests/compile-fail/shadow.rs
@@ -19,4 +19,12 @@ fn main() {
     let x = first(x); //~ERROR: x is shadowed by first(x) which reuses
     let y = 1;
     let x = y; //~ERROR: x is shadowed by y in this declaration
+    
+    let o = Some(1u8);
+    
+    if let Some(p) = o { assert_eq!(1, p); }
+    match o {
+        Some(p) => p, // no error, because the p above is in its own scope
+        None => 0,
+    };
 }


### PR DESCRIPTION
also I now only push the name when it's not already bound, which should improve performance a bit.