### PR TITLE
Fix some false positive in needless_lifetimes lint

### DIFF
--- a/tests/compile-fail/lifetimes.rs
+++ b/tests/compile-fail/lifetimes.rs
@@ -85,5 +85,26 @@ fn already_elided<'a>(_: &u8, _: &'a u8) -> &'a u8 {
     unimplemented!()
 }
 
+fn struct_with_lt<'a>(_foo: Foo<'a>) -> &'a str { unimplemented!() } //~ERROR explicit lifetimes given
+
+// no warning, two input lifetimes (named on the reference, anonymous on Foo)
+fn struct_with_lt2<'a>(_foo: &'a Foo) -> &'a str { unimplemented!() }
+
+// no warning, two input lifetimes (anonymous on the reference, named on Foo)
+fn struct_with_lt3<'a>(_foo: &Foo<'a> ) -> &'a str { unimplemented!() }
+
+// no warning, two input lifetimes
+fn struct_with_lt4<'a, 'b>(_foo: &'a Foo<'b> ) -> &'a str { unimplemented!() }
+
+trait WithLifetime<'a> {}
+type WithLifetimeAlias<'a> = WithLifetime<'a>;
+
+// should not warn because it won't build without the lifetime
+fn trait_obj_elided<'a>(_arg: &'a WithLifetime) -> &'a str { unimplemented!() }
+
+// this should warn because there is no lifetime on Drop, so this would be
+// unambiguous if we elided the lifetime
+fn trait_obj_elided2<'a>(_arg: &'a Drop) -> &'a str { unimplemented!() } //~ERROR explicit lifetimes given
+
 fn main() {
 }


### PR DESCRIPTION
Fixes #417

The current lifetime-collecting visitor in `needless_lifetimes` doesn't take into account elided lifetimes on structs, enums or trait objects when collecting input and output lifetimes, which can lead to false positives. These changes fix it to consider these elided lifetimes as well.

One problem that I couldn't figure out is how to look up the definitions for type (and trait) aliases, which I would need to do to make this work with type aliases in function argument and return types as well. Any hints would be appreciated (although this PR should already strictly, and significantly, decrease the number of false positives).