### PR TITLE
Use suggestion for needless_return

### DIFF
--- a/src/returns.rs
+++ b/src/returns.rs
@@ -4,7 +4,7 @@ use syntax::ast::*;
 use syntax::codemap::{Span, Spanned};
 use syntax::visit::FnKind;
 
-use utils::{span_lint, snippet, match_path_ast, in_external_macro};
+use utils::{span_lint, span_lint_and_then, snippet_opt, match_path_ast, in_external_macro};
 
 declare_lint!(pub NEEDLESS_RETURN, Warn,
               "using a return statement like `return expr;` where an expression would suffice");
@@ -23,7 +23,7 @@ impl ReturnPass {
         } else if let Some(stmt) = block.stmts.last() {
             if let StmtSemi(ref expr, _) = stmt.node {
                 if let ExprRet(Some(ref inner)) = expr.node {
-                    self.emit_return_lint(cx, (expr.span, inner.span));
+                    self.emit_return_lint(cx, (stmt.span, inner.span));
                 }
             }
         }
@@ -59,10 +59,15 @@ impl ReturnPass {
 
     fn emit_return_lint(&mut self, cx: &EarlyContext, spans: (Span, Span)) {
         if in_external_macro(cx, spans.1) {return;}
-        span_lint(cx, NEEDLESS_RETURN, spans.0, &format!(
-            "unneeded return statement. Consider using `{}` \
-             without the return and trailing semicolon",
-            snippet(cx, spans.1, "..")))
+        span_lint_and_then(cx, NEEDLESS_RETURN, spans.0,
+                           "unneeded return statement",
+                           || {
+            if let Some(snippet) = snippet_opt(cx, spans.1) {
+                cx.sess().span_suggestion(spans.0,
+                                          "remove `return` as shown:",
+                                          snippet);
+            }
+        });
     }
 
     // Check for "let x = EXPR; x"

--- a/tests/compile-fail/needless_return.rs
+++ b/tests/compile-fail/needless_return.rs
@@ -8,11 +8,17 @@ fn test_end_of_fn() -> bool {
         // no error!
         return true;
     }
-    return true;           //~ERROR unneeded return statement
+    return true;
+    //~^ ERROR unneeded return statement
+    //~| HELP remove `return` as shown
+    //~| SUGGESTION true
 }
 
 fn test_no_semicolon() -> bool {
-    return true            //~ERROR unneeded return statement
+    return true
+    //~^ ERROR unneeded return statement
+    //~| HELP remove `return` as shown
+    //~| SUGGESTION true
 }
 
 fn test_if_block() -> bool {
@@ -29,7 +35,7 @@ fn test_match(x: bool) -> bool {
             return false;  //~ERROR unneeded return statement
         }
         false => {
-            return true    //~ERROR unneeded return statement
+            return true;   //~ERROR unneeded return statement
         }
     }
 }


### PR DESCRIPTION
cc #442.

Instead of saying "without trailing semicolon", show the replacement without trailing semicolon.