### PR TITLE
Consider lifetime in self parameter in unused_lifetime lint

### DIFF
--- a/tests/compile-fail/lifetimes.rs
+++ b/tests/compile-fail/lifetimes.rs
@@ -1,8 +1,8 @@
 #![feature(plugin)]
 #![plugin(clippy)]
 
-#![deny(needless_lifetimes)]
-#![allow(dead_code, unused_lifetimes)]
+#![deny(needless_lifetimes, unused_lifetimes)]
+#![allow(dead_code)]
 fn distinct_lifetimes<'a, 'b>(_x: &'a u8, _y: &'b u8, _z: u8) { }
 //~^ERROR explicit lifetimes given
 

--- a/tests/compile-fail/unused_lt.rs
+++ b/tests/compile-fail/unused_lt.rs
@@ -52,6 +52,13 @@ pub fn parse2<'a, I>(_it: &mut I) where I: Iterator<Item=&'a str>{
     unimplemented!()
 }
 
+struct X { x: u32 }
+
+impl X {
+    fn self_ref_with_lifetime<'a>(&'a self) {}
+    fn explicit_self_with_lifetime<'a>(self: &'a Self) {}
+}
+
 fn main() {
 
 }


### PR DESCRIPTION
The unused_lifetimes lint currently ignores the `self` parameters in method signatures, leading to false positives.
Fixes #550