### PR TITLE
Lint `map(f).unwrap_or(a)` and `map(f).unwrap_or_else(g)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 77 lints included in this crate:
+There are 79 lints included in this crate:
 
 name                                                                                                     | default | meaning
 ---------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -53,6 +53,8 @@ name                                                                            
 [non_ascii_literal](https://github.com/Manishearth/rust-clippy/wiki#non_ascii_literal)                   | allow   | using any literal non-ASCII chars in a string literal; suggests using the \\u escape instead
 [nonsensical_open_options](https://github.com/Manishearth/rust-clippy/wiki#nonsensical_open_options)     | warn    | nonsensical combination of options for opening a file
 [ok_expect](https://github.com/Manishearth/rust-clippy/wiki#ok_expect)                                   | warn    | using `ok().expect()`, which gives worse error messages than calling `expect` directly on the Result
+[option_map_unwrap_or](https://github.com/Manishearth/rust-clippy/wiki#option_map_unwrap_or)             | warn    | using `Option.map(f).unwrap_or(a)`, which is more succinctly expressed as `map_or(a, f)`)
+[option_map_unwrap_or_else](https://github.com/Manishearth/rust-clippy/wiki#option_map_unwrap_or_else)   | warn    | using `Option.map(f).unwrap_or_else(g)`, which is more succinctly expressed as `map_or_else(g, f)`)
 [option_unwrap_used](https://github.com/Manishearth/rust-clippy/wiki#option_unwrap_used)                 | allow   | using `Option.unwrap()`, which should at least get a better message using `expect()`
 [precedence](https://github.com/Manishearth/rust-clippy/wiki#precedence)                                 | warn    | catches operations where precedence may be unclear. See the wiki for a list of cases caught
 [ptr_arg](https://github.com/Manishearth/rust-clippy/wiki#ptr_arg)                                       | warn    | fn arguments of the type `&Vec<...>` or `&String`, suggesting to use `&[...]` or `&str` instead, respectively

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,8 @@ pub fn plugin_registrar(reg: &mut Registry) {
         matches::MATCH_REF_PATS,
         matches::SINGLE_MATCH,
         methods::OK_EXPECT,
+        methods::OPTION_MAP_UNWRAP_OR,
+        methods::OPTION_MAP_UNWRAP_OR_ELSE,
         methods::SHOULD_IMPLEMENT_TRAIT,
         methods::STR_TO_STRING,
         methods::STRING_TO_STRING,

--- a/src/mut_mut.rs
+++ b/src/mut_mut.rs
@@ -39,17 +39,20 @@ fn check_expr_mut(cx: &LateContext, expr: &Expr) {
     }
 
     unwrap_addr(expr).map_or((), |e| {
-        unwrap_addr(e).map(|_| {
-            span_lint(cx, MUT_MUT, expr.span,
-                      "generally you want to avoid `&mut &mut _` if possible")
-        }).unwrap_or_else(|| {
-            if let TyRef(_, TypeAndMut{ty: _, mutbl: MutMutable}) =
-                cx.tcx.expr_ty(e).sty {
-                    span_lint(cx, MUT_MUT, expr.span,
-                              "this expression mutably borrows a mutable reference. \
-                               Consider reborrowing")
+        unwrap_addr(e).map_or_else(
+            || {
+                if let TyRef(_, TypeAndMut{ty: _, mutbl: MutMutable}) =
+                    cx.tcx.expr_ty(e).sty {
+                        span_lint(cx, MUT_MUT, expr.span,
+                                  "this expression mutably borrows a mutable reference. \
+                                   Consider reborrowing")
                 }
-        })
+            },
+            |_| {
+                span_lint(cx, MUT_MUT, expr.span,
+                          "generally you want to avoid `&mut &mut _` if possible")
+            }
+        )
     })
 }
 


### PR DESCRIPTION
Implement lints for `Option.map(f).unwrap_or(a)` and `Option.map(f).unwrap_or_else(g)` #424