### PR TITLE
new lint to detect `loop {}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 60 lints included in this crate:
+There are 61 lints included in this crate:
 
 name                                                                                                   | default | meaning
 -------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ name                                                                            
 [cmp_nan](https://github.com/Manishearth/rust-clippy/wiki#cmp_nan)                                     | deny    | comparisons to NAN (which will always return false, which is probably not intended)
 [cmp_owned](https://github.com/Manishearth/rust-clippy/wiki#cmp_owned)                                 | warn    | creating owned instances for comparing with others, e.g. `x == "foo".to_string()`
 [collapsible_if](https://github.com/Manishearth/rust-clippy/wiki#collapsible_if)                       | warn    | two nested `if`-expressions can be collapsed into one, e.g. `if x { if y { foo() } }` can be written as `if x && y { foo() }`
+[empty_loop](https://github.com/Manishearth/rust-clippy/wiki#empty_loop)                               | warn    | empty `loop {}` detected
 [eq_op](https://github.com/Manishearth/rust-clippy/wiki#eq_op)                                         | warn    | equal operands on both sides of a comparison or bitwise combination (e.g. `x == x`)
 [explicit_counter_loop](https://github.com/Manishearth/rust-clippy/wiki#explicit_counter_loop)         | warn    | for-looping with an explicit counter when `_.enumerate()` would do
 [explicit_iter_loop](https://github.com/Manishearth/rust-clippy/wiki#explicit_iter_loop)               | warn    | for-looping over `_.iter()` or `_.iter_mut()` when `&_` or `&mut _` would do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         len_zero::LEN_WITHOUT_IS_EMPTY,
         len_zero::LEN_ZERO,
         lifetimes::NEEDLESS_LIFETIMES,
+        loops::EMPTY_LOOP,
         loops::EXPLICIT_COUNTER_LOOP,
         loops::EXPLICIT_ITER_LOOP,
         loops::ITER_NEXT_LOOP,

--- a/tests/compile-fail/while_loop.rs
+++ b/tests/compile-fail/while_loop.rs
@@ -1,7 +1,7 @@
 #![feature(plugin)]
 #![plugin(clippy)]
 
-#![deny(while_let_loop)]
+#![deny(while_let_loop, empty_loop)]
 #![allow(dead_code, unused)]
 
 fn main() {
@@ -58,6 +58,6 @@ fn no_panic<T>(slice: &[T]) {
             Some(ele) => ele,
             None => break
         };
-        loop {}
+        loop {} //~ERROR empty `loop {}` detected.
     }
 }


### PR DESCRIPTION
I wanted a break from my Cow lint project, and seeing that during the while-let lint, "`loop {}`" popped up, I wrote a quick lint to detect that. :smile: