### PR TITLE
Nightly fixes

### DIFF
--- a/src/map_clone.rs
+++ b/src/map_clone.rs
@@ -82,7 +82,7 @@ fn expr_eq_ident(expr: &Expr, id: Ident) -> bool {
     match expr.node {
         ExprPath(None, ref path) => {
             let arg_segment = [PathSegment { identifier: id, parameters: PathParameters::none() }];
-            !path.global && path.segments == arg_segment
+            !path.global && path.segments[..] == arg_segment
         }
         _ => false,
     }

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -435,9 +435,9 @@ impl OutType {
     fn matches(&self, ty: &FunctionRetTy) -> bool {
         match (self, ty) {
             (&UnitType, &DefaultReturn(_)) => true,
-            (&UnitType, &Return(ref ty)) if ty.node == TyTup(vec![]) => true,
+            (&UnitType, &Return(ref ty)) if ty.node == TyTup(vec![].into()) => true,
             (&BoolType, &Return(ref ty)) if is_bool(ty) => true,
-            (&AnyType, &Return(ref ty)) if ty.node != TyTup(vec![])  => true,
+            (&AnyType, &Return(ref ty)) if ty.node != TyTup(vec![].into())  => true,
             (&RefType, &Return(ref ty)) => {
                 if let TyRptr(_, _) = ty.node { true } else { false }
             }


### PR DESCRIPTION
As of
https://github.com/rust-lang/rust/commit/e3da2a90033d233bf6d77e3c725880c12cfc8728#diff-12e06f1e9ca371a11bdc4615f50a4071L59
HirVec is syntax::ptr::P instead of Vec.