### PR TITLE
extended pattern matching

### DIFF
--- a/src/shadow.rs
+++ b/src/shadow.rs
@@ -130,17 +130,17 @@ fn check_pat(cx: &Context, pat: &Pat, init: &Option<&Expr>, span: Span,
             },
         PatBox(ref inner) => {
             if let Some(ref initp) = *init {
-                match initp.node {
-                    ExprBox(_, ref inner_init) =>
-                        check_pat(cx, inner, &Some(&**inner_init), span, bindings),
-                    //TODO: ExprCall on Box::new
-                    _ => check_pat(cx, inner, init, span, bindings),
+                if let ExprBox(_, ref inner_init) = initp.node {
+                    check_pat(cx, inner, &Some(&**inner_init), span, bindings),
+                } else {
+                    check_pat(cx, inner, init, span, bindings),
                 }
             } else {
                 check_pat(cx, inner, init, span, bindings);
             }
         },
-        //PatRegion(P<Pat>, Mutability),
+        PatRegion(ref inner, _) =>
+            check_pat(cx, inner, init, span, bindings),
         //PatRange(P<Expr>, P<Expr>),
         //PatVec(Vec<P<Pat>>, Option<P<Pat>>, Vec<P<Pat>>),
         _ => (),

--- a/src/shadow.rs
+++ b/src/shadow.rs
@@ -60,7 +60,7 @@ fn check_decl(cx: &Context, decl: &Decl, bindings: &mut Vec<Name>) {
     if let DeclLocal(ref local) = decl.node {
         let Local{ ref pat, ref ty, ref init, id: _, span } = **local;
         if let &Some(ref t) = ty { check_ty(cx, t, bindings) }
-        if let &Some(ref o) = init { 
+        if let &Some(ref o) = init {
             check_expr(cx, o, bindings);
             check_pat(cx, pat, &Some(o), span, bindings);
         } else {
@@ -92,10 +92,9 @@ fn check_pat(cx: &Context, pat: &Pat, init: &Option<&Expr>, span: Span,
             if let Some(ref p) = *inner { check_pat(cx, p, init, span, bindings); }
         },
         //PatEnum(Path, Option<Vec<P<Pat>>>),
-        PatStruct(_, ref pfields, _) => 
-            if let Some(ref init_struct) = *init { // TODO follow
-                if let ExprStruct(_, ref efields, ref _base) = init_struct.node {
-                    // TODO: follow base
+        PatStruct(_, ref pfields, _) =>
+            if let Some(ref init_struct) = *init {
+                if let ExprStruct(_, ref efields, _) = init_struct.node {
                     for field in pfields {
                         let ident = field.node.ident;
                         let efield = efields.iter()
@@ -105,7 +104,7 @@ fn check_pat(cx: &Context, pat: &Pat, init: &Option<&Expr>, span: Span,
                     }
                 } else {
                     for field in pfields {
-                        check_pat(cx, &field.node.pat, &None, span, bindings);
+                        check_pat(cx, &field.node.pat, init, span, bindings);
                     }
                 }
             } else {
@@ -114,14 +113,14 @@ fn check_pat(cx: &Context, pat: &Pat, init: &Option<&Expr>, span: Span,
                 }
             },
         PatTup(ref inner) =>
-            if let Some(ref init_tup) = *init { //TODO: follow
+            if let Some(ref init_tup) = *init {
                 if let ExprTup(ref tup) = init_tup.node {
-                    for (i, p) in inner.iter().enumerate() { 
+                    for (i, p) in inner.iter().enumerate() {
                         check_pat(cx, p, &Some(&tup[i]), p.span, bindings);
                     }
                 } else {
                     for p in inner {
-                        check_pat(cx, p, &None, span, bindings);
+                        check_pat(cx, p, init, span, bindings);
                     }
                 }
             } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,7 +23,7 @@ pub fn in_macro(cx: &Context, opt_info: Option<&ExpnInfo>) -> bool {
                 if info.callee.name() == "closure expansion" {
                     return false;
                 }
-            }, 
+            },
             ExpnFormat::MacroAttribute(..) => {
                 // these are all plugins
                 return true;
@@ -177,11 +177,26 @@ pub fn span_lint(cx: &Context, lint: &'static Lint, sp: Span, msg: &str) {
 
 pub fn span_help_and_lint(cx: &Context, lint: &'static Lint, span: Span,
         msg: &str, help: &str) {
-    span_lint(cx, lint, span, msg);
+    cx.span_lint(lint, span, msg);
     if cx.current_level(lint) != Level::Allow {
         cx.sess().fileline_help(span, &format!("{}\nfor further information \
             visit https://github.com/Manishearth/rust-clippy/wiki#{}",
             help, lint.name_lower()))
+    }
+}
+
+pub fn span_note_and_lint(cx: &Context, lint: &'static Lint, span: Span,
+        msg: &str, note_span: Span, note: &str) {
+    cx.span_lint(lint, span, msg);
+    if cx.current_level(lint) != Level::Allow {
+        if note_span == span {
+            cx.sess().fileline_note(note_span, note)
+        } else {
+            cx.sess().span_note(note_span, note)
+        }
+        cx.sess().fileline_help(span, &format!("for further information visit \
+            https://github.com/Manishearth/rust-clippy/wiki#{}",
+            lint.name_lower()))
     }
 }
 

--- a/tests/compile-fail/matches.rs
+++ b/tests/compile-fail/matches.rs
@@ -39,14 +39,16 @@ fn single_match(){
 }
 
 fn ref_pats() {
-    let ref v = Some(0);
-    match v {  //~ERROR instead of prefixing all patterns with `&`
-        &Some(v) => println!("{:?}", v),
-        &None => println!("none"),
-    }
-    match v {  // this doesn't trigger, we have a different pattern
-        &Some(v) => println!("some"),
-        other => println!("other"),
+    {
+        let ref v = Some(0);
+        match v {  //~ERROR instead of prefixing all patterns with `&`
+            &Some(v) => println!("{:?}", v),
+            &None => println!("none"),
+        }
+        match v {  // this doesn't trigger, we have a different pattern
+            &Some(v) => println!("some"),
+            other => println!("other"),
+        }
     }
     let ref tup = (1, 2);
     match tup {  //~ERROR instead of prefixing all patterns with `&`

--- a/tests/compile-fail/shadow.rs
+++ b/tests/compile-fail/shadow.rs
@@ -18,7 +18,7 @@ fn main() {
     let x = (1, x); //~ERROR: x is shadowed by (1, x) which reuses
     let x = first(x); //~ERROR: x is shadowed by first(x) which reuses
     let y = 1;
-    let x = y; //~ERROR: x is shadowed by y in this declaration
+    let x = y; //~ERROR: x is shadowed by y
 
     let o = Some(1u8);
 


### PR DESCRIPTION
This is not yet complete; notably we could use ref/paren/block following (like in constants) here. However, it should already reduce the number of false positives a bit (e.g. for plain tuple patterns).