### PR TITLE
Fix deprecation warning on latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(plugin_registrar, box_syntax)]
 #![feature(rustc_private, collections)]
-#![feature(num_bits_bytes, iter_arith)]
+#![feature(iter_arith)]
 #![feature(custom_attribute)]
 #![allow(unknown_lints)]
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -209,7 +209,7 @@ fn int_ty_to_nbits(typ: &ty::TyS) -> usize {
     };
     // n == 4 is the usize/isize case
     if n == 4 {
-        ::std::usize::BITS
+        ::std::mem::size_of::<usize>() * 8
     } else {
         n
     }


### PR DESCRIPTION
`std::usize::BITS` has been deprecated.