### PR TITLE
#333 Calling main: Catches calls to main unless #![no_std] attr set

### DIFF
--- a/tests/compile-fail/calling_main.rs
+++ b/tests/compile-fail/calling_main.rs
@@ -1,0 +1,11 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+#![deny(calling_main)]
+
+fn main() {}
+
+#[allow(dead_code)]
+fn calling_main() {
+    main(); //~ERROR calling into main() detected
+}
+


### PR DESCRIPTION
This implements the check for calls to the main(). The calling_main.rs test shows calls (or at least this test's call) to main() gets picked up on and there is code to suppress that check when #![no_std] is present. However, there is no test to demonstrate the latter works, reason being that the only no_std project I was able to set up uses libc which requires a two-arg main function to compile which in turn prevents addition of the same-named one-arg main function this lint is matching calls for.