### PR TITLE
Lint uses of `ok().expect()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 74 lints included in this crate:
+There are 75 lints included in this crate:
 
 name                                                                                                   | default | meaning
 -------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -50,6 +50,7 @@ name                                                                            
 [no_effect](https://github.com/Manishearth/rust-clippy/wiki#no_effect)                                 | warn    | statements with no effect
 [non_ascii_literal](https://github.com/Manishearth/rust-clippy/wiki#non_ascii_literal)                 | allow   | using any literal non-ASCII chars in a string literal; suggests using the \\u escape instead
 [nonsensical_open_options](https://github.com/Manishearth/rust-clippy/wiki#nonsensical_open_options)   | warn    | nonsensical combination of options for opening a file
+[ok_expect](https://github.com/Manishearth/rust-clippy/wiki#ok_expect)                                 | warn    | using `ok().expect()`, which gives worse error messages than calling `expect` directly on the Result
 [option_unwrap_used](https://github.com/Manishearth/rust-clippy/wiki#option_unwrap_used)               | allow   | using `Option.unwrap()`, which should at least get a better message using `expect()`
 [precedence](https://github.com/Manishearth/rust-clippy/wiki#precedence)                               | warn    | catches operations where precedence may be unclear. See the wiki for a list of cases caught
 [ptr_arg](https://github.com/Manishearth/rust-clippy/wiki#ptr_arg)                                     | warn    | fn arguments of the type `&Vec<...>` or `&String`, suggesting to use `&[...]` or `&str` instead, respectively

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_late_lint_pass(box unicode::Unicode);
     reg.register_late_lint_pass(box strings::StringAdd);
     reg.register_early_lint_pass(box returns::ReturnPass);
-    reg.register_late_lint_pass(box methods::MethodsPass);
+    reg.register_late_lint_pass(box methods::MethodsPass::new());
     reg.register_late_lint_pass(box shadow::ShadowPass);
     reg.register_late_lint_pass(box types::LetPass);
     reg.register_late_lint_pass(box types::UnitCmp);
@@ -151,6 +151,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         matches::MATCH_BOOL,
         matches::MATCH_REF_PATS,
         matches::SINGLE_MATCH,
+        methods::OK_EXPECT,
         methods::SHOULD_IMPLEMENT_TRAIT,
         methods::STR_TO_STRING,
         methods::STRING_TO_STRING,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_late_lint_pass(box unicode::Unicode);
     reg.register_late_lint_pass(box strings::StringAdd);
     reg.register_early_lint_pass(box returns::ReturnPass);
-    reg.register_late_lint_pass(box methods::MethodsPass::new());
+    reg.register_late_lint_pass(box methods::MethodsPass);
     reg.register_late_lint_pass(box shadow::ShadowPass);
     reg.register_late_lint_pass(box types::LetPass);
     reg.register_late_lint_pass(box types::UnitCmp);

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -154,14 +154,14 @@ fn get_error_type<'a>(cx: &LateContext, ty: ty::Ty<'a>) -> Option<ty::Ty<'a>> {
 // conservative, i.e. it should not return false positives, but will return
 // false negatives.
 fn has_debug_impl<'a, 'b>(ty: ty::Ty<'a>, cx: &LateContext<'b, 'a>) -> bool {
-    let ty = walk_ptrs_ty(ty);
+    let no_ref_ty = walk_ptrs_ty(ty);
     let debug = match cx.tcx.lang_items.debug_trait() {
         Some(debug) => debug,
         None => return false
     };
     let debug_def = cx.tcx.lookup_trait_def(debug);
     let mut debug_impl_exists = false;
-    debug_def.for_each_relevant_impl(cx.tcx, ty, |d| {
+    debug_def.for_each_relevant_impl(cx.tcx, no_ref_ty, |d| {
         let self_ty = &cx.tcx.impl_trait_ref(d).and_then(|im| im.substs.self_ty());
         if let Some(self_ty) = *self_ty {
             if !self_ty.flags.get().contains(ty::TypeFlags::HAS_PARAMS) {

--- a/tests/compile-fail/methods.rs
+++ b/tests/compile-fail/methods.rs
@@ -54,7 +54,7 @@ fn main() {
     // the error type implements `Debug`
     let res2: Result<i32, MyError> = Ok(0);
     res2.ok().expect("oh noes!");
-    // we're currently don't warn if the error type has a type parameter
+    // we currently don't warn if the error type has a type parameter
     // (but it would be nice if we did)
     let res3: Result<u32, MyErrorWithParam<u8>>= Ok(0);
     res3.ok().expect("whoof");
@@ -62,6 +62,8 @@ fn main() {
     res4.ok().expect("argh"); //~ERROR called `ok().expect()`
     let res5: io::Result<u32> = Ok(0);
     res5.ok().expect("oops"); //~ERROR called `ok().expect()`
+    let res6: Result<u32, &str> = Ok(0);
+    res6.ok().expect("meh"); //~ERROR called `ok().expect()`
 }
 
 struct MyError(()); // doesn't implement Debug

--- a/tests/compile-fail/methods.rs
+++ b/tests/compile-fail/methods.rs
@@ -35,6 +35,8 @@ impl Mul<T> for T {
 }
 
 fn main() {
+    use std::io;
+
     let opt = Some(0);
     let _ = opt.unwrap();  //~ERROR used unwrap() on an Option
 
@@ -46,4 +48,25 @@ fn main() {
     let v = &"str";
     let string = v.to_string();  //~ERROR `(*v).to_owned()` is faster
     let _again = string.to_string();  //~ERROR `String.to_string()` is a no-op
+
+    res.ok().expect("disaster!"); //~ERROR called `ok().expect()`
+    // the following should not warn, since `expect` isn't implemented unless
+    // the error type implements `Debug`
+    let res2: Result<i32, MyError> = Ok(0);
+    res2.ok().expect("oh noes!");
+    // we're currently don't warn if the error type has a type parameter
+    // (but it would be nice if we did)
+    let res3: Result<u32, MyErrorWithParam<u8>>= Ok(0);
+    res3.ok().expect("whoof");
+    let res4: Result<u32, io::Error> = Ok(0);
+    res4.ok().expect("argh"); //~ERROR called `ok().expect()`
+    let res5: io::Result<u32> = Ok(0);
+    res5.ok().expect("oops"); //~ERROR called `ok().expect()`
+}
+
+struct MyError(()); // doesn't implement Debug
+
+#[derive(Debug)]
+struct MyErrorWithParam<T> {
+    x: T
 }


### PR DESCRIPTION
Fixes #429 (mostly).
This adds a lint for calling `ok().expect()` on a `Result`. Since I wanted to avoid false positives (if the error type doesn't implement `Debug`, you cannot call `expect` directly on the `Result`) and I couldn't figure out how to properly check if a type implements `Debug`, this has false negatives if the result's error type has type parameters. I don't think this is terribly common, though. If someone could point me in the right direction regarding checking for `Debug` impls, I'd be happy to fix this.