### PR TITLE
Fix documentation that disagrees with code

### DIFF
--- a/src/ptr_arg.rs
+++ b/src/ptr_arg.rs
@@ -1,6 +1,6 @@
 //! Checks for usage of &Vec[_] and &String
 //!
-//! This lint is **warn** by default
+//! This lint is **allow** by default
 
 use rustc::lint::*;
 use rustc_front::hir::*;


### PR DESCRIPTION
Minor fix: the comment currently disagrees with the lint declaration.

Out of curiosity: why is this lint `allow` by default? It seems to me like this should be uncontroversial.