### PR TITLE
Don't show the explicit_iter_loop lint for arrays with more than 32 elements

### DIFF
--- a/src/loops.rs
+++ b/src/loops.rs
@@ -199,7 +199,7 @@ fn is_ref_iterable_type(cx: &Context, e: &Expr) -> bool {
     // no walk_ptrs_ty: calling iter() on a reference can make sense because it
     // will allow further borrows afterwards
     let ty = cx.tcx.expr_ty(e);
-    is_array(ty) ||
+    is_iterable_array(ty) ||
         match_type(cx, ty, &VEC_PATH) ||
         match_type(cx, ty, &LL_PATH) ||
         match_type(cx, ty, &["std", "collections", "hash", "map", "HashMap"]) ||
@@ -210,9 +210,10 @@ fn is_ref_iterable_type(cx: &Context, e: &Expr) -> bool {
         match_type(cx, ty, &["collections", "btree", "set", "BTreeSet"])
 }
 
-fn is_array(ty: ty::Ty) -> bool {
+fn is_iterable_array(ty: ty::Ty) -> bool {
+    //IntoIterator is currently only implemented for array sizes <= 32 in rustc
     match ty.sty {
-        ty::TyArray(..) => true,
+        ty::TyArray(_, 0...32) => true,
         _ => false
     }
 }

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -42,6 +42,8 @@ fn main() {
 
     for _v in [1, 2, 3].iter() { } //~ERROR it is more idiomatic to loop over `&[
     for _v in (&mut [1, 2, 3]).iter() { } // no error
+    for _v in [0; 32].iter() {} //~ERROR it is more idiomatic to loop over `&[
+    for _v in [0; 33].iter() {} // no error
     let ll: LinkedList<()> = LinkedList::new();
     for _v in ll.iter() { } //~ERROR it is more idiomatic to loop over `&ll`
     let vd: VecDeque<()> = VecDeque::new();


### PR DESCRIPTION
The IntoIterator trait is currently not implemented for arrays with more than
32 elements, so for longer arrays, the iter() or iter_mut() methods must be
used.

I.e. this compiles
```
for _ in &[0; 32] {}
```
but this does not:
```
for _ in &[0; 33] {}
```