### PR TITLE
Fix wiki

### DIFF
--- a/util/update_wiki.py
+++ b/util/update_wiki.py
@@ -79,7 +79,7 @@ errors of missing symbols.
 """
 
 
-template = """# `%s`
+template = """\n# `%s`
 
 **Default level:** %s
 


### PR DESCRIPTION
Ref https://github.com/Manishearth/rust-clippy/issues/634#issuecomment-181019893.

Markdown is hell.

```markdown
* foobar
# foobar
```
> * foobar
> # foobar

is not the same as
```markdown
* foobar

# foobar
```

> * foobar

> # foobar