### PR TITLE
update readme to specify both lint groups are needed for the  whole set

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ if let Some(y) = x { println!("{:?}", y) }
 ```
 
 You can add options  to `allow`/`warn`/`deny`:
-- the whole set using the `clippy` lint group (`#![deny(clippy)]`, etc)
+- the whole set using the `clippy` and `clippy_pedantic` lint groups (`#![deny(clippy)]`, `#![deny(clippy_pedantic)]`, etc)
 - only some lints (`#![deny(single_match, box_vec)]`, etc)
 - `allow`/`warn`/`deny` can be limited to a single function or module using `#[allow(...)]`, etc
 


### PR DESCRIPTION
As a new user and newbie to rust, after reading this part of the readme("whole set"), I thought I was seeing a bug when I used `#![deny(clippy)]` but also had to add `#![deny(shadow_unrelated)]`.
But this explained it: https://github.com/Manishearth/rust-clippy/blob/3322ffa8a048ef5369d3cdd914869fdf383473a4/src/lib.rs#L108