### PR TITLE
Make unneeded_lifetimes lint work properly with type aliases

### DIFF
--- a/src/lifetimes.rs
+++ b/src/lifetimes.rs
@@ -3,7 +3,7 @@ use reexport::*;
 use rustc::lint::*;
 use syntax::codemap::Span;
 use rustc_front::intravisit::{Visitor, walk_ty, walk_ty_param_bound};
-use rustc::middle::def::Def::{DefTy, DefTrait};
+use rustc::middle::def::Def::{DefTy, DefTrait, DefStruct};
 use std::collections::HashSet;
 
 use utils::{in_external_macro, span_lint};
@@ -187,23 +187,22 @@ impl <'v, 't> RefVisitor<'v, 't>  {
         let last_path_segment = path.segments.last().map(|s| &s.parameters);
         if let Some(&AngleBracketedParameters(ref params)) = last_path_segment {
             if params.lifetimes.is_empty() {
-                let def = self.cx.tcx.def_map.borrow().get(&ty.id).map(|r| r.full_def());
-                match def {
-                    Some(DefTy(def_id, _)) => {
-                        if let Some(ty_def) = self.cx.tcx.adt_defs.borrow().get(&def_id) {
-                            let scheme = ty_def.type_scheme(self.cx.tcx);
-                            for _ in scheme.generics.regions.as_slice() {
+                if let Some(def) = self.cx.tcx.def_map.borrow().get(&ty.id).map(|r| r.full_def()) {
+                    match def {
+                        DefTy(def_id, _) | DefStruct(def_id) => {
+                            let type_scheme = self.cx.tcx.lookup_item_type(def_id);
+                            for _ in type_scheme.generics.regions.as_slice() {
                                 self.record(&None);
                             }
-                        }
+                        },
+                        DefTrait(def_id) => {
+                            let trait_def = self.cx.tcx.trait_defs.borrow()[&def_id];
+                            for _ in &trait_def.generics.regions {
+                                self.record(&None);
+                            }
+                        },
+                        _ => {}
                     }
-                    Some(DefTrait(def_id)) => {
-                        let trait_def = self.cx.tcx.trait_defs.borrow()[&def_id];
-                        for _ in &trait_def.generics.regions {
-                            self.record(&None);
-                        }
-                    }
-                    _ => {}
                 }
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -256,7 +256,6 @@ pub fn get_parent_expr<'c>(cx: &'c LateContext, e: &Expr) -> Option<&'c Expr> {
         if let NodeExpr(parent) = node { Some(parent) } else { None } )
 }
 
-#[allow(needless_lifetimes)] // workaround for https://github.com/Manishearth/rust-clippy/issues/417
 pub fn get_enclosing_block<'c>(cx: &'c LateContext, node: NodeId) -> Option<&'c Block> {
     let map = &cx.tcx.map;
     let enclosing_node = map.get_enclosing_scope(node)

--- a/tests/compile-fail/lifetimes.rs
+++ b/tests/compile-fail/lifetimes.rs
@@ -106,5 +106,18 @@ fn trait_obj_elided<'a>(_arg: &'a WithLifetime) -> &'a str { unimplemented!() }
 // unambiguous if we elided the lifetime
 fn trait_obj_elided2<'a>(_arg: &'a Drop) -> &'a str { unimplemented!() } //~ERROR explicit lifetimes given
 
+type FooAlias<'a> = Foo<'a>;
+
+fn alias_with_lt<'a>(_foo: FooAlias<'a>) -> &'a str { unimplemented!() } //~ERROR explicit lifetimes given
+
+// no warning, two input lifetimes (named on the reference, anonymous on Foo)
+fn alias_with_lt2<'a>(_foo: &'a FooAlias) -> &'a str { unimplemented!() }
+
+// no warning, two input lifetimes (anonymous on the reference, named on Foo)
+fn alias_with_lt3<'a>(_foo: &FooAlias<'a> ) -> &'a str { unimplemented!() }
+
+// no warning, two input lifetimes
+fn alias_with_lt4<'a, 'b>(_foo: &'a FooAlias<'b> ) -> &'a str { unimplemented!() }
+
 fn main() {
 }


### PR DESCRIPTION
This makes the unneeded_lifetimes lint count lifetimes on type aliases correctly, and also fixes an issue with externally-defined types (because for some unclear-to-me reason, looking up a type definition seems to return a `DefTy` if the type is defined locally but a `DefStruct` otherwise o.O ).

I also removed an `allow` because now `unneeded_lifetimes` doesn't break `dogfood.sh` any more :smile: 