### PR TITLE
Lint for loops with explicit counter variable (#159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints that give helpful tips to newbies and catch oversights.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 57 lints included in this crate:
+There are 58 lints included in this crate:
 
 name                                                                                                   | default | meaning
 -------------------------------------------------------------------------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -21,6 +21,7 @@ name                                                                            
 [cmp_owned](https://github.com/Manishearth/rust-clippy/wiki#cmp_owned)                                 | warn    | creating owned instances for comparing with others, e.g. `x == "foo".to_string()`
 [collapsible_if](https://github.com/Manishearth/rust-clippy/wiki#collapsible_if)                       | warn    | two nested `if`-expressions can be collapsed into one, e.g. `if x { if y { foo() } }` can be written as `if x && y { foo() }`
 [eq_op](https://github.com/Manishearth/rust-clippy/wiki#eq_op)                                         | warn    | equal operands on both sides of a comparison or bitwise combination (e.g. `x == x`)
+[explicit_counter_loop](https://github.com/Manishearth/rust-clippy/wiki#explicit_counter_loop)         | warn    | for-looping with an explicit counter when `_.enumerate()` would do
 [explicit_iter_loop](https://github.com/Manishearth/rust-clippy/wiki#explicit_iter_loop)               | warn    | for-looping over `_.iter()` or `_.iter_mut()` when `&_` or `&mut _` would do
 [float_cmp](https://github.com/Manishearth/rust-clippy/wiki#float_cmp)                                 | warn    | using `==` or `!=` on float values (as floating-point operations usually involve rounding errors, it is always better to check for approximate equality within small bounds)
 [identity_op](https://github.com/Manishearth/rust-clippy/wiki#identity_op)                             | warn    | using identity operations, e.g. `x + 0` or `y / 1`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         len_zero::LEN_WITHOUT_IS_EMPTY,
         len_zero::LEN_ZERO,
         lifetimes::NEEDLESS_LIFETIMES,
+        loops::EXPLICIT_COUNTER_LOOP,
         loops::EXPLICIT_ITER_LOOP,
         loops::ITER_NEXT_LOOP,
         loops::NEEDLESS_RANGE_LOOP,

--- a/src/loops.rs
+++ b/src/loops.rs
@@ -351,6 +351,7 @@ impl<'v, 't> Visitor<'v> for IncrementVisitor<'v, 't> {
                             }
                         },
                     ExprAssign(ref lhs, _) if lhs.id == expr.id => *state = VarState::DontWarn,
+                    ExprAddrOf(mutability,_) if mutability == MutMutable => *state = VarState::DontWarn,
                     _ => ()
                 }
             }
@@ -430,6 +431,7 @@ impl<'v, 't> Visitor<'v> for InitializeVisitor<'v, 't> {
                         } else {
                             VarState::DontWarn
                         }},
+                    ExprAddrOf(mutability,_) if mutability == MutMutable => self.state = VarState::DontWarn,
                     _ => ()
                 }
             }

--- a/src/loops.rs
+++ b/src/loops.rs
@@ -146,9 +146,9 @@ impl LintPass for LoopsPass {
                             if let Some(name) = visitor2.name {
                                 span_lint(cx, EXPLICIT_COUNTER_LOOP, expr.span,
                                           &format!("the variable `{0}` is used as a loop counter. Consider \
-                                                    using `for ({0}, item) in _.iter().enumerate()` \
-                                                    or similar iterators.",
-                                                   name));
+                                                    using `for ({0}, item) in {1}.enumerate()` \
+                                                    or similar iterators",
+                                                   name, snippet(cx, arg.span, "_")));
                             }
                         }
                     }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -7,7 +7,7 @@ use syntax::codemap::{Span, Spanned};
 use rustc_front::visit::FnKind;
 use rustc::middle::ty;
 
-use utils::{get_item_name, match_path, snippet, span_lint, walk_ptrs_ty};
+use utils::{get_item_name, match_path, snippet, span_lint, walk_ptrs_ty, is_integer_literal};
 use consts::constant;
 
 declare_lint!(pub TOPLEVEL_REF_ARG, Warn,
@@ -183,21 +183,12 @@ impl LintPass for ModuloOne {
     fn check_expr(&mut self, cx: &Context, expr: &Expr) {
         if let ExprBinary(ref cmp, _, ref right) = expr.node {
             if let &Spanned {node: BinOp_::BiRem, ..} = cmp {
-                if is_lit_one(right) {
+                if is_integer_literal(right, 1) {
                     cx.span_lint(MODULO_ONE, expr.span, "any number modulo 1 will be 0");
                 }
             }
         }
     }
-}
-
-fn is_lit_one(expr: &Expr) -> bool {
-    if let ExprLit(ref spanned) = expr.node {
-        if let LitInt(1, _) = spanned.node {
-            return true;
-        }
-    }
-    false
 }
 
 declare_lint!(pub REDUNDANT_PATTERN, Warn, "using `name @ _` in a pattern");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -244,6 +244,17 @@ pub fn walk_ptrs_ty_depth(ty: ty::Ty) -> (ty::Ty, usize) {
     inner(ty, 0)
 }
 
+pub fn is_integer_literal(expr: &Expr, value: u64) -> bool
+{
+    // FIXME: use constant folding
+    if let ExprLit(ref spanned) = expr.node {
+        if let LitInt(v, _) = spanned.node {
+            return v == value;
+        }
+    }
+    false
+}
+
 /// Produce a nested chain of if-lets and ifs from the patterns:
 ///
 ///     if_let_chain! {

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -179,4 +179,8 @@ fn main() {
     let mut _index = 1;
     if false { _index = 0 };
     for _v in &vec { _index += 1 }
+
+    let mut _index = 0;
+    { let mut _x = &mut _index; }
+    for _v in &vec { _index += 1 }
 }

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -14,9 +14,9 @@ impl Unrelated {
     }
 }
 
-#[deny(needless_range_loop, explicit_iter_loop, iter_next_loop, reverse_range_loop)]
+#[deny(needless_range_loop, explicit_iter_loop, iter_next_loop, reverse_range_loop, explicit_counter_loop)]
 #[deny(unused_collect)]
-#[allow(linkedlist)]
+#[allow(linkedlist,shadow_unrelated)]
 fn main() {
     let mut vec = vec![1, 2, 3, 4];
     let vec2 = vec![1, 2, 3, 4];
@@ -119,4 +119,64 @@ fn main() {
     let mut out = vec![];
     vec.iter().map(|x| out.push(x)).collect::<Vec<_>>(); //~ERROR you are collect()ing an iterator
     let _y = vec.iter().map(|x| out.push(x)).collect::<Vec<_>>(); // this is fine
+
+    // Loop with explicit counter variable
+    let mut _index = 0;
+    for _v in &vec { _index += 1 } //~ERROR the variable `_index` is used as a loop counter
+
+    let mut _index = 1;
+    _index = 0;
+    for _v in &vec { _index += 1 } //~ERROR the variable `_index` is used as a loop counter
+
+    let mut _index;
+    _index = 0;
+    for _v in &vec { _index += 1 } //~ERROR the variable `_index` is used as a loop counter
+    for _v in &vec { _index += 1 } // But this does not warn
+
+    // Potential false positives
+    let mut _index = 0;
+    _index = 1;
+    for _v in &vec { _index += 1 }
+
+    let mut _index = 0;
+    _index += 1;
+    for _v in &vec { _index += 1 }
+
+    let mut _index = 0;
+    if true { _index = 1 }
+    for _v in &vec { _index += 1 }
+
+    let mut _index = 0;
+    let mut _index = 1;
+    for _v in &vec { _index += 1 }
+
+    let mut _index = 0;
+    for _v in &vec { _index += 1; _index += 1 }
+
+    let mut _index = 0;
+    for _v in &vec { _index *= 2; _index += 1 }
+
+    let mut _index = 0;
+    for _v in &vec { _index = 1; _index += 1 }
+
+    let mut _index = 0;
+
+    for _v in &vec { let mut _index = 0; _index += 1 }
+
+    let mut _index = 0;
+    for _v in &vec { _index += 1; _index = 0; }
+
+    let mut _index = 0;
+    for _v in &vec { for _x in 0..1 { _index += 1; }; _index += 1 }
+
+    let mut _index = 0;
+    for x in &vec { if *x == 1 { _index += 1 } }
+
+    let mut _index = 0;
+    if true { _index = 1 };
+    for _v in &vec { _index += 1 }
+
+    let mut _index = 1;
+    if false { _index = 0 };
+    for _v in &vec { _index += 1 }
 }


### PR DESCRIPTION
This basically walks the AST of the loop looking for variables that are incremented exactly once per iteration. Then it walks the parent block to make sure that they're initialized to zero at the start of the loop.

The idea is simple, but avoiding false positives turned out to be tricky. We have to be sure that the initialization and increment aren't inside an if, match, or nested loop, that the counter isn't reassigned after initializing to zero, and so forth. So there's a fair amount of code here but I think it covers all the bases.

Limitations:
 * If there are nested loops, or another loop between declaration and use of the counter, it just gives up and doesn't warn
 * There could be false positives if the counter is modified through a mutable reference