### PR TITLE
Don't trigger block_in_if_condition_expr lint if the block is unsafe

### DIFF
--- a/tests/compile-fail/block_in_if_condition.rs
+++ b/tests/compile-fail/block_in_if_condition.rs
@@ -60,5 +60,14 @@ fn closure_without_block() {
     }
 }
 
+fn condition_is_unsafe_block() {
+    let a: i32 = 1;
+
+    // this should not warn because the condition is an unsafe block
+    if unsafe { 1u32 == std::mem::transmute(a) } {
+        println!("1u32 == a");
+    }
+}
+
 fn main() {
 }


### PR DESCRIPTION
Fixes #516

Since the diff isn't very readable: All this does is put the checks for `BLOCK_IN_IF_CONDITION_STMT` and `BLOCK_IN_IF_CONDITION_EXPR` inside a `if block.rules == DefaultBlock` conditional.