### PR TITLE
Compare float literals to stringified constants

### DIFF
--- a/tests/compile-fail/approx_const.rs
+++ b/tests/compile-fail/approx_const.rs
@@ -42,7 +42,7 @@ fn main() {
     let my_ln_2 = 0.6931471805599453; //~ERROR approximate value of `f{32, 64}::LN_2` found
     let no_ln_2 = 0.693;
 
-    let my_log10_e = 0.43429448190325176; //~ERROR approximate value of `f{32, 64}::LOG10_E` found
+    let my_log10_e = 0.43429448190325182; //~ERROR approximate value of `f{32, 64}::LOG10_E` found
     let no_log10_e = 0.434;
 
     let my_log2_e = 1.4426950408889634; //~ERROR approximate value of `f{32, 64}::LOG2_E` found


### PR DESCRIPTION
This PR changes the behaviour of `approx_const` (yet again) to convert constants and float literals to strings and then compare (as discussed in #408). I wasn't too sure of the best way to approach the potential rounding of the final digit, but this is what I've come up with for now. I don't have much background in Rust, so please correct me if my code is not very idiomatic!

I also considered making `KNOWN_CONSTS` a 4-tuple with a `max_digits` element, where after a certain amount of precision, it would only compare `max_digits` number of digits, rather than the entire length of the float literal, though I'm not sure if this would be necessary.