### PR TITLE
fixed #528

### DIFF
--- a/src/block_in_if_condition.rs
+++ b/src/block_in_if_condition.rs
@@ -92,7 +92,9 @@ impl LateLintPass for BlockInIfCondition {
                                                         snippet_block(cx, then.span, "..")));
                         }
                     } else {
-                        if in_macro(cx, expr.span) || differing_macro_contexts(expr.span, block.stmts[0].span) {
+                        let span = block.expr.as_ref().map_or_else(|| block.stmts[0].span,
+                                                                   |e| e.span);
+                        if in_macro(cx, span) || differing_macro_contexts(expr.span, span) {
                             return;
                         }
                         // move block higher

--- a/tests/compile-fail/block_in_if_condition.rs
+++ b/tests/compile-fail/block_in_if_condition.rs
@@ -3,17 +3,28 @@
 
 #![deny(block_in_if_condition_expr)]
 #![deny(block_in_if_condition_stmt)]
-#![allow(unused)]
+#![allow(unused, let_and_return)]
 
 
 macro_rules! blocky {
     () => {{true}}
 }
 
+macro_rules! blocky_too {
+    () => {{
+        let r = true;
+        r
+    }}
+}
+
 fn macro_if() {
     if blocky!() {
     }
+    
+    if blocky_too!() {
+    }
 }
+
 fn condition_has_block() -> i32 {
 
     if { //~ERROR in an 'if' condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a 'let'


### PR DESCRIPTION
I just changed the macro check to look at the block's expression if available. Also added a test.

This closes #528, hopefully for good.

@Manishearth r?