### PR TITLE
fix doc comment for if_let_chain!

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,9 +20,9 @@ pub const LL_PATH:     [&'static str; 3] = ["collections", "linked_list", "Linke
 ///
 ///     if_let_chain! {
 ///         [
-///             Some(y) = x,
+///             let Some(y) = x,
 ///             y.len() == 2,
-///             Some(z) = y,
+///             let Some(z) = y,
 ///         ],
 ///         {
 ///             block


### PR DESCRIPTION
I was browsing a PR and got intrigued by if_let_chain! (which looks fun), and it looks to me like the comment went stale.