### PR TITLE
Fix another false positive in lifetime elision lint

### DIFF
--- a/src/lifetimes.rs
+++ b/src/lifetimes.rs
@@ -144,7 +144,6 @@ fn could_use_elision(cx: &LateContext, func: &FnDecl, slf: Option<&ExplicitSelf>
             match (&input_lts[0], &output_lts[0]) {
                 (&Named(n1), &Named(n2)) if n1 == n2 => true,
                 (&Named(_), &Unnamed) => true,
-                (&Unnamed, &Named(_)) => true,
                 _ => false, // already elided, different named lifetimes
                 // or something static going on
             }

--- a/tests/compile-fail/lifetimes.rs
+++ b/tests/compile-fail/lifetimes.rs
@@ -119,5 +119,9 @@ fn alias_with_lt3<'a>(_foo: &FooAlias<'a> ) -> &'a str { unimplemented!() }
 // no warning, two input lifetimes
 fn alias_with_lt4<'a, 'b>(_foo: &'a FooAlias<'b> ) -> &'a str { unimplemented!() }
 
+fn named_input_elided_output<'a>(_arg: &'a str) -> &str { unimplemented!() } //~ERROR explicit lifetimes given
+
+fn elided_input_named_output<'a>(_arg: &str) -> &'a str { unimplemented!() }
+
 fn main() {
 }


### PR DESCRIPTION
The false positive occurred when we have an anonymous input lifetime and a
named output lifetime. This is not elidable, because if we elided the output
lifetime, it would be inferred to be the same as the input.

Fixes #291 