### PR TITLE
New lint for zip with array length instead of enumerate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 70 lints included in this crate:
+There are 71 lints included in this crate:
 
 name                                                                                                   | default | meaning
 -------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -53,6 +53,7 @@ name                                                                            
 [precedence](https://github.com/Manishearth/rust-clippy/wiki#precedence)                               | warn    | catches operations where precedence may be unclear. See the wiki for a list of cases caught
 [ptr_arg](https://github.com/Manishearth/rust-clippy/wiki#ptr_arg)                                     | warn    | fn arguments of the type `&Vec<...>` or `&String`, suggesting to use `&[...]` or `&str` instead, respectively
 [range_step_by_zero](https://github.com/Manishearth/rust-clippy/wiki#range_step_by_zero)               | warn    | using Range::step_by(0), which produces an infinite iterator
+[range_zip_with_len](https://github.com/Manishearth/rust-clippy/wiki#range_zip_with_len)               | warn    | zipping iterator with a range when enumerate() would do
 [redundant_closure](https://github.com/Manishearth/rust-clippy/wiki#redundant_closure)                 | warn    | using redundant closures, i.e. `|a| foo(a)` (which can be written as just `foo`)
 [redundant_pattern](https://github.com/Manishearth/rust-clippy/wiki#redundant_pattern)                 | warn    | using `name @ _` in a pattern
 [result_unwrap_used](https://github.com/Manishearth/rust-clippy/wiki#result_unwrap_used)               | allow   | using `Result.unwrap()`, which might be better handled

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         precedence::PRECEDENCE,
         ptr_arg::PTR_ARG,
         ranges::RANGE_STEP_BY_ZERO,
+        ranges::RANGE_ZIP_WITH_LEN,
         returns::LET_AND_RETURN,
         returns::NEEDLESS_RETURN,
         types::BOX_VEC,

--- a/tests/compile-fail/range.rs
+++ b/tests/compile-fail/range.rs
@@ -7,7 +7,7 @@ impl NotARange {
     fn step_by(&self, _: u32) {}
 }
 
-#[deny(range_step_by_zero)]
+#[deny(range_step_by_zero, range_zip_with_len)]
 fn main() {
     (0..1).step_by(0); //~ERROR Range::step_by(0) produces an infinite iterator
     // No warning for non-zero step
@@ -21,4 +21,9 @@ fn main() {
     // No error, not a range.
     let y = NotARange;
     y.step_by(0);
+
+    let _v1 = vec![1,2,3];
+    let _v2 = vec![4,5];
+    let _x = _v1.iter().zip(0.._v1.len()); //~ERROR It is more idiomatic to use _v1.iter().enumerate()
+    let _y = _v1.iter().zip(0.._v2.len()); // No error
 }


### PR DESCRIPTION
Fixes #11.

I have one question about this: I'm matching an expression like `x.iter().zip(0..x.len())` and I need to check that `.iter()` and `.len()` are called on the same thing. Right now I compare the `snippet()` of the two expressions but that seems kludgey. Is there a better way to check that two expressions are equivalent?