### PR TITLE
Rustup to syntax::errors changes 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.33"
+version = "0.0.34"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.34"
+version = "0.0.35"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",

--- a/src/cyclomatic_complexity.rs
+++ b/src/cyclomatic_complexity.rs
@@ -9,7 +9,7 @@ use syntax::attr::*;
 use syntax::ast::Attribute;
 use rustc_front::intravisit::{Visitor, walk_expr};
 
-use utils::{in_macro, LimitStack};
+use utils::{in_macro, LimitStack, span_help_and_lint};
 
 /// **What it does:** It `Warn`s on methods with high cyclomatic complexity
 ///
@@ -59,8 +59,8 @@ impl CyclomaticComplexity {
         } else {
             let rust_cc = cc + divergence - narms;
             if rust_cc > self.limit.limit() {
-                cx.span_lint_help(CYCLOMATIC_COMPLEXITY, span,
-                &format!("The function has a cyclomatic complexity of {}.", rust_cc),
+                span_help_and_lint(cx, CYCLOMATIC_COMPLEXITY, span,
+                &format!("The function has a cyclomatic complexity of {}", rust_cc),
                 "You could split it up into multiple smaller functions");
             }
         }
@@ -140,8 +140,9 @@ fn report_cc_bug(cx: &LateContext, cc: u64, narms: u64, div: u64, span: Span) {
 #[cfg(not(feature="debugging"))]
 fn report_cc_bug(cx: &LateContext, cc: u64, narms: u64, div: u64, span: Span) {
     if cx.current_level(CYCLOMATIC_COMPLEXITY) != Level::Allow {
-        cx.sess().span_note(span, &format!("Clippy encountered a bug calculating cyclomatic complexity \
-                                            (hide this message with `#[allow(cyclomatic_complexity)]`): \
-                                            cc = {}, arms = {}, div = {}. Please file a bug report.", cc, narms, div));
+        cx.sess().span_note_without_error(span,
+                                          &format!("Clippy encountered a bug calculating cyclomatic complexity \
+                                                    (hide this message with `#[allow(cyclomatic_complexity)]`): \
+                                                    cc = {}, arms = {}, div = {}. Please file a bug report.", cc, narms, div));
     }
 }

--- a/src/eta_reduction.rs
+++ b/src/eta_reduction.rs
@@ -84,9 +84,9 @@ fn check_closure(cx: &LateContext, expr: &Expr) {
                 }
                 span_lint_and_then(cx, REDUNDANT_CLOSURE, expr.span,
                                    "redundant closure found",
-                                   || {
+                                   |db| {
                     if let Some(snippet) = snippet_opt(cx, caller.span) {
-                        cx.sess().span_suggestion(expr.span,
+                        db.span_suggestion(expr.span,
                                                   "remove closure as shown:",
                                                   snippet);
                     }

--- a/src/len_zero.rs
+++ b/src/len_zero.rs
@@ -135,7 +135,7 @@ fn check_len_zero(cx: &LateContext, span: Span, name: &Name,
             has_is_empty(cx, &args[0]) {
                 span_lint(cx, LEN_ZERO, span, &format!(
                     "consider replacing the len comparison with `{}{}.is_empty()`",
-                    op, snippet(cx, args[0].span, "_")))
+                    op, snippet(cx, args[0].span, "_")));
             }
     }
 }

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -37,7 +37,7 @@ impl LateLintPass for MinMaxPass {
                     (_, None) | (Max, Some(Less)) | (Min, Some(Greater)) => (),
                     _ => {
                         span_lint(cx, MIN_MAX, expr.span,
-                            "this min/max combination leads to constant result")
+                            "this min/max combination leads to constant result");
                     }
                 }
             }

--- a/src/mut_mut.rs
+++ b/src/mut_mut.rs
@@ -30,8 +30,8 @@ impl LateLintPass for MutMut {
     }
 
     fn check_ty(&mut self, cx: &LateContext, ty: &Ty) {
-        unwrap_mut(ty).and_then(unwrap_mut).map_or((), |_| span_lint(cx, MUT_MUT,
-            ty.span, "generally you want to avoid `&mut &mut _` if possible"))
+        unwrap_mut(ty).and_then(unwrap_mut).map_or((), |_| { span_lint(cx, MUT_MUT,
+            ty.span, "generally you want to avoid `&mut &mut _` if possible"); });
     }
 }
 
@@ -52,12 +52,12 @@ fn check_expr_mut(cx: &LateContext, expr: &Expr) {
                     cx.tcx.expr_ty(e).sty {
                         span_lint(cx, MUT_MUT, expr.span,
                                   "this expression mutably borrows a mutable reference. \
-                                   Consider reborrowing")
+                                   Consider reborrowing");
                 }
             },
             |_| {
                 span_lint(cx, MUT_MUT, expr.span,
-                          "generally you want to avoid `&mut &mut _` if possible")
+                          "generally you want to avoid `&mut &mut _` if possible");
             }
         )
     })

--- a/src/mutex_atomic.rs
+++ b/src/mutex_atomic.rs
@@ -63,7 +63,7 @@ impl LateLintPass for MutexAtomic {
                         ty::TyInt(t) if t != ast::TyIs =>
                             span_lint(cx, MUTEX_INTEGER, expr.span, &msg),
                         _ => span_lint(cx, MUTEX_ATOMIC, expr.span, &msg)
-                    }
+                    };
                 }
             }
         }

--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -33,21 +33,27 @@ impl EarlyLintPass for Precedence {
         if let ExprBinary(Spanned { node: op, ..}, ref left, ref right) = expr.node {
             if !is_bit_op(op) { return; }
             match (is_arith_expr(left), is_arith_expr(right)) {
-                (true, true) =>  span_lint(cx, PRECEDENCE, expr.span,
+                (true, true) => {
+                    span_lint(cx, PRECEDENCE, expr.span, 
                     &format!("operator precedence can trip the unwary. \
                          Consider parenthesizing your expression:\
                          `({}) {} ({})`", snippet(cx, left.span, ".."),
-                         op.to_string(), snippet(cx, right.span, ".."))),
-                (true, false) => span_lint(cx, PRECEDENCE, expr.span,
+                         op.to_string(), snippet(cx, right.span, "..")));
+                },
+                (true, false) => {
+                    span_lint(cx, PRECEDENCE, expr.span, 
                     &format!("operator precedence can trip the unwary. \
                          Consider parenthesizing your expression:\
                          `({}) {} {}`", snippet(cx, left.span, ".."),
-                         op.to_string(), snippet(cx, right.span, ".."))),
-                (false, true) => span_lint(cx, PRECEDENCE, expr.span,
+                         op.to_string(), snippet(cx, right.span, "..")));
+                },
+                (false, true) => {
+                    span_lint(cx, PRECEDENCE, expr.span, 
                     &format!("operator precedence can trip the unwary. \
                          Consider parenthesizing your expression:\
                          `{} {} ({})`", snippet(cx, left.span, ".."),
-                         op.to_string(), snippet(cx, right.span, ".."))),
+                         op.to_string(), snippet(cx, right.span, "..")));
+                },
                 _ => (),
             }
         }
@@ -57,12 +63,13 @@ impl EarlyLintPass for Precedence {
                 if let Some(slf) = args.first() {
                     if let ExprLit(ref lit) = slf.node {
                         match lit.node {
-                            LitInt(..) | LitFloat(..) | LitFloatUnsuffixed(..) =>
+                            LitInt(..) | LitFloat(..) | LitFloatUnsuffixed(..) => {
                                 span_lint(cx, PRECEDENCE, expr.span, &format!(
                                     "unary minus has lower precedence than \
                                      method call. Consider adding parentheses \
                                      to clarify your intent: -({})",
-                                     snippet(cx, rhs.span, ".."))),
+                                     snippet(cx, rhs.span, "..")));
+                            }
                             _ => ()
                         }
                     }

--- a/src/returns.rs
+++ b/src/returns.rs
@@ -75,9 +75,9 @@ impl ReturnPass {
         if in_external_macro(cx, spans.1) {return;}
         span_lint_and_then(cx, NEEDLESS_RETURN, spans.0,
                            "unneeded return statement",
-                           || {
+                           |db| {
             if let Some(snippet) = snippet_opt(cx, spans.1) {
-                cx.sess().span_suggestion(spans.0,
+                db.span_suggestion(spans.0,
                                           "remove `return` as shown:",
                                           snippet);
             }
@@ -105,11 +105,11 @@ impl ReturnPass {
 
     fn emit_let_lint(&mut self, cx: &EarlyContext, lint_span: Span, note_span: Span) {
         if in_external_macro(cx, note_span) {return;}
-        span_lint(cx, LET_AND_RETURN, lint_span,
+        let mut db = span_lint(cx, LET_AND_RETURN, lint_span,
                   "returning the result of a let binding from a block. \
                    Consider returning the expression directly.");
         if cx.current_level(LET_AND_RETURN) != Level::Allow {
-            cx.sess().span_note(note_span,
+            db.span_note(note_span,
                                 "this expression can be directly returned");
         }
     }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -75,13 +75,13 @@ impl LateLintPass for StringAdd {
                 }
                 span_lint(cx, STRING_ADD, e.span,
                     "you added something to a string. \
-                     Consider using `String::push_str()` instead")
+                     Consider using `String::push_str()` instead");
             }
         } else if let ExprAssign(ref target, ref src) = e.node {
             if is_string(cx, target) && is_add(cx, src, target) {
                 span_lint(cx, STRING_ADD_ASSIGN, e.span,
                     "you assigned the result of adding something to this string. \
-                     Consider using `String::push_str()` instead")
+                     Consider using `String::push_str()` instead");
             }
         }
     }

--- a/tests/compile-fail/cyclomatic_complexity.rs
+++ b/tests/compile-fail/cyclomatic_complexity.rs
@@ -4,7 +4,8 @@
 #![deny(cyclomatic_complexity)]
 #![allow(unused)]
 
-fn main() { //~ ERROR: The function has a cyclomatic complexity of 28.
+
+fn main() { //~ERROR The function has a cyclomatic complexity of 28
     if true {
         println!("a");
     }


### PR DESCRIPTION
Fixes #525

compiletest isn't working with the cyclomatic complexity lint, it's mentioning an unexpected error where the error marking exists. Not sure what's going on here, cc @oli-obk / @llogiq

I'm going to publish this anyway, since the code is working but we have a bug with the test harness.