### PR TITLE
Fix ICE

### DIFF
--- a/src/methods.rs
+++ b/src/methods.rs
@@ -1,6 +1,7 @@
 use syntax::ast::*;
 use rustc::lint::*;
 use rustc::middle::ty;
+use rustc::middle::subst::Subst;
 use std::iter;
 use std::borrow::Cow;
 
@@ -225,7 +226,7 @@ fn is_copy(cx: &Context, ast_ty: &Ty, item: &Item) -> bool {
         None => false,
         Some(ty) => {
             let env = ty::ParameterEnvironment::for_item(cx.tcx, item.id);
-            !ty.moves_by_default(&env, ast_ty.span)
+            !ty.subst(cx.tcx, &env.free_substs).moves_by_default(&env, ast_ty.span)
         }
     }
 }


### PR DESCRIPTION
Was causing the following ICE on servo due to unbound regions:

```
home/manishearth/Mozilla/servo/components/gfx/text/glyph.rs:355:10: 355:23 error: internal compiler error: cannot relate bound region: '_#0r <= ReEarlyBound(51364, TypeSpace, 0, 'a)
/home/manishearth/Mozilla/servo/components/gfx/text/glyph.rs:355 impl<'a> GlyphInfo<'a> {
                                                                          ^~~~~~~~~~~~~
note: the compiler unexpectedly panicked. this is a bug.
note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
thread 'rustc' panicked at 'Box<Any>', src/libsyntax/diagnostic.rs:176

stack backtrace:
   1:     0x7f92722bd569 - sys::backtrace::tracing::imp::write::h079cf364a48d995aMns
   2:     0x7f92722c5286 - panicking::on_panic::h0af95cd615077cb32ox
   3:     0x7f927228937e - rt::unwind::begin_unwind_inner::ha19c9fa5f9b03821GRw
   4:     0x7f926f23f2d7 - rt::unwind::begin_unwind::h14707709421042257701
   5:     0x7f926f23f296 - diagnostic::SpanHandler::span_bug::h6916614245ddff37QRA
   6:     0x7f9270333963 - middle::infer::region_inference::RegionVarBindings<'a, 'tcx>::make_subregion::he3d2e1a2482dab07bJy
   7:     0x7f92702f1f7e - middle::infer::region_inference::RegionVarBindings<'a, 'tcx>::make_eqregion::h69c77932f9701f69DIy
   8:     0x7f92702e9c26 - middle::infer::equate::Equate<'a, 'tcx>.TypeRelation<'a, 'tcx>::regions::hd94b909098ec4259gDt
   9:     0x7f92702e98f2 - iter::_&'a mut I.Iterator::next::h17507341540582404049
  10:     0x7f92702e8ec2 - middle::ty_relate::relate_substs::h7054866111559389909
  11:     0x7f92702e857b - middle::ty_relate::relate_item_substs::h6332465106605722059
  12:     0x7f92702e6cd6 - middle::ty_relate::super_relate_tys::h3573003706644934224
  13:     0x7f92702e3edd - middle::infer::equate::Equate<'a, 'tcx>.TypeRelation<'a, 'tcx>::tys::he3757d426668b5ddgzt
  14:     0x7f92702e4bf3 - middle::infer::sub::Sub<'a, 'tcx>.TypeRelation<'a, 'tcx>::relate_with_variance::h10432440036354080484
  15:     0x7f92702ecc51 - iter::_&'a mut I.Iterator::next::h11754882004804685290
  16:     0x7f92702ebef9 - middle::ty_relate::relate_substs::h17282916536938504362
  17:     0x7f92702ebb7b - middle::ty_relate::relate_item_substs::h2481470111944448962
  18:     0x7f92702eb923 - middle::ty_relate::ty..TraitRef<'tcx>.Relate<'a, 'tcx>::relate::h1926850038695327517
  19:     0x7f927035106e - middle::infer::InferCtxt<'a, 'tcx>::sub_trait_refs::h2860a69ca51fe660pWC
  20:     0x7f92703d9aac - middle::traits::select::SelectionContext<'cx, 'tcx>::match_impl::h4998541705fdb54ehYX
  21:     0x7f92703df228 - middle::ty::TraitDef<'tcx>::for_each_relevant_impl::h13667760450615414017
  22:     0x7f92703dc19b - middle::traits::select::SelectionContext<'cx, 'tcx>::assemble_candidates::h9a99066b7cda9ee0WNV
  23:     0x7f92703d0b73 - middle::traits::select::SelectionContext<'cx, 'tcx>::candidate_from_obligation::hd14ed0e70c2ebda1ssV
  24:     0x7f92702ac2ac - middle::traits::select::SelectionContext<'cx, 'tcx>::select::h4e9d10e148a117d0N5U
  25:     0x7f92703baca3 - middle::traits::fulfill::process_predicate::hcd395596852dcc14MUS
  26:     0x7f92703b9651 - middle::traits::fulfill::FulfillmentContext<'tcx>::select::h8be9c7e92eaadd2aeOS
  27:     0x7f92703b91a7 - middle::traits::fulfill::FulfillmentContext<'tcx>::select_where_possible::h284f076d04ee6ceaIMS
  28:     0x7f9270251163 - middle::traits::fulfill::FulfillmentContext<'tcx>::select_all_or_error::h4362e054458e2f977KS
  29:     0x7f92703558bf - middle::traits::type_known_to_meet_builtin_bound::h782190315c967cediMZ
  30:     0x7f927040be5b - middle::ty::TyS<'tcx>::impls_bound::h3290c6bf878ef034xha
  31:     0x7f9270355a4f - middle::ty::TyS<'tcx>::moves_by_default::hfa5f4ec97fd17593Oja
  32:     0x7f9247c51df6 - methods::is_copy::ha99ebb825fcdb6e4ate
                        at /home/manishearth/Mozilla/Wall/rust-clippy/src/methods.rs:228
  33:     0x7f9247c50ced - methods::MethodsPass.LintPass::check_item::h0f734c63eda0c3d3zee
                        at /home/manishearth/Mozilla/Wall/rust-clippy/src/methods.rs:91
  34:     0x7f92704bfb20 - lint::context::Context<'a, 'tcx>::with_lint_attrs::h9288545466317054733
  35:     0x7f92704c4e1e - lint::context::Context<'a, 'tcx>.Visitor<'v>::visit_mod::h950da8e9b6667627vSx
  36:     0x7f92704c01b4 - lint::context::Context<'a, 'tcx>::with_lint_attrs::h9288545466317054733
  37:     0x7f92704c4e1e - lint::context::Context<'a, 'tcx>.Visitor<'v>::visit_mod::h950da8e9b6667627vSx
  38:     0x7f92704c01b4 - lint::context::Context<'a, 'tcx>::with_lint_attrs::h9288545466317054733
  39:     0x7f92704c4e1e - lint::context::Context<'a, 'tcx>.Visitor<'v>::visit_mod::h950da8e9b6667627vSx
  40:     0x7f92704d20fb - lint::context::check_crate::h053d6d2dac2c55e4ucy
  41:     0x7f9272816d79 - driver::phase_3_run_analysis_passes::closure.20689
  42:     0x7f92727f4f33 - middle::ty::ctxt<'tcx>::create_and_enter::h11141936354077625890
  43:     0x7f92727f02cd - driver::phase_3_run_analysis_passes::h17824639219362387491
  44:     0x7f92727d37b6 - driver::compile_input::ha2eeb4ddf4ccab66Tba
  45:     0x7f927293584b - run_compiler::h109cd7dc120e4cb70bc
  46:     0x7f9272933167 - boxed::F.FnBox<A>::call_box::h6499549129824229154
  47:     0x7f9272932bd4 - rt::unwind::try::try_fn::h12831862872674318132
  48:     0x7f92722c4e28 - __rust_try
  49:     0x7f92722b1542 - rt::unwind::try::inner_try::h7ad94d24dbab5183zNw
  50:     0x7f9272932d68 - boxed::F.FnBox<A>::call_box::h13018385408625072274
  51:     0x7f92722c4273 - sys::thread::Thread::new::thread_start::h6529454a6c71bc13mXv
  52:     0x7f926ca186a9 - start_thread
  53:     0x7f9271f42eec - clone
  54:                0x0 - <unknown>
```