### PR TITLE
Upgrade Rust to rustc 1.5.0-nightly (b2f379cdc 2015-09-23)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.15"
+version = "0.0.16"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -24,19 +24,19 @@ impl LintPass for AttrPass {
 impl LateLintPass for AttrPass {
     fn check_item(&mut self, cx: &LateContext, item: &Item) {
         if is_relevant_item(item) {
-            check_attrs(cx, item.span, &item.ident, &item.attrs)
+            check_attrs(cx, item.span, &item.name, &item.attrs)
         }
     }
 
     fn check_impl_item(&mut self, cx: &LateContext, item: &ImplItem) {
         if is_relevant_impl(item) {
-            check_attrs(cx, item.span, &item.ident, &item.attrs)
+            check_attrs(cx, item.span, &item.name, &item.attrs)
         }
     }
 
     fn check_trait_item(&mut self, cx: &LateContext, item: &TraitItem) {
         if is_relevant_trait(item) {
-            check_attrs(cx, item.span, &item.ident, &item.attrs)
+            check_attrs(cx, item.span, &item.name, &item.attrs)
         }
     }
 }
@@ -88,7 +88,7 @@ fn is_relevant_expr(expr: &Expr) -> bool {
     }
 }
 
-fn check_attrs(cx: &LateContext, span: Span, ident: &Ident,
+fn check_attrs(cx: &LateContext, span: Span, name: &Name,
         attrs: &[Attribute]) {
     if in_macro(cx, span) { return; }
 
@@ -100,7 +100,7 @@ fn check_attrs(cx: &LateContext, span: Span, ident: &Ident,
                 span_lint(cx, INLINE_ALWAYS, attr.span, &format!(
                     "you have declared `#[inline(always)]` on `{}`. This \
                      is usually a bad idea. Are you sure?",
-                    ident.name));
+                    name));
             }
         }
     }

--- a/src/len_zero.rs
+++ b/src/len_zero.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc_front::hir::*;
+use syntax::ast::Name;
 use syntax::ptr::P;
 use syntax::codemap::{Span, Spanned};
 use rustc::middle::def_id::DefId;
@@ -51,7 +52,7 @@ impl LateLintPass for LenZero {
 
 fn check_trait_items(cx: &LateContext, item: &Item, trait_items: &[P<TraitItem>]) {
     fn is_named_self(item: &TraitItem, name: &str) -> bool {
-        item.ident.name == name && if let MethodTraitItem(ref sig, _) =
+        item.name == name && if let MethodTraitItem(ref sig, _) =
             item.node { is_self_sig(sig) } else { false }
     }
 
@@ -62,7 +63,7 @@ fn check_trait_items(cx: &LateContext, item: &Item, trait_items: &[P<TraitItem>]
                 span_lint(cx, LEN_WITHOUT_IS_EMPTY, i.span,
                           &format!("trait `{}` has a `.len(_: &Self)` method, but no \
                                     `.is_empty(_: &Self)` method. Consider adding one",
-                                   item.ident.name));
+                                   item.name));
             }
         };
     }
@@ -70,7 +71,7 @@ fn check_trait_items(cx: &LateContext, item: &Item, trait_items: &[P<TraitItem>]
 
 fn check_impl_items(cx: &LateContext, item: &Item, impl_items: &[P<ImplItem>]) {
     fn is_named_self(item: &ImplItem, name: &str) -> bool {
-        item.ident.name == name && if let MethodImplItem(ref sig, _) =
+        item.name == name && if let MethodImplItem(ref sig, _) =
             item.node { is_self_sig(sig) } else { false }
     }
 
@@ -82,7 +83,7 @@ fn check_impl_items(cx: &LateContext, item: &Item, impl_items: &[P<ImplItem>]) {
                           Span{ lo: s.lo, hi: s.lo, expn_id: s.expn_id },
                           &format!("item `{}` has a `.len(_: &Self)` method, but no \
                                     `.is_empty(_: &Self)` method. Consider adding one",
-                                   item.ident.name));
+                                   item.name));
                 return;
             }
         }
@@ -101,17 +102,17 @@ fn check_cmp(cx: &LateContext, span: Span, left: &Expr, right: &Expr, op: &str) 
     }
     match (&left.node, &right.node) {
         (&ExprLit(ref lit), &ExprMethodCall(ref method, _, ref args)) =>
-            check_len_zero(cx, span, method, args, lit, op),
+            check_len_zero(cx, span, &method.node, args, lit, op),
         (&ExprMethodCall(ref method, _, ref args), &ExprLit(ref lit)) =>
-            check_len_zero(cx, span, method, args, lit, op),
+            check_len_zero(cx, span, &method.node, args, lit, op),
         _ => ()
     }
 }
 
-fn check_len_zero(cx: &LateContext, span: Span, method: &SpannedIdent,
+fn check_len_zero(cx: &LateContext, span: Span, name: &Name,
                   args: &[P<Expr>], lit: &Lit, op: &str) {
     if let Spanned{node: LitInt(0, _), ..} = *lit {
-        if method.node.name == "len" && args.len() == 1 &&
+        if name.as_str() == "len" && args.len() == 1 &&
             has_is_empty(cx, &args[0]) {
                 span_lint(cx, LEN_ZERO, span, &format!(
                     "consider replacing the len comparison with `{}{}.is_empty()`",

--- a/src/loops.rs
+++ b/src/loops.rs
@@ -108,7 +108,7 @@ impl LateLintPass for LoopsPass {
             if let ExprMethodCall(ref method, _, ref args) = arg.node {
                 // just the receiver, no arguments
                 if args.len() == 1 {
-                    let method_name = method.node.name;
+                    let method_name = method.node;
                     // check for looping over x.iter() or x.iter_mut(), could use &x or &mut x
                     if method_name == "iter" || method_name == "iter_mut" {
                         if is_ref_iterable_type(cx, &args[0]) {
@@ -191,7 +191,7 @@ impl LateLintPass for LoopsPass {
     fn check_stmt(&mut self, cx: &LateContext, stmt: &Stmt) {
         if let StmtSemi(ref expr, _) = stmt.node {
             if let ExprMethodCall(ref method, _, ref args) = expr.node {
-                if args.len() == 1 && method.node.name == "collect" &&
+                if args.len() == 1 && method.node == "collect" &&
                         match_trait_method(cx, expr, &["core", "iter", "Iterator"]) {
                     span_lint(cx, UNUSED_COLLECT, expr.span, &format!(
                         "you are collect()ing an iterator and throwing away the result. \

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -40,9 +40,9 @@ impl LintPass for MethodsPass {
 
 impl LateLintPass for MethodsPass {
     fn check_expr(&mut self, cx: &LateContext, expr: &Expr) {
-        if let ExprMethodCall(ref ident, _, ref args) = expr.node {
+        if let ExprMethodCall(ref name, _, ref args) = expr.node {
             let (obj_ty, ptr_depth) = walk_ptrs_ty_depth(cx.tcx.expr_ty(&args[0]));
-            if ident.node.name == "unwrap" {
+            if name.node.as_str() == "unwrap" {
                 if match_type(cx, obj_ty, &OPTION_PATH) {
                     span_lint(cx, OPTION_UNWRAP_USED, expr.span,
                               "used unwrap() on an Option value. If you don't want \
@@ -54,7 +54,7 @@ impl LateLintPass for MethodsPass {
                                of Err values is preferred");
                 }
             }
-            else if ident.node.name == "to_string" {
+            else if name.node.as_str() == "to_string" {
                 if obj_ty.sty == ty::TyStr {
                     let mut arg_str = snippet(cx, args[0].span, "_");
                     if ptr_depth > 1 {
@@ -76,7 +76,7 @@ impl LateLintPass for MethodsPass {
     fn check_item(&mut self, cx: &LateContext, item: &Item) {
         if let ItemImpl(_, _, _, None, ref ty, ref items) = item.node {
             for implitem in items {
-                let name = implitem.ident.name;
+                let name = implitem.name;
                 if let MethodImplItem(ref sig, _) = implitem.node {
                     // check missing trait implementations
                     for &(method_name, n_args, self_kind, out_type, trait_name) in &TRAIT_METHODS {

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -173,10 +173,9 @@ impl LateLintPass for CmpOwned {
 
 fn check_to_owned(cx: &LateContext, expr: &Expr, other_span: Span) {
     match expr.node {
-        ExprMethodCall(Spanned{node: ref ident, ..}, _, ref args) => {
-            let name = ident.name;
-            if name == "to_string" ||
-                name == "to_owned" && is_str_arg(cx, args) {
+        ExprMethodCall(Spanned{node: ref name, ..}, _, ref args) => {
+            if name.as_str() == "to_string" ||
+                name.as_str() == "to_owned" && is_str_arg(cx, args) {
                     span_lint(cx, CMP_OWNED, expr.span, &format!(
                         "this creates an owned instance just for comparison. \
                          Consider using `{}.as_slice()` to compare without allocation",

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -19,10 +19,10 @@ impl LintPass for StepByZero {
 
 impl LateLintPass for StepByZero {
     fn check_expr(&mut self, cx: &LateContext, expr: &Expr) {
-        if let ExprMethodCall(Spanned { node: ref ident, .. }, _,
+        if let ExprMethodCall(Spanned { node: ref name, .. }, _,
                               ref args) = expr.node {
             // Only warn on literal ranges.
-            if ident.name == "step_by" && args.len() == 2 &&
+            if name.as_str() == "step_by" && args.len() == 2 &&
                 is_range(cx, &args[0]) && is_integer_literal(&args[1], 0) {
                 cx.span_lint(RANGE_STEP_BY_ZERO, expr.span,
                              "Range::step_by(0) produces an infinite iterator. \

--- a/src/shadow.rs
+++ b/src/shadow.rs
@@ -106,9 +106,9 @@ fn check_pat(cx: &LateContext, pat: &Pat, init: &Option<&Expr>, span: Span,
             if let Some(ref init_struct) = *init {
                 if let ExprStruct(_, ref efields, _) = init_struct.node {
                     for field in pfields {
-                        let ident = field.node.ident;
+                        let name = field.node.name;
                         let efield = efields.iter()
-                            .find(|ref f| f.ident.node == ident)
+                            .find(|ref f| f.name.node == name)
                             .map(|f| &*f.expr);
                         check_pat(cx, &field.node.pat, &efield, span, bindings);
                     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -105,10 +105,10 @@ pub fn match_path(path: &Path, segments: &[&str]) -> bool {
 pub fn get_item_name(cx: &LateContext, expr: &Expr) -> Option<Name> {
     let parent_id = cx.tcx.map.get_parent(expr.id);
     match cx.tcx.map.find(parent_id) {
-        Some(NodeItem(&Item{ ref ident, .. })) |
-        Some(NodeTraitItem(&TraitItem{ id: _, ref ident, .. })) |
-        Some(NodeImplItem(&ImplItem{ id: _, ref ident, .. })) => {
-            Some(ident.name)
+        Some(NodeItem(&Item{ ref name, .. })) |
+        Some(NodeTraitItem(&TraitItem{ id: _, ref name, .. })) |
+        Some(NodeImplItem(&ImplItem{ id: _, ref name, .. })) => {
+            Some(*name)
         },
         _ => None,
     }


### PR DESCRIPTION
Ident was removed in many HIR structures in favor of Name.