### PR TITLE
less false positives for approx_const and float_cmp

### DIFF
--- a/src/approx_const.rs
+++ b/src/approx_const.rs
@@ -1,8 +1,5 @@
 use rustc::lint::*;
-use rustc::metadata::cstore::crate_metadata;
 use rustc_front::hir::*;
-use syntax::codemap::Span;
-use std::borrow::Borrow;
 use std::f64::consts as f64;
 use utils::span_lint;
 
@@ -32,36 +29,28 @@ impl LintPass for ApproxConstant {
 
     fn check_expr(&mut self, cx: &Context, e: &Expr) {
         if let &ExprLit(ref lit) = &e.node {
-            if let Some(res) = cx.tcx.def_map.borrow().get(&e.id) {
-                let krate = res.def_id().krate;
-                let cdata = &cx.sess().cstore.get_crate_data(krate);
-                let crate_data : &crate_metadata = cdata.borrow();
-                let name = &crate_data.name;
-                if name == "f32" || name == "f64" { return; }
-            }
-            check_lit(cx, lit, e.span);
+            check_lit(cx, lit, e);
         }
     }
 }
 
-fn check_lit(cx: &Context, lit: &Lit, span: Span) {
+fn check_lit(cx: &Context, lit: &Lit, e: &Expr) {
     match lit.node {
-        LitFloat(ref str, TyF32) => check_known_consts(cx, span, str, "f32"),
-        LitFloat(ref str, TyF64) => check_known_consts(cx, span, str, "f64"),
+        LitFloat(ref str, TyF32) => check_known_consts(cx, e, str, "f32"),
+        LitFloat(ref str, TyF64) => check_known_consts(cx, e, str, "f64"),
         LitFloatUnsuffixed(ref str) =>
-            check_known_consts(cx, span, str, "f{32, 64}"),
+            check_known_consts(cx, e, str, "f{32, 64}"),
         _ => ()
     }
 }
 
-fn check_known_consts(cx: &Context, span: Span, str: &str, module: &str) {
+fn check_known_consts(cx: &Context, e: &Expr, str: &str, module: &str) {
     if let Ok(value) = str.parse::<f64>() {
         for &(constant, name) in KNOWN_CONSTS {
-            if within_epsilon(constant, value) {
-                span_lint(cx, APPROX_CONSTANT, span, &format!(
-                    "approximate value of `{}::{}` found. \
-                    Consider using it directly", module, &name));
-            }
+            if !within_epsilon(constant, value) { continue; }
+            span_lint(cx, APPROX_CONSTANT, e.span, &format!(
+                "approximate value of `{}::{}` found. \
+                Consider using it directly", module, &name));
         }
     }
 }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -93,7 +93,7 @@ impl LintPass for FloatCmp {
                     return;
                 }
                 if let Some(name) = get_item_name(cx, expr) {
-                    if name == "eq" || name == "ne" ||
+                    if name == "eq" || name == "ne" || name == "is_nan" ||
                             name.as_str().starts_with("eq_") ||
                             name.as_str().ends_with("_eq") {
                         return;


### PR DESCRIPTION
I'm not entirely sure about the approx_const one, though; perhaps it'd be better to match the whole crate path?