### PR TITLE
Mention VecDeque in linkedlist lint

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -26,7 +26,7 @@ pub struct TypePass;
 /// **Example:** `struct X { values: Box<Vec<Foo>> }`
 declare_lint!(pub BOX_VEC, Warn,
               "usage of `Box<Vec<T>>`, vector elements are already on the heap");
-/// **What it does:** This lint checks for usage of any `LinkedList`, suggesting to use a `Vec` or `RingBuf`.
+/// **What it does:** This lint checks for usage of any `LinkedList`, suggesting to use a `Vec` or a `VecDeque` (formerly called `RingBuf`).
 ///
 /// **Why is this bad?** Gankro says:
 ///


### PR DESCRIPTION
I couldn't find anything named RingBuf in the standard library. Some
search revealed that it had been renamed to VecDeque before the first
stable Rust release.