### PR TITLE
New lint for struct update that has no effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 67 lints included in this crate:
+There are 68 lints included in this crate:
 
 name                                                                                                   | default | meaning
 -------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -45,6 +45,7 @@ name                                                                            
 [needless_lifetimes](https://github.com/Manishearth/rust-clippy/wiki#needless_lifetimes)               | warn    | using explicit lifetimes for references in function arguments when elision rules would allow omitting them
 [needless_range_loop](https://github.com/Manishearth/rust-clippy/wiki#needless_range_loop)             | warn    | for-looping over a range of indices where an iterator over items would do
 [needless_return](https://github.com/Manishearth/rust-clippy/wiki#needless_return)                     | warn    | using a return statement like `return expr;` where an expression would suffice
+[needless_update](https://github.com/Manishearth/rust-clippy/wiki#needless_update)                     | warn    | using `{ ..base }` when there are no missing fields
 [non_ascii_literal](https://github.com/Manishearth/rust-clippy/wiki#non_ascii_literal)                 | allow   | using any literal non-ASCII chars in a string literal; suggests using the \\u escape instead
 [nonsensical_open_options](https://github.com/Manishearth/rust-clippy/wiki#nonsensical_open_options)   | warn    | nonsensical combination of options for opening a file
 [option_unwrap_used](https://github.com/Manishearth/rust-clippy/wiki#option_unwrap_used)               | allow   | using `Option.unwrap()`, which should at least get a better message using `expect()`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod mutex_atomic;
 pub mod zero_div_zero;
 pub mod open_options;
 pub mod needless_features;
+pub mod needless_update;
 
 mod reexport {
     pub use syntax::ast::{Name, Ident, NodeId};
@@ -96,6 +97,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_late_lint_pass(box zero_div_zero::ZeroDivZeroPass);
     reg.register_late_lint_pass(box mutex_atomic::MutexAtomic);
     reg.register_late_lint_pass(box needless_features::NeedlessFeaturesPass);
+    reg.register_late_lint_pass(box needless_update::NeedlessUpdatePass);
 
     reg.register_lint_group("clippy_pedantic", vec![
         methods::OPTION_UNWRAP_USED,
@@ -155,6 +157,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         needless_bool::NEEDLESS_BOOL,
         needless_features::UNSTABLE_AS_MUT_SLICE,
         needless_features::UNSTABLE_AS_SLICE,
+        needless_update::NEEDLESS_UPDATE,
         open_options::NONSENSICAL_OPEN_OPTIONS,
         precedence::PRECEDENCE,
         ptr_arg::PTR_ARG,

--- a/src/needless_update.rs
+++ b/src/needless_update.rs
@@ -1,0 +1,35 @@
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::middle::ty::TyStruct;
+use rustc_front::hir::{Expr, ExprStruct};
+
+use utils::span_lint;
+
+declare_lint! {
+    pub NEEDLESS_UPDATE,
+    Warn,
+    "using `{ ..base }` when there are no missing fields"
+}
+
+#[derive(Copy, Clone)]
+pub struct NeedlessUpdatePass;
+
+impl LintPass for NeedlessUpdatePass {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(NEEDLESS_UPDATE)
+    }
+}
+
+impl LateLintPass for NeedlessUpdatePass {
+    fn check_expr(&mut self, cx: &LateContext, expr: &Expr) {
+        if let ExprStruct(_, ref fields, Some(ref base)) = expr.node {
+            let ty = cx.tcx.expr_ty(expr);
+            if let TyStruct(def, _) = ty.sty {
+                if fields.len() == def.struct_variant().fields.len() {
+                    span_lint(cx, NEEDLESS_UPDATE, base.span,
+                              "struct update has no effect, all the fields \
+                              in the struct have already been specified");
+                }
+            }
+        }
+    }
+}

--- a/tests/compile-fail/needless_update.rs
+++ b/tests/compile-fail/needless_update.rs
@@ -1,0 +1,16 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+#![deny(needless_update)]
+
+struct S {
+    pub a: i32,
+    pub b: i32,
+}
+
+fn main() {
+    let base = S { a: 0, b: 0 };
+    S { ..base }; // no error
+    S { a: 1, ..base }; // no error
+    S { a: 1, b: 1, ..base }; //~ERROR struct update has no effect
+}


### PR DESCRIPTION
This is my first lint to Clippy. It is an implementaiton of rust-lang/rust#23199.

It does not implement side-effect check yet (see the Rust issue), but I think maybe Clippy should warn when the update has no effect except side-effect?