### PR TITLE
implement iterating over an empty range lint as described in #330

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints that give helpful tips to newbies and catch oversights.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 56 lints included in this crate:
+There are 57 lints included in this crate:
 
 name                                                                                                   | default | meaning
 -------------------------------------------------------------------------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -48,6 +48,7 @@ name                                                                            
 [redundant_closure](https://github.com/Manishearth/rust-clippy/wiki#redundant_closure)                 | warn    | using redundant closures, i.e. `|a| foo(a)` (which can be written as just `foo`)
 [redundant_pattern](https://github.com/Manishearth/rust-clippy/wiki#redundant_pattern)                 | warn    | using `name @ _` in a pattern
 [result_unwrap_used](https://github.com/Manishearth/rust-clippy/wiki#result_unwrap_used)               | allow   | using `Result.unwrap()`, which might be better handled
+[reverse_range_loop](https://github.com/Manishearth/rust-clippy/wiki#reverse_range_loop)               | warn    | Iterating over an empty range, such as `10..0` or `5..5`
 [shadow_reuse](https://github.com/Manishearth/rust-clippy/wiki#shadow_reuse)                           | allow   | rebinding a name to an expression that re-uses the original value, e.g. `let x = x + 1`
 [shadow_same](https://github.com/Manishearth/rust-clippy/wiki#shadow_same)                             | allow   | rebinding a name to itself, e.g. `let mut x = &mut x`
 [shadow_unrelated](https://github.com/Manishearth/rust-clippy/wiki#shadow_unrelated)                   | allow   | The name is re-bound without even using the original value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         loops::EXPLICIT_ITER_LOOP,
         loops::ITER_NEXT_LOOP,
         loops::NEEDLESS_RANGE_LOOP,
+        loops::REVERSE_RANGE_LOOP,
         loops::UNUSED_COLLECT,
         loops::WHILE_LET_LOOP,
         matches::MATCH_REF_PATS,

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -34,17 +34,52 @@ fn main() {
         println!("{}", vec[i]);
     }
 
-    for i in 10..0 { //~ERROR this range is empty and this for loop will never run. Consider using `(0..10).rev()`
+    for i in 10..0 { //~ERROR this range is empty so this for loop will never run
         println!("{}", i);
     }
 
-    for i in 5..5 { //~ERROR this range is empty and this for loop will never run
+    for i in 5..5 { //~ERROR this range is empty so this for loop will never run
         println!("{}", i);
     }
 
     for i in 0..10 { // not an error, the start index is less than the end index
         println!("{}", i);
     }
+
+    for i in (10..0).rev() { // not an error, this is an established idiom for looping backwards on a range
+        println!("{}", i);
+    }
+
+    for i in (10..0).map(|x| x * 2) { // not an error, it can't be known what arbitrary methods do to a range
+        println!("{}", i);
+    }
+
+    // testing that the empty range lint folds constants
+    for i in 10..5+4 { //~ERROR this range is empty so this for loop will never run
+        println!("{}", i);
+    }
+
+    for i in (5+2)..(3-1) { //~ERROR this range is empty so this for loop will never run
+        println!("{}", i);
+    }
+
+    for i in (5+2)..(8-1) { //~ERROR this range is empty so this for loop will never run
+        println!("{}", i);
+    }
+
+    for i in (2*2)..(2*3) { // no error, 4..6 is fine
+        println!("{}", i);
+    }
+
+    let x = 42;
+    for i in x..10 { // no error, not constant-foldable
+        println!("{}", i);
+    }
+
+    /*
+    for i in (10..0).map(|x| x * 2) {
+        println!("{}", i);
+    }*/
 
     for _v in vec.iter() { } //~ERROR it is more idiomatic to loop over `&vec`
     for _v in vec.iter_mut() { } //~ERROR it is more idiomatic to loop over `&mut vec`

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -14,7 +14,7 @@ impl Unrelated {
     }
 }
 
-#[deny(needless_range_loop, explicit_iter_loop, iter_next_loop)]
+#[deny(needless_range_loop, explicit_iter_loop, iter_next_loop, reverse_range_loop)]
 #[deny(unused_collect)]
 #[allow(linkedlist)]
 fn main() {
@@ -32,6 +32,18 @@ fn main() {
 
     for i in 5..vec.len() {      // not an error, not starting with 0
         println!("{}", vec[i]);
+    }
+
+    for i in 10..0 { //~ERROR this range is empty and this for loop will never run. Consider using `(0..10).rev()`
+        println!("{}", i);
+    }
+
+    for i in 5..5 { //~ERROR this range is empty and this for loop will never run
+        println!("{}", i);
+    }
+
+    for i in 0..10 { // not an error, the start index is less than the end index
+        println!("{}", i);
     }
 
     for _v in vec.iter() { } //~ERROR it is more idiomatic to loop over `&vec`


### PR DESCRIPTION
This is a small implementation of a lint that warns when iterating over a range that is empty, causing the body of the for loop to never run. This lint catches things such as

```rust
for i in 42..10 { // <- warning raised
    println!("{}", i);
}
```
and
```rust
for i in 5..5 { // <- warning raised
    println!("{}", i);
}
```

In the first case, it raises a warning and suggests using `(10..42).rev()` instead if the intention was to iterate over the range in reverse, starting with 42 and ending at 10. In the second case, it simply raises a warning indicating that this loop will never be executed.

This implementation is pretty naive and doesn't attempt to fold constants. If there's a mechanism for folding constants, though, it would be easy to adapt this lint to use it. I'll be the first to admit that grammar and error messages are not my strong suit, so I'd welcome any and all comments and suggestions for messages or alternate names for this lint - as well as comments on my code!
