### PR TITLE
Use FnKind::Closure, instead of ::FkClosure

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -22,7 +22,7 @@ impl LintPass for TopLevelRefPass {
     }
 
     fn check_fn(&mut self, cx: &Context, k: FnKind, decl: &FnDecl, _: &Block, _: Span, _: NodeId) {
-        if let FnKind::FkClosure = k {
+        if let FnKind::Closure = k {
             // Does not apply to closures
             return
         }


### PR DESCRIPTION
From what I can tell, the `FkClosure` variant got renamed to `Closure` in rust-lang/rust@2076cdd, which causes the clippy build to fail on the latest nightly (`rustc 1.4.0-nightly (7d78f2d33 2015-09-01)`). This commit simply renames the enum, fixing the problem.

I'm not terribly familiar with `rustc` internals so if this is the wrong way to fix the build problem, feel free to ignore! :)