### PR TITLE
Handle more iterator adapter cases in for loops

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -445,6 +445,7 @@ pub fn walk_ptrs_ty_depth(ty: ty::Ty) -> (ty::Ty, usize) {
     inner(ty, 0)
 }
 
+/// Check whether the given expression is a constant literal of the given value.
 pub fn is_integer_literal(expr: &Expr, value: u64) -> bool {
     // FIXME: use constant folding
     if let ExprLit(ref spanned) = expr.node {

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -20,18 +20,36 @@ impl Unrelated {
 fn main() {
     let mut vec = vec![1, 2, 3, 4];
     let vec2 = vec![1, 2, 3, 4];
-    for i in 0..vec.len() {      //~ERROR the loop variable `i` is only used to index `vec`.
+    for i in 0..vec.len() {
+        //~^ ERROR `i` is only used to index `vec`. Consider using `for item in &vec`
         println!("{}", vec[i]);
     }
-    for i in 0..vec.len() {      //~ERROR the loop variable `i` is used to index `vec`.
+    for i in 0..vec.len() {
+        //~^ ERROR `i` is used to index `vec`. Consider using `for (i, item) in vec.iter().enumerate()`
         println!("{} {}", vec[i], i);
     }
     for i in 0..vec.len() {      // not an error, indexing more than one variable
         println!("{} {}", vec[i], vec2[i]);
     }
 
-    for i in 5..vec.len() {      // not an error, not starting with 0
+    for i in 5..vec.len() {
+        //~^ ERROR `i` is only used to index `vec`. Consider using `for item in vec.iter().skip(5)`
         println!("{}", vec[i]);
+    }
+
+    for i in 5..10 {
+        //~^ ERROR `i` is only used to index `vec`. Consider using `for item in vec.iter().take(10).skip(5)`
+        println!("{}", vec[i]);
+    }
+
+    for i in 5..vec.len() {
+        //~^ ERROR `i` is used to index `vec`. Consider using `for (i, item) in vec.iter().enumerate().skip(5)`
+        println!("{} {}", vec[i], i);
+    }
+
+    for i in 5..10 {
+        //~^ ERROR `i` is used to index `vec`. Consider using `for (i, item) in vec.iter().enumerate().take(10).skip(5)`
+        println!("{} {}", vec[i], i);
     }
 
     for i in 10..0 { //~ERROR this range is empty so this for loop will never run

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -32,6 +32,11 @@ fn main() {
         println!("{} {}", vec[i], vec2[i]);
     }
 
+    for i in 0..vec.len() {
+        //~^ ERROR `i` is only used to index `vec2`. Consider using `for item in vec2.iter().take(vec.len())`
+        println!("{}", vec2[i]);
+    }
+
     for i in 5..vec.len() {
         //~^ ERROR `i` is only used to index `vec`. Consider using `for item in vec.iter().skip(5)`
         println!("{}", vec[i]);


### PR DESCRIPTION
Fix #281.
Also partial fix for #398. I'm not sure it's worth fixing the second example, in such corner case maybe allowing the lint would be acceptable.