### PR TITLE
lint against enums where all variants share a prefix/postfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 105 lints included in this crate:
+There are 106 lints included in this crate:
 
 name                                                                                                           | default | meaning
 ---------------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -30,6 +30,7 @@ name                                                                            
 [derive_hash_not_eq](https://github.com/Manishearth/rust-clippy/wiki#derive_hash_not_eq)                       | warn    | deriving `Hash` but implementing `PartialEq` explicitly
 [duplicate_underscore_argument](https://github.com/Manishearth/rust-clippy/wiki#duplicate_underscore_argument) | warn    | Function arguments having names which only differ by an underscore
 [empty_loop](https://github.com/Manishearth/rust-clippy/wiki#empty_loop)                                       | warn    | empty `loop {}` detected
+[enum_variant_names](https://github.com/Manishearth/rust-clippy/wiki#enum_variant_names)                       | warn    | finds enums where all variants share a prefix/postfix
 [eq_op](https://github.com/Manishearth/rust-clippy/wiki#eq_op)                                                 | warn    | equal operands on both sides of a comparison or bitwise combination (e.g. `x == x`)
 [expl_impl_clone_on_copy](https://github.com/Manishearth/rust-clippy/wiki#expl_impl_clone_on_copy)             | warn    | implementing `Clone` explicitly on `Copy` types
 [explicit_counter_loop](https://github.com/Manishearth/rust-clippy/wiki#explicit_counter_loop)                 | warn    | for-looping with an explicit counter when `_.enumerate()` would do

--- a/src/enum_variants.rs
+++ b/src/enum_variants.rs
@@ -1,0 +1,90 @@
+//! lint on enum variants that are prefixed or suffixed by the same characters
+
+use rustc::lint::*;
+use syntax::attr::*;
+use syntax::ast::*;
+use syntax::parse::token::InternedString;
+
+use utils::span_help_and_lint;
+
+/// **What it does:** Warns on enum variants that are prefixed or suffixed by the same characters
+///
+/// **Why is this bad?** Enum variant names should specify their variant, not the enum, too.
+///
+/// **Known problems:** None
+///
+/// **Example:** enum Cake { BlackForestCake, HummingbirdCake }
+declare_lint! { pub ENUM_VARIANT_NAMES, Warn,
+    "finds enums where all variants share a prefix/postfix" }
+
+pub struct EnumVariantNames;
+
+impl LintPass for EnumVariantNames {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(ENUM_VARIANT_NAMES)
+    }
+}
+
+fn var2str(var: &Variant) -> InternedString {
+    var.node.name.name.as_str()
+}
+
+fn partial_match(left: &str, right: &str) -> usize {
+    left.chars().zip(right.chars()).take_while(|&(l, r)| l == r).count()
+}
+
+fn partial_rmatch(left: &str, right: &str) -> usize {
+    left.chars().rev().zip(right.chars().rev()).take_while(|&(l, r)| l == r).count()
+}
+
+impl EarlyLintPass for EnumVariantNames {
+    fn check_item(&mut self, cx: &EarlyContext, item: &Item) {
+        if let ItemEnum(ref def, _) = item.node {
+            if def.variants.len() < 2 {
+                return;
+            }
+            let first = var2str(&*def.variants[0]);
+            let mut pre = first.to_string();
+            let mut post = pre.clone();
+            for var in &def.variants[1..] {
+                let name = var2str(var);
+                let pre_match = partial_match(&pre, &name);
+                let post_match = partial_rmatch(&post, &name);
+                pre.truncate(pre_match);
+                let post_end = post.len() - post_match;
+                post.drain(..post_end);
+            }
+            if let Some(c) = first[pre.len()..].chars().next() {
+                if !c.is_uppercase() {
+                    // non camel case prefix
+                    pre.clear()
+                }
+            }
+            if let Some(c) = first[..(first.len() - post.len())].chars().rev().next() {
+                if let Some(c1) = post.chars().next() {
+                    if !c.is_lowercase() || !c1.is_uppercase() {
+                        // non camel case postfix
+                        post.clear()
+                    }
+                }
+            }
+            if pre == "_" {
+                // don't lint on underscores which are meant to allow dead code
+                pre.clear();
+            }
+            let (what, value) = if !pre.is_empty() {
+                ("pre", pre)
+            } else if !post.is_empty() {
+                ("post", post)
+            } else {
+                return
+            };
+            span_help_and_lint(cx,
+                               ENUM_VARIANT_NAMES,
+                               item.span,
+                               &format!("All variants have the same {}fix: `{}`", what, value),
+                               &format!("remove the {}fixes and use full paths to \
+                                         the variants instead of glob imports", what));
+        }
+    }
+}

--- a/src/identity_op.rs
+++ b/src/identity_op.rs
@@ -2,8 +2,7 @@ use rustc::lint::*;
 use rustc_front::hir::*;
 use syntax::codemap::Span;
 
-use consts::{constant_simple, is_negative};
-use consts::Constant::ConstantInt;
+use consts::{constant_simple, is_negative, Constant};
 use utils::{span_lint, snippet, in_macro};
 
 /// **What it does:** This lint checks for identity operations, e.g. `x + 0`. It is `Warn` by default.
@@ -54,7 +53,7 @@ impl LateLintPass for IdentityOp {
 
 
 fn check(cx: &LateContext, e: &Expr, m: i8, span: Span, arg: Span) {
-    if let Some(ConstantInt(v, ty)) = constant_simple(e) {
+    if let Some(Constant::Int(v, ty)) = constant_simple(e) {
         if match m {
             0 => v == 0,
             -1 => is_negative(ty) && v == 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod ptr_arg;
 pub mod needless_bool;
 pub mod approx_const;
 pub mod eta_reduction;
+pub mod enum_variants;
 pub mod identity_op;
 pub mod items_after_statements;
 pub mod minmax;
@@ -93,6 +94,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_late_lint_pass(box misc::TopLevelRefPass);
     reg.register_late_lint_pass(box misc::CmpNan);
     reg.register_late_lint_pass(box eq_op::EqOp);
+    reg.register_early_lint_pass(box enum_variants::EnumVariantNames);
     reg.register_late_lint_pass(box bit_mask::BitMask);
     reg.register_late_lint_pass(box ptr_arg::PtrArg);
     reg.register_late_lint_pass(box needless_bool::NeedlessBool);
@@ -183,6 +185,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         derive::DERIVE_HASH_NOT_EQ,
         derive::EXPL_IMPL_CLONE_ON_COPY,
         entry::MAP_ENTRY,
+        enum_variants::ENUM_VARIANT_NAMES,
         eq_op::EQ_OP,
         escape::BOXED_LOCAL,
         eta_reduction::REDUNDANT_CLOSURE,

--- a/src/loops.rs
+++ b/src/loops.rs
@@ -365,8 +365,8 @@ fn check_for_loop_reverse_range(cx: &LateContext, arg: &Expr, expr: &Expr) {
     // if this for loop is iterating over a two-sided range...
     if let ExprRange(Some(ref start_expr), Some(ref stop_expr)) = arg.node {
         // ...and both sides are compile-time constant integers...
-        if let Some(start_idx @ Constant::ConstantInt(..)) = constant_simple(start_expr) {
-            if let Some(stop_idx @ Constant::ConstantInt(..)) = constant_simple(stop_expr) {
+        if let Some(start_idx @ Constant::Int(..)) = constant_simple(start_expr) {
+            if let Some(stop_idx @ Constant::Int(..)) = constant_simple(stop_expr) {
                 // ...and the start index is greater than the stop index,
                 // this loop will never run. This is often confusing for developers
                 // who think that this will iterate from the larger value to the

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -19,9 +19,6 @@ use utils::{
 use utils::MethodArgs;
 use rustc::middle::cstore::CrateStore;
 
-use self::SelfKind::*;
-use self::OutType::*;
-
 #[derive(Clone)]
 pub struct MethodsPass;
 
@@ -456,11 +453,11 @@ fn lint_extend(cx: &LateContext, expr: &Expr, args: &MethodArgs) {
     }
 }
 
-fn derefs_to_slice(cx: &LateContext, expr: &Expr, ty: &ty::Ty) 
+fn derefs_to_slice(cx: &LateContext, expr: &Expr, ty: &ty::Ty)
    -> Option<(Span, &'static str)> {
     fn may_slice(cx: &LateContext, ty: &ty::Ty) -> bool {
         match ty.sty {
-            ty::TySlice(_) => true,            
+            ty::TySlice(_) => true,
             ty::TyStruct(..) => match_type(cx, ty, &VEC_PATH),
             ty::TyArray(_, size) => size < 32,
             ty::TyRef(_, ty::TypeAndMut { ty: ref inner, .. }) |
@@ -469,7 +466,7 @@ fn derefs_to_slice(cx: &LateContext, expr: &Expr, ty: &ty::Ty)
         }
     }
     if let ExprMethodCall(name, _, ref args) = expr.node {
-        if &name.node.as_str() == &"iter" && 
+        if &name.node.as_str() == &"iter" &&
                may_slice(cx, &cx.tcx.expr_ty(&args[0])) {
             Some((args[0].span, "&"))
         } else {
@@ -479,7 +476,7 @@ fn derefs_to_slice(cx: &LateContext, expr: &Expr, ty: &ty::Ty)
         match ty.sty {
             ty::TySlice(_) => Some((expr.span, "")),
             ty::TyRef(_, ty::TypeAndMut { ty: ref inner, .. }) |
-            ty::TyBox(ref inner) => if may_slice(cx, inner) { 
+            ty::TyBox(ref inner) => if may_slice(cx, inner) {
                 Some((expr.span, ""))
             } else { None },
             _ => None
@@ -731,180 +728,180 @@ fn has_debug_impl<'a, 'b>(ty: ty::Ty<'a>, cx: &LateContext<'b, 'a>) -> bool {
     debug_impl_exists
 }
 
-const CONVENTIONS: [(&'static str, &'static [SelfKind]); 5] = [("into_", &[ValueSelf]),
-                                                               ("to_", &[RefSelf]),
-                                                               ("as_", &[RefSelf, RefMutSelf]),
-                                                               ("is_", &[RefSelf, NoSelf]),
-                                                               ("from_", &[NoSelf])];
+const CONVENTIONS: [(&'static str, &'static [SelfKind]); 5] = [("into_", &[SelfKind::Value]),
+                                                               ("to_", &[SelfKind::Ref]),
+                                                               ("as_", &[SelfKind::Ref, SelfKind::RefMut]),
+                                                               ("is_", &[SelfKind::Ref, SelfKind::No]),
+                                                               ("from_", &[SelfKind::No])];
 
 const TRAIT_METHODS: [(&'static str, usize, SelfKind, OutType, &'static str); 30] = [("add",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::Add"),
                                                                                      ("sub",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::Sub"),
                                                                                      ("mul",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::Mul"),
                                                                                      ("div",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::Div"),
                                                                                      ("rem",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::Rem"),
                                                                                      ("shl",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::Shl"),
                                                                                      ("shr",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::Shr"),
                                                                                      ("bitand",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::BitAnd"),
                                                                                      ("bitor",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::BitOr"),
                                                                                      ("bitxor",
                                                                                       2,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::BitXor"),
                                                                                      ("neg",
                                                                                       1,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::Neg"),
                                                                                      ("not",
                                                                                       1,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::ops::Not"),
                                                                                      ("drop",
                                                                                       1,
-                                                                                      RefMutSelf,
-                                                                                      UnitType,
+                                                                                      SelfKind::RefMut,
+                                                                                      OutType::Unit,
                                                                                       "std::ops::Drop"),
                                                                                      ("index",
                                                                                       2,
-                                                                                      RefSelf,
-                                                                                      RefType,
+                                                                                      SelfKind::Ref,
+                                                                                      OutType::Ref,
                                                                                       "std::ops::Index"),
                                                                                      ("index_mut",
                                                                                       2,
-                                                                                      RefMutSelf,
-                                                                                      RefType,
+                                                                                      SelfKind::RefMut,
+                                                                                      OutType::Ref,
                                                                                       "std::ops::IndexMut"),
                                                                                      ("deref",
                                                                                       1,
-                                                                                      RefSelf,
-                                                                                      RefType,
+                                                                                      SelfKind::Ref,
+                                                                                      OutType::Ref,
                                                                                       "std::ops::Deref"),
                                                                                      ("deref_mut",
                                                                                       1,
-                                                                                      RefMutSelf,
-                                                                                      RefType,
+                                                                                      SelfKind::RefMut,
+                                                                                      OutType::Ref,
                                                                                       "std::ops::DerefMut"),
                                                                                      ("clone",
                                                                                       1,
-                                                                                      RefSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Ref,
+                                                                                      OutType::Any,
                                                                                       "std::clone::Clone"),
                                                                                      ("borrow",
                                                                                       1,
-                                                                                      RefSelf,
-                                                                                      RefType,
+                                                                                      SelfKind::Ref,
+                                                                                      OutType::Ref,
                                                                                       "std::borrow::Borrow"),
                                                                                      ("borrow_mut",
                                                                                       1,
-                                                                                      RefMutSelf,
-                                                                                      RefType,
+                                                                                      SelfKind::RefMut,
+                                                                                      OutType::Ref,
                                                                                       "std::borrow::BorrowMut"),
                                                                                      ("as_ref",
                                                                                       1,
-                                                                                      RefSelf,
-                                                                                      RefType,
+                                                                                      SelfKind::Ref,
+                                                                                      OutType::Ref,
                                                                                       "std::convert::AsRef"),
                                                                                      ("as_mut",
                                                                                       1,
-                                                                                      RefMutSelf,
-                                                                                      RefType,
+                                                                                      SelfKind::RefMut,
+                                                                                      OutType::Ref,
                                                                                       "std::convert::AsMut"),
                                                                                      ("eq",
                                                                                       2,
-                                                                                      RefSelf,
-                                                                                      BoolType,
+                                                                                      SelfKind::Ref,
+                                                                                      OutType::Bool,
                                                                                       "std::cmp::PartialEq"),
                                                                                      ("cmp",
                                                                                       2,
-                                                                                      RefSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Ref,
+                                                                                      OutType::Any,
                                                                                       "std::cmp::Ord"),
                                                                                      ("default",
                                                                                       0,
-                                                                                      NoSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::No,
+                                                                                      OutType::Any,
                                                                                       "std::default::Default"),
                                                                                      ("hash",
                                                                                       2,
-                                                                                      RefSelf,
-                                                                                      UnitType,
+                                                                                      SelfKind::Ref,
+                                                                                      OutType::Unit,
                                                                                       "std::hash::Hash"),
                                                                                      ("next",
                                                                                       1,
-                                                                                      RefMutSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::RefMut,
+                                                                                      OutType::Any,
                                                                                       "std::iter::Iterator"),
                                                                                      ("into_iter",
                                                                                       1,
-                                                                                      ValueSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::Value,
+                                                                                      OutType::Any,
                                                                                       "std::iter::IntoIterator"),
                                                                                      ("from_iter",
                                                                                       1,
-                                                                                      NoSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::No,
+                                                                                      OutType::Any,
                                                                                       "std::iter::FromIterator"),
                                                                                      ("from_str",
                                                                                       1,
-                                                                                      NoSelf,
-                                                                                      AnyType,
+                                                                                      SelfKind::No,
+                                                                                      OutType::Any,
                                                                                       "std::str::FromStr")];
 
 #[derive(Clone, Copy)]
 enum SelfKind {
-    ValueSelf,
-    RefSelf,
-    RefMutSelf,
-    NoSelf,
+    Value,
+    Ref,
+    RefMut,
+    No,
 }
 
 impl SelfKind {
     fn matches(&self, slf: &ExplicitSelf_, allow_value_for_ref: bool) -> bool {
         match (self, slf) {
-            (&ValueSelf, &SelfValue(_)) => true,
-            (&RefSelf, &SelfRegion(_, Mutability::MutImmutable, _)) => true,
-            (&RefMutSelf, &SelfRegion(_, Mutability::MutMutable, _)) => true,
-            (&RefSelf, &SelfValue(_)) => allow_value_for_ref,
-            (&RefMutSelf, &SelfValue(_)) => allow_value_for_ref,
-            (&NoSelf, &SelfStatic) => true,
+            (&SelfKind::Value, &SelfValue(_)) => true,
+            (&SelfKind::Ref, &SelfRegion(_, Mutability::MutImmutable, _)) => true,
+            (&SelfKind::RefMut, &SelfRegion(_, Mutability::MutMutable, _)) => true,
+            (&SelfKind::Ref, &SelfValue(_)) => allow_value_for_ref,
+            (&SelfKind::RefMut, &SelfValue(_)) => allow_value_for_ref,
+            (&SelfKind::No, &SelfStatic) => true,
             (_, &SelfExplicit(ref ty, _)) => self.matches_explicit_type(ty, allow_value_for_ref),
             _ => false,
         }
@@ -912,41 +909,41 @@ impl SelfKind {
 
     fn matches_explicit_type(&self, ty: &Ty, allow_value_for_ref: bool) -> bool {
         match (self, &ty.node) {
-            (&ValueSelf, &TyPath(..)) => true,
-            (&RefSelf, &TyRptr(_, MutTy { mutbl: Mutability::MutImmutable, .. })) => true,
-            (&RefMutSelf, &TyRptr(_, MutTy { mutbl: Mutability::MutMutable, .. })) => true,
-            (&RefSelf, &TyPath(..)) => allow_value_for_ref,
-            (&RefMutSelf, &TyPath(..)) => allow_value_for_ref,
+            (&SelfKind::Value, &TyPath(..)) => true,
+            (&SelfKind::Ref, &TyRptr(_, MutTy { mutbl: Mutability::MutImmutable, .. })) => true,
+            (&SelfKind::RefMut, &TyRptr(_, MutTy { mutbl: Mutability::MutMutable, .. })) => true,
+            (&SelfKind::Ref, &TyPath(..)) => allow_value_for_ref,
+            (&SelfKind::RefMut, &TyPath(..)) => allow_value_for_ref,
             _ => false,
         }
     }
 
     fn description(&self) -> &'static str {
         match *self {
-            ValueSelf => "self by value",
-            RefSelf => "self by reference",
-            RefMutSelf => "self by mutable reference",
-            NoSelf => "no self",
+            SelfKind::Value => "self by value",
+            SelfKind::Ref => "self by reference",
+            SelfKind::RefMut => "self by mutable reference",
+            SelfKind::No => "no self",
         }
     }
 }
 
 #[derive(Clone, Copy)]
 enum OutType {
-    UnitType,
-    BoolType,
-    AnyType,
-    RefType,
+    Unit,
+    Bool,
+    Any,
+    Ref,
 }
 
 impl OutType {
     fn matches(&self, ty: &FunctionRetTy) -> bool {
         match (self, ty) {
-            (&UnitType, &DefaultReturn(_)) => true,
-            (&UnitType, &Return(ref ty)) if ty.node == TyTup(vec![].into()) => true,
-            (&BoolType, &Return(ref ty)) if is_bool(ty) => true,
-            (&AnyType, &Return(ref ty)) if ty.node != TyTup(vec![].into()) => true,
-            (&RefType, &Return(ref ty)) => {
+            (&OutType::Unit, &DefaultReturn(_)) => true,
+            (&OutType::Unit, &Return(ref ty)) if ty.node == TyTup(vec![].into()) => true,
+            (&OutType::Bool, &Return(ref ty)) if is_bool(ty) => true,
+            (&OutType::Any, &Return(ref ty)) if ty.node != TyTup(vec![].into()) => true,
+            (&OutType::Ref, &Return(ref ty)) => {
                 if let TyRptr(_, _) = ty.node {
                     true
                 } else {

--- a/src/zero_div_zero.rs
+++ b/src/zero_div_zero.rs
@@ -35,8 +35,8 @@ impl LateLintPass for ZeroDivZeroPass {
                 // TODO - constant_simple does not fold many operations involving floats.
                 // That's probably fine for this lint - it's pretty unlikely that someone would
                 // do something like 0.0/(2.0 - 2.0), but it would be nice to warn on that case too.
-                let Some(Constant::ConstantFloat(ref lhs_value, lhs_width)) = constant_simple(left),
-                let Some(Constant::ConstantFloat(ref rhs_value, rhs_width)) = constant_simple(right),
+                let Some(Constant::Float(ref lhs_value, lhs_width)) = constant_simple(left),
+                let Some(Constant::Float(ref rhs_value, rhs_width)) = constant_simple(right),
                 let Some(0.0) = lhs_value.parse().ok(),
                 let Some(0.0) = rhs_value.parse().ok()
             ],

--- a/tests/cc_seme.rs
+++ b/tests/cc_seme.rs
@@ -3,8 +3,8 @@
 
 #[allow(dead_code)]
 enum Baz {
-    Baz1,
-    Baz2,
+    One,
+    Two,
 }
 
 struct Test {
@@ -14,11 +14,11 @@ struct Test {
 
 fn main() {
     use Baz::*;
-    let x = Test { t: Some(0), b: Baz1 };
+    let x = Test { t: Some(0), b: One };
 
     match x {
-        Test { t: Some(_), b: Baz1 } => unreachable!(),
-        Test { t: Some(42), b: Baz2 } => unreachable!(),
+        Test { t: Some(_), b: One } => unreachable!(),
+        Test { t: Some(42), b: Two } => unreachable!(),
         Test { t: None, .. } => unreachable!(),
         Test { .. } => unreachable!(),
     }

--- a/tests/compile-fail/complex_types.rs
+++ b/tests/compile-fail/complex_types.rs
@@ -16,8 +16,8 @@ struct S {
 struct TS(Vec<Vec<Box<(u32, u32, u32, u32)>>>); //~ERROR very complex type
 
 enum E {
-    V1(Vec<Vec<Box<(u32, u32, u32, u32)>>>), //~ERROR very complex type
-    V2 { f: Vec<Vec<Box<(u32, u32, u32, u32)>>> }, //~ERROR very complex type
+    Tuple(Vec<Vec<Box<(u32, u32, u32, u32)>>>), //~ERROR very complex type
+    Struct { f: Vec<Vec<Box<(u32, u32, u32, u32)>>> }, //~ERROR very complex type
 }
 
 impl S {

--- a/tests/compile-fail/no_effect.rs
+++ b/tests/compile-fail/no_effect.rs
@@ -11,8 +11,8 @@ struct Struct {
     field: i32
 }
 enum Enum {
-    TupleVariant(i32),
-    StructVariant { field: i32 },
+    Tuple(i32),
+    Struct { field: i32 },
 }
 
 fn get_number() -> i32 { 0 }
@@ -26,14 +26,14 @@ fn main() {
     Tuple(0); //~ERROR statement with no effect
     Struct { field: 0 }; //~ERROR statement with no effect
     Struct { ..s }; //~ERROR statement with no effect
-    Enum::TupleVariant(0); //~ERROR statement with no effect
-    Enum::StructVariant { field: 0 }; //~ERROR statement with no effect
+    Enum::Tuple(0); //~ERROR statement with no effect
+    Enum::Struct { field: 0 }; //~ERROR statement with no effect
 
     // Do not warn
     get_number();
     Tuple(get_number());
     Struct { field: get_number() };
     Struct { ..get_struct() };
-    Enum::TupleVariant(get_number());
-    Enum::StructVariant { field: get_number() };
+    Enum::Tuple(get_number());
+    Enum::Struct { field: get_number() };
 }

--- a/tests/compile-fail/used_underscore_binding.rs
+++ b/tests/compile-fail/used_underscore_binding.rs
@@ -50,17 +50,17 @@ fn multiple_underscores(__foo: u32) -> u32 {
 fn _fn_test() {}
 struct _StructTest;
 enum _EnumTest {
-    _FieldA,
-    _FieldB(_StructTest)
+    _Empty,
+    _Value(_StructTest)
 }
 
 /// Test that we do not lint for non-variable bindings
 fn non_variables() {
     _fn_test();
     let _s = _StructTest;
-    let _e = match _EnumTest::_FieldB(_StructTest) {
-        _EnumTest::_FieldA => 0,
-        _EnumTest::_FieldB(_st) => 1,
+    let _e = match _EnumTest::_Value(_StructTest) {
+        _EnumTest::_Empty => 0,
+        _EnumTest::_Value(_st) => 1,
     };
     let f = _fn_test;
     f();

--- a/tests/consts.rs
+++ b/tests/consts.rs
@@ -18,7 +18,6 @@ use syntax::ast::StrStyle::*;
 use syntax::ast::Sign::*;
 
 use clippy::consts::{constant_simple, Constant};
-use clippy::consts::Constant::*;
 
 fn spanned<T>(t: T) -> Spanned<T> {
     Spanned{ node: t, span: COMMAND_LINE_SP }
@@ -45,18 +44,18 @@ fn check(expect: Constant, expr: &Expr) {
     assert_eq!(Some(expect), constant_simple(expr))
 }
 
-const TRUE : Constant = ConstantBool(true);
-const FALSE : Constant = ConstantBool(false);
-const ZERO : Constant = ConstantInt(0, UnsuffixedIntLit(Plus));
-const ONE : Constant = ConstantInt(1, UnsuffixedIntLit(Plus));
-const TWO : Constant = ConstantInt(2, UnsuffixedIntLit(Plus));
+const TRUE : Constant = Constant::Bool(true);
+const FALSE : Constant = Constant::Bool(false);
+const ZERO : Constant = Constant::Int(0, UnsuffixedIntLit(Plus));
+const ONE : Constant = Constant::Int(1, UnsuffixedIntLit(Plus));
+const TWO : Constant = Constant::Int(2, UnsuffixedIntLit(Plus));
 
 #[test]
 fn test_lit() {
     check(TRUE, &lit(LitBool(true)));
     check(FALSE, &lit(LitBool(false)));
     check(ZERO, &lit(LitInt(0, UnsuffixedIntLit(Plus))));
-    check(ConstantStr("cool!".into(), CookedStr), &lit(LitStr(
+    check(Constant::Str("cool!".into(), CookedStr), &lit(LitStr(
         InternedString::new("cool!"), CookedStr)));
 }
 


### PR DESCRIPTION
This makes sure to check for camel-case. Thus something like

```rust
pub enum FloatWidth {
    Fw32,
    Fw64,
    FwAny,
}
```

is not linted against, because numbers aren't uppercase or lowercase.