### PR TITLE
Only handle ranges starting with 0 for needless_range_loop (fixes #279)

### DIFF
--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -30,6 +30,10 @@ fn main() {
         println!("{} {}", vec[i], vec2[i]);
     }
 
+    for i in 5..vec.len() {      // not an error, not starting with 0
+        println!("{}", vec[i]);
+    }
+
     for _v in vec.iter() { } //~ERROR it is more idiomatic to loop over `&vec`
     for _v in vec.iter_mut() { } //~ERROR it is more idiomatic to loop over `&mut vec`
 


### PR DESCRIPTION
I can file a followup to suggest `take()` and `last()` for the cases when the bounds are lit integers,
but not zero.

r? @llogiq