### PR TITLE
Remove dup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ how this syntax structure is encoded in the AST, it is recommended to run `rustc
 example of the structure and compare with the
 [nodes in the AST docs](http://manishearth.github.io/rust-internals-docs/syntax/ast/). Usually
 the lint will end up to be a nested series of matches and ifs,
-[like so](https://github.com/Manishearth/rust-clippy/blob/de5ccdfab68a5e37689f3c950ed1532ba9d652a0/src/misc.rs#L34)
+[like so](https://github.com/Manishearth/rust-clippy/blob/de5ccdfab68a5e37689f3c950ed1532ba9d652a0/src/misc.rs#L34).
 
 T-middle issues can be more involved and require verifying types. The
 [`middle::ty`](http://manishearth.github.io/rust-internals-docs/rustc/middle/ty) module contains a

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -370,52 +370,6 @@ pub fn is_adjusted(cx: &LateContext, e: &Expr) -> bool {
     cx.tcx.tables.borrow().adjustments.get(&e.id).is_some()
 }
 
-/// Produce a nested chain of if-lets and ifs from the patterns:
-///
-///     if_let_chain! {
-///         [
-///             Some(y) = x,
-///             y.len() == 2,
-///             Some(z) = y,
-///         ],
-///         {
-///             block
-///         }
-///     }
-///
-/// becomes
-///
-///     if let Some(y) = x {
-///         if y.len() == 2 {
-///             if let Some(z) = y {
-///                 block
-///             }
-///         }
-///     }
-#[macro_export]
-macro_rules! if_let_chain {
-    ([let $pat:pat = $expr:expr, $($tt:tt)+], $block:block) => {
-        if let $pat = $expr {
-           if_let_chain!{ [$($tt)+], $block }
-        }
-    };
-    ([let $pat:pat = $expr:expr], $block:block) => {
-        if let $pat = $expr {
-           $block
-        }
-    };
-    ([$expr:expr, $($tt:tt)+], $block:block) => {
-        if $expr {
-           if_let_chain!{ [$($tt)+], $block }
-        }
-    };
-    ([$expr:expr], $block:block) => {
-        if $expr {
-           $block
-        }
-    };
-}
-
 pub struct LimitStack {
     stack: Vec<u64>,
 }


### PR DESCRIPTION
The macro `if_let_chain!` was defined twice.
Maybe clippy needs a lint to check for that? :smile: 