### PR TITLE
compiletest_rs needs to be at least 0.0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ plugin = true
 unicode-normalization = "*"
 
 [dev-dependencies]
-compiletest_rs = "*"
+compiletest_rs = "0.0.11"
 regex = "*"
 regex_macros = "*"
 lazy_static = "*"


### PR DESCRIPTION
otherwise tests using `SUGGESTION` will fail (see `compile-fail/eta.rs`)