### PR TITLE
New lint, new utility functions and nightly fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 92 lints included in this crate:
+There are 93 lints included in this crate:
 
 name                                                                                                           | default | meaning
 ---------------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -63,6 +63,7 @@ name                                                                            
 [option_map_unwrap_or](https://github.com/Manishearth/rust-clippy/wiki#option_map_unwrap_or)                   | warn    | using `Option.map(f).unwrap_or(a)`, which is more succinctly expressed as `map_or(a, f)`
 [option_map_unwrap_or_else](https://github.com/Manishearth/rust-clippy/wiki#option_map_unwrap_or_else)         | warn    | using `Option.map(f).unwrap_or_else(g)`, which is more succinctly expressed as `map_or_else(g, f)`
 [option_unwrap_used](https://github.com/Manishearth/rust-clippy/wiki#option_unwrap_used)                       | allow   | using `Option.unwrap()`, which should at least get a better message using `expect()`
+[or_fun_call](https://github.com/Manishearth/rust-clippy/wiki#or_fun_call)                                     | warn    | using any `*or` method when the `*or_else` would do
 [out_of_bounds_indexing](https://github.com/Manishearth/rust-clippy/wiki#out_of_bounds_indexing)               | deny    | out of bound constant indexing
 [panic_params](https://github.com/Manishearth/rust-clippy/wiki#panic_params)                                   | warn    | missing parameters in `panic!`
 [precedence](https://github.com/Manishearth/rust-clippy/wiki#precedence)                                       | warn    | catches operations where precedence may be unclear. See the wiki for a list of cases caught

--- a/src/bit_mask.rs
+++ b/src/bit_mask.rs
@@ -278,7 +278,7 @@ fn fetch_int_literal(cx: &LateContext, lit: &Expr) -> Option<u64> {
                     _ => None,
                 }
             }
-            .and_then(|def_id| lookup_const_by_id(cx.tcx, def_id, None))
+            .and_then(|def_id| lookup_const_by_id(cx.tcx, def_id, None, None))
             .and_then(|l| fetch_int_literal(cx, l))
         }
         _ => None,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -484,7 +484,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
             if let Some(&PathResolution { base_def: DefConst(id), ..}) = lcx.tcx.def_map.borrow().get(&e.id) {
                 maybe_id = Some(id);
             }
-            // separate if lets to avoid doubleborrowing the defmap
+            // separate if lets to avoid double borrowing the def_map
             if let Some(id) = maybe_id {
                 if let Some(const_expr) = lookup_const_by_id(lcx.tcx, id, None) {
                     let ret = self.expr(const_expr);

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -486,7 +486,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
             }
             // separate if lets to avoid double borrowing the def_map
             if let Some(id) = maybe_id {
-                if let Some(const_expr) = lookup_const_by_id(lcx.tcx, id, None) {
+                if let Some(const_expr) = lookup_const_by_id(lcx.tcx, id, None, None) {
                     let ret = self.expr(const_expr);
                     if ret.is_some() {
                         self.needed_resolution = true;

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -45,7 +45,7 @@ impl LintPass for EscapePass {
 impl LateLintPass for EscapePass {
     fn check_fn(&mut self, cx: &LateContext, _: visit::FnKind, decl: &FnDecl, body: &Block, _: Span, id: NodeId) {
         let param_env = ty::ParameterEnvironment::for_item(cx.tcx, id);
-        let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, Some(param_env), false);
+        let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, Some(param_env));
         let mut v = EscapeDelegate {
             cx: cx,
             set: NodeSet(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         methods::OK_EXPECT,
         methods::OPTION_MAP_UNWRAP_OR,
         methods::OPTION_MAP_UNWRAP_OR_ELSE,
+        methods::OR_FUN_CALL,
         methods::SEARCH_IS_SOME,
         methods::SHOULD_IMPLEMENT_TRAIT,
         methods::STR_TO_STRING,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,20 +1,20 @@
-use rustc::lint::*;
-use rustc_front::hir::*;
+use consts::constant;
 use reexport::*;
-use syntax::codemap::{ExpnInfo, Span, ExpnFormat};
 use rustc::front::map::Node::*;
+use rustc::lint::*;
 use rustc::middle::def_id::DefId;
-use rustc::middle::ty;
+use rustc::middle::{cstore, def, infer, ty, traits};
+use rustc::session::Session;
+use rustc_front::hir::*;
 use std::borrow::Cow;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
 use syntax::ast::Lit_::*;
 use syntax::ast;
+use syntax::codemap::{ExpnInfo, Span, ExpnFormat};
 use syntax::errors::DiagnosticBuilder;
 use syntax::ptr::P;
-use consts::constant;
-
-use rustc::session::Session;
-use std::str::FromStr;
-use std::ops::{Deref, DerefMut};
 
 pub type MethodArgs = HirVec<P<Expr>>;
 
@@ -23,6 +23,7 @@ pub const BEGIN_UNWIND: [&'static str; 3] = ["std", "rt", "begin_unwind"];
 pub const BTREEMAP_PATH: [&'static str; 4] = ["collections", "btree", "map", "BTreeMap"];
 pub const CLONE_PATH: [&'static str; 2] = ["Clone", "clone"];
 pub const COW_PATH: [&'static str; 3] = ["collections", "borrow", "Cow"];
+pub const DEFAULT_TRAIT_PATH: [&'static str; 3] = ["core", "default", "Default"];
 pub const HASHMAP_PATH: [&'static str; 5] = ["std", "collections", "hash", "map", "HashMap"];
 pub const LL_PATH: [&'static str; 3] = ["collections", "linked_list", "LinkedList"];
 pub const MUTEX_PATH: [&'static str; 4] = ["std", "sync", "mutex", "Mutex"];
@@ -132,7 +133,7 @@ pub fn match_type(cx: &LateContext, ty: ty::Ty, path: &[&str]) -> bool {
     }
 }
 
-/// Check if the method call given in `expr` belongs to given trait.
+/// Check if the method call given in `expr` belongs to given type.
 pub fn match_impl_method(cx: &LateContext, expr: &Expr, path: &[&str]) -> bool {
     let method_call = ty::MethodCall::expr(expr.id);
 
@@ -184,6 +185,73 @@ pub fn match_path(path: &Path, segments: &[&str]) -> bool {
 /// ```
 pub fn match_path_ast(path: &ast::Path, segments: &[&str]) -> bool {
     path.segments.iter().rev().zip(segments.iter().rev()).all(|(a, b)| a.identifier.name.as_str() == *b)
+}
+
+/// Get the definition associated to a path.
+/// TODO: investigate if there is something more efficient for that.
+pub fn path_to_def(cx: &LateContext, path: &[&str]) -> Option<cstore::DefLike> {
+    let cstore = &cx.tcx.sess.cstore;
+
+    let crates = cstore.crates();
+    let krate = crates.iter().find(|&&krate| cstore.crate_name(krate) == path[0]);
+    if let Some(krate) = krate {
+        let mut items = cstore.crate_top_level_items(*krate);
+        let mut path_it = path.iter().skip(1).peekable();
+
+        loop {
+            let segment = match path_it.next() {
+                Some(segment) => segment,
+                None => return None
+            };
+
+            for item in &mem::replace(&mut items, vec![]) {
+                if item.name.as_str() == *segment {
+                    if path_it.peek().is_none() {
+                        return Some(item.def);
+                    }
+
+                    let def_id = match item.def {
+                        cstore::DefLike::DlDef(def) => def.def_id(),
+                        cstore::DefLike::DlImpl(def_id) => def_id,
+                        _ => panic!("Unexpected {:?}", item.def),
+                    };
+
+                    items = cstore.item_children(def_id);
+                    break;
+                }
+            }
+        }
+    }
+    else {
+        None
+    }
+}
+
+/// Convenience function to get the `DefId` of a trait by path.
+pub fn get_trait_def_id(cx: &LateContext, path: &[&str]) -> Option<DefId> {
+    let def = match path_to_def(cx, path) {
+        Some(def) => def,
+        None => return None,
+    };
+
+    match def {
+        cstore::DlDef(def::DefTrait(trait_id)) => Some(trait_id),
+        _ => None,
+    }
+}
+
+/// Check whether a type implements a trait.
+/// See also `get_trait_def_id`.
+pub fn implements_trait<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: ty::Ty<'tcx>, trait_id: DefId) -> bool {
+    cx.tcx.populate_implementations_for_trait_if_necessary(trait_id);
+
+    let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, None, true);
+    let obligation = traits::predicate_for_trait_def(cx.tcx,
+                                                     traits::ObligationCause::dummy(),
+                                                     trait_id, 0, ty,
+                                                     vec![]);
+
+    traits::SelectionContext::new(&infcx).evaluate_obligation_conservatively(&obligation)
 }
 
 /// Match an `Expr` against a chain of methods, and return the matched `Expr`s.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -245,7 +245,7 @@ pub fn get_trait_def_id(cx: &LateContext, path: &[&str]) -> Option<DefId> {
 pub fn implements_trait<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: ty::Ty<'tcx>, trait_id: DefId) -> bool {
     cx.tcx.populate_implementations_for_trait_if_necessary(trait_id);
 
-    let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, None, true);
+    let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, None);
     let obligation = traits::predicate_for_trait_def(cx.tcx,
                                                      traits::ObligationCause::dummy(),
                                                      trait_id, 0, ty,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -244,7 +244,7 @@ pub fn is_from_for_desugar(decl: &Decl) -> bool {
 /// snippet(cx, expr.span, "..")
 /// ```
 pub fn snippet<'a, T: LintContext>(cx: &T, span: Span, default: &'a str) -> Cow<'a, str> {
-    cx.sess().codemap().span_to_snippet(span).map(From::from).unwrap_or(Cow::Borrowed(default))
+    cx.sess().codemap().span_to_snippet(span).map(From::from).unwrap_or_else(|_| Cow::Borrowed(default))
 }
 
 /// Convert a span to a code snippet. Returns `None` if not available.

--- a/tests/compile-fail/methods.rs
+++ b/tests/compile-fail/methods.rs
@@ -177,29 +177,55 @@ fn search_is_some() {
 
 /// Checks implementation of the OR_FUN_CALL lint
 fn or_fun_call() {
-    let foo = Some(vec![1]);
-    foo.unwrap_or(Vec::new());
-    //~^ERROR use of `unwrap_or`
-    //~|HELP try this
-    //~|SUGGESTION foo.unwrap_or_else(Vec::new);
+    fn make<T>() -> T { unimplemented!(); }
 
-    let bar = Some(vec![1]);
-    bar.unwrap_or(Vec::with_capacity(12));
+    let with_constructor = Some(vec![1]);
+    with_constructor.unwrap_or(make());
     //~^ERROR use of `unwrap_or`
     //~|HELP try this
-    //~|SUGGESTION bar.unwrap_or_else(|| Vec::with_capacity(12));
+    //~|SUGGESTION with_constructor.unwrap_or_else(make)
 
-    let baz : Result<_, ()> = Ok(vec![1]);
-    baz.unwrap_or(Vec::new());
+    let with_new = Some(vec![1]);
+    with_new.unwrap_or(Vec::new());
     //~^ERROR use of `unwrap_or`
     //~|HELP try this
-    //~|SUGGESTION baz.unwrap_or_else(|_| Vec::new());
+    //~|SUGGESTION with_new.unwrap_or_default();
 
-    let qux : Result<_, ()> = Ok(vec![1]);
-    qux.unwrap_or(Vec::with_capacity(12));
+    let with_const_args = Some(vec![1]);
+    with_const_args.unwrap_or(Vec::with_capacity(12));
     //~^ERROR use of `unwrap_or`
     //~|HELP try this
-    //~|SUGGESTION qux.unwrap_or_else(|_| Vec::with_capacity(12));
+    //~|SUGGESTION with_const_args.unwrap_or_else(|| Vec::with_capacity(12));
+
+    let with_err : Result<_, ()> = Ok(vec![1]);
+    with_err.unwrap_or(make());
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION with_err.unwrap_or_else(|_| make());
+
+    let with_err_args : Result<_, ()> = Ok(vec![1]);
+    with_err_args.unwrap_or(Vec::with_capacity(12));
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION with_err_args.unwrap_or_else(|_| Vec::with_capacity(12));
+
+    let with_default_trait = Some(1);
+    with_default_trait.unwrap_or(Default::default());
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION with_default_trait.unwrap_or_default();
+
+    let with_default_type = Some(1);
+    with_default_type.unwrap_or(u64::default());
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION with_default_type.unwrap_or_default();
+
+    let with_vec = Some(vec![1]);
+    with_vec.unwrap_or(vec![]);
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION with_vec.unwrap_or_else(|| vec![]);
 }
 
 fn main() {

--- a/tests/compile-fail/methods.rs
+++ b/tests/compile-fail/methods.rs
@@ -177,6 +177,12 @@ fn search_is_some() {
 
 /// Checks implementation of the OR_FUN_CALL lint
 fn or_fun_call() {
+    struct Foo;
+
+    impl Foo {
+        fn new() -> Foo { Foo }
+    }
+
     fn make<T>() -> T { unimplemented!(); }
 
     let with_constructor = Some(vec![1]);
@@ -226,6 +232,12 @@ fn or_fun_call() {
     //~^ERROR use of `unwrap_or`
     //~|HELP try this
     //~|SUGGESTION with_vec.unwrap_or_else(|| vec![]);
+
+    let without_default = Some(Foo);
+    without_default.unwrap_or(Foo::new());
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION without_default.unwrap_or_else(Foo::new);
 }
 
 fn main() {

--- a/tests/compile-fail/methods.rs
+++ b/tests/compile-fail/methods.rs
@@ -175,6 +175,33 @@ fn search_is_some() {
     let _ = foo.rposition().is_some();
 }
 
+/// Checks implementation of the OR_FUN_CALL lint
+fn or_fun_call() {
+    let foo = Some(vec![1]);
+    foo.unwrap_or(Vec::new());
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION foo.unwrap_or_else(Vec::new);
+
+    let bar = Some(vec![1]);
+    bar.unwrap_or(Vec::with_capacity(12));
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION bar.unwrap_or_else(|| Vec::with_capacity(12));
+
+    let baz : Result<_, ()> = Ok(vec![1]);
+    baz.unwrap_or(Vec::new());
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION baz.unwrap_or_else(|_| Vec::new());
+
+    let qux : Result<_, ()> = Ok(vec![1]);
+    qux.unwrap_or(Vec::with_capacity(12));
+    //~^ERROR use of `unwrap_or`
+    //~|HELP try this
+    //~|SUGGESTION qux.unwrap_or_else(|_| Vec::with_capacity(12));
+}
+
 fn main() {
     use std::io;
 

--- a/tests/compile-fail/needless_features.rs
+++ b/tests/compile-fail/needless_features.rs
@@ -1,5 +1,4 @@
 #![feature(plugin)]
-#![feature(convert)]
 #![plugin(clippy)]
 
 #![deny(clippy)]


### PR DESCRIPTION
This adds a lint to test for things like `foo.unwrap_or(String::new())` because there are `unwrap_or_else` and `unwrap_or_default` methods which can avoid the allocation.
This also adds utility methods to check for trait implementation.

Fix #496.