### PR TITLE
Add a smarter macro check, use it

### DIFF
--- a/src/block_in_if_condition.rs
+++ b/src/block_in_if_condition.rs
@@ -79,13 +79,18 @@ impl LateLintPass for BlockInIfCondition {
                         if let Some(ref ex) = block.expr {
                             // don't dig into the expression here, just suggest that they remove
                             // the block
-
+                            if differing_macro_contexts(expr.span, ex.span) {
+                                return;
+                            }
                             span_help_and_lint(cx, BLOCK_IN_IF_CONDITION_EXPR, check.span,
                                 BRACED_EXPR_MESSAGE,
                                 &format!("try\nif {} {} ... ", snippet_block(cx, ex.span, ".."),
                                 snippet_block(cx, then.span, "..")));
                         }
                     } else {
+                        if differing_macro_contexts(expr.span, block.stmts[0].span) {
+                            return;
+                        }
                         // move block higher
                         span_help_and_lint(cx, BLOCK_IN_IF_CONDITION_STMT, check.span,
                             COMPLEX_BLOCK_MESSAGE,

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,9 +9,7 @@ use syntax::ast::IntTy::*;
 use syntax::ast::UintTy::*;
 use syntax::ast::FloatTy::*;
 
-use utils::{match_type, snippet, span_lint, span_help_and_lint};
-use utils::{is_from_for_desugar, in_macro, in_external_macro};
-use utils::{LL_PATH, VEC_PATH};
+use utils::*;
 
 /// Handles all the linting of funky types
 #[allow(missing_copy_implementations)]
@@ -50,6 +48,9 @@ impl LintPass for TypePass {
 
 impl LateLintPass for TypePass {
     fn check_ty(&mut self, cx: &LateContext, ast_ty: &Ty) {
+        if in_macro(cx, ast_ty.span) {
+            return
+        }
         if let Some(ty) = cx.tcx.ast_ty_to_ty_cache.borrow().get(&ast_ty.id) {
             if let ty::TyBox(ref inner) = ty.sty {
                 if match_type(cx, inner, &VEC_PATH) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -74,6 +74,10 @@ macro_rules! if_let_chain {
     };
 }
 
+/// Returns true if the two spans come from differing expansions (i.e. one is from a macro and one isn't)
+pub fn differing_macro_contexts(sp1: Span, sp2: Span) -> bool {
+    sp1.expn_id != sp2.expn_id
+}
 /// returns true if this expn_info was expanded by any macro
 pub fn in_macro<T: LintContext>(cx: &T, span: Span) -> bool {
     cx.sess().codemap().with_expn_info(span.expn_id,

--- a/tests/compile-fail/block_in_if_condition.rs
+++ b/tests/compile-fail/block_in_if_condition.rs
@@ -5,6 +5,15 @@
 #![deny(block_in_if_condition_stmt)]
 #![allow(unused)]
 
+
+macro_rules! blocky {
+    () => {{true}}
+}
+
+fn macro_if() {
+    if blocky!() {
+    }
+}
 fn condition_has_block() -> i32 {
 
     if { //~ERROR in an 'if' condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a 'let'

--- a/tests/compile-fail/box_vec.rs
+++ b/tests/compile-fail/box_vec.rs
@@ -3,6 +3,15 @@
 #![plugin(clippy)]
 #![deny(clippy)]
 
+macro_rules! boxit {
+    ($init:expr, $x:ty) => {
+        let _: Box<$x> = Box::new($init);
+    }
+}
+
+fn test_macro() {
+    boxit!(Vec::new(), Vec<u8>);
+}
 pub fn test(foo: Box<Vec<bool>>) { //~ ERROR you seem to be trying to use `Box<Vec<T>>`
     println!("{:?}", foo.get(0))
 }
@@ -14,4 +23,5 @@ pub fn test2(foo: Box<Fn(Vec<u32>)>) { // pass if #31 is fixed
 fn main(){
     test(Box::new(Vec::new()));
     test2(Box::new(|v| println!("{:?}", v)));
+    test_macro();
 }


### PR DESCRIPTION
Using a dumb macro check for box_vec since I don't think the smarter one is necessary
and it requires extra checking of type parameters to work.

r? @llogiq