### PR TITLE
Add lint for "string literal".as_bytes()

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 93 lints included in this crate:
+There are 94 lints included in this crate:
 
 name                                                                                                           | default | meaning
 ---------------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -83,6 +83,7 @@ name                                                                            
 [str_to_string](https://github.com/Manishearth/rust-clippy/wiki#str_to_string)                                 | warn    | using `to_string()` on a str, which should be `to_owned()`
 [string_add](https://github.com/Manishearth/rust-clippy/wiki#string_add)                                       | allow   | using `x + ..` where x is a `String`; suggests using `push_str()` instead
 [string_add_assign](https://github.com/Manishearth/rust-clippy/wiki#string_add_assign)                         | allow   | using `x = x + ..` where x is a `String`; suggests using `push_str()` instead
+[string_lit_as_bytes](https://github.com/Manishearth/rust-clippy/wiki#string_lit_as_bytes)                     | warn    | calling `as_bytes` on a string literal; suggests using a byte string literal instead
 [string_to_string](https://github.com/Manishearth/rust-clippy/wiki#string_to_string)                           | warn    | calling `String.to_string()` which is a no-op
 [temporary_assignment](https://github.com/Manishearth/rust-clippy/wiki#temporary_assignment)                   | warn    | assignments to temporaries
 [toplevel_ref_arg](https://github.com/Manishearth/rust-clippy/wiki#toplevel_ref_arg)                           | warn    | An entire binding was declared as `ref`, in a function argument (`fn foo(ref x: Bar)`), or a `let` statement (`let ref x = foo()`). In such cases, it is preferred to take references with `&`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_late_lint_pass(box misc::UsedUnderscoreBinding);
     reg.register_late_lint_pass(box array_indexing::ArrayIndexing);
     reg.register_late_lint_pass(box panic::PanicPass);
+    reg.register_late_lint_pass(box strings::StringLitAsBytes);
 
 
     reg.register_lint_group("clippy_pedantic", vec![
@@ -225,6 +226,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         ranges::RANGE_ZIP_WITH_LEN,
         returns::LET_AND_RETURN,
         returns::NEEDLESS_RETURN,
+        strings::STRING_LIT_AS_BYTES,
         temporary_assignment::TEMPORARY_ASSIGNMENT,
         transmute::USELESS_TRANSMUTE,
         types::BOX_VEC,

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -134,13 +134,13 @@ impl LateLintPass for StringLitAsBytes {
     fn check_expr(&mut self, cx: &LateContext, e: &Expr) {
         use std::ascii::AsciiExt;
         use syntax::ast::Lit_::LitStr;
-        use utils::snippet;
+        use utils::{snippet, in_macro};
 
         if let ExprMethodCall(ref name, _, ref args) = e.node {
             if name.node.as_str() == "as_bytes" {
                 if let ExprLit(ref lit) = args[0].node {
                     if let LitStr(ref lit_content, _) = lit.node {
-                        if lit_content.chars().all(|c| c.is_ascii()) {
+                        if lit_content.chars().all(|c| c.is_ascii()) && !in_macro(cx, e.span) {
                             let msg = format!("calling `as_bytes()` on a string literal. \
                                                Consider using a byte string literal instead: \
                                                `b{}`",

--- a/tests/compile-fail/strings.rs
+++ b/tests/compile-fail/strings.rs
@@ -44,6 +44,14 @@ fn both() {
     assert_eq!(&x, &z);
 }
 
+#[allow(dead_code, unused_variables)]
+#[deny(string_lit_as_bytes)]
+fn str_lit_as_bytes() {
+    let bs = "hello there".as_bytes(); //~ERROR calling `as_bytes()`
+    // no warning, because this cannot be written as a byte string literal:
+    let ubs = "☃".as_bytes();
+}
+
 fn main() {
     add_only();
     add_assign_only();


### PR DESCRIPTION
Fixes #560

I've made this `Warn` by default because I think byte string literals should be strictly preferred. Let me know if you think it should be `Allow`, since this is somewhat subjective.