### PR TITLE
Lints about `new` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 120 lints included in this crate:
+There are 121 lints included in this crate:
 
 name                                                                                                           | default | meaning
 ---------------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -76,6 +76,7 @@ name                                                                            
 [needless_range_loop](https://github.com/Manishearth/rust-clippy/wiki#needless_range_loop)                     | warn    | for-looping over a range of indices where an iterator over items would do
 [needless_return](https://github.com/Manishearth/rust-clippy/wiki#needless_return)                             | warn    | using a return statement like `return expr;` where an expression would suffice
 [needless_update](https://github.com/Manishearth/rust-clippy/wiki#needless_update)                             | warn    | using `{ ..base }` when there are no missing fields
+[new_ret_no_self](https://github.com/Manishearth/rust-clippy/wiki#new_ret_no_self)                             | warn    | not returning `Self` in a `new` method
 [no_effect](https://github.com/Manishearth/rust-clippy/wiki#no_effect)                                         | warn    | statements with no effect
 [non_ascii_literal](https://github.com/Manishearth/rust-clippy/wiki#non_ascii_literal)                         | allow   | using any literal non-ASCII chars in a string literal; suggests using the \\u escape instead
 [nonsensical_open_options](https://github.com/Manishearth/rust-clippy/wiki#nonsensical_open_options)           | warn    | nonsensical combination of options for opening a file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         methods::CLONE_ON_COPY,
         methods::EXTEND_FROM_SLICE,
         methods::FILTER_NEXT,
+        methods::NEW_RET_NO_SELF,
         methods::OK_EXPECT,
         methods::OPTION_MAP_UNWRAP_OR,
         methods::OPTION_MAP_UNWRAP_OR_ELSE,

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -274,7 +274,6 @@ declare_lint! {
 ///    println!("{:p} {:p}",*y, z); // prints out the same pointer
 /// }
 /// ```
-/// 
 declare_lint! {
     pub CLONE_DOUBLE_REF, Warn, "using `clone` on `&&T`"
 }
@@ -789,26 +788,12 @@ fn get_error_type<'a>(cx: &LateContext, ty: ty::Ty<'a>) -> Option<ty::Ty<'a>> {
     None
 }
 
-/// This checks whether a given type is known to implement Debug. It's
-/// conservative, i.e. it should not return false positives, but will return
-/// false negatives.
+/// This checks whether a given type is known to implement Debug.
 fn has_debug_impl<'a, 'b>(ty: ty::Ty<'a>, cx: &LateContext<'b, 'a>) -> bool {
-    let no_ref_ty = walk_ptrs_ty(ty);
-    let debug = match cx.tcx.lang_items.debug_trait() {
-        Some(debug) => debug,
-        None => return false,
-    };
-    let debug_def = cx.tcx.lookup_trait_def(debug);
-    let mut debug_impl_exists = false;
-    debug_def.for_each_relevant_impl(cx.tcx, no_ref_ty, |d| {
-        let self_ty = &cx.tcx.impl_trait_ref(d).and_then(|im| im.substs.self_ty());
-        if let Some(self_ty) = *self_ty {
-            if !self_ty.flags.get().contains(ty::TypeFlags::HAS_PARAMS) {
-                debug_impl_exists = true;
-            }
-        }
-    });
-    debug_impl_exists
+    match cx.tcx.lang_items.debug_trait() {
+        Some(debug) => implements_trait(cx, ty, debug, Some(vec![])),
+        None => false,
+    }
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]

--- a/tests/compile-fail/methods.rs
+++ b/tests/compile-fail/methods.rs
@@ -274,10 +274,8 @@ fn main() {
     // the error type implements `Debug`
     let res2: Result<i32, MyError> = Ok(0);
     res2.ok().expect("oh noes!");
-    // we currently don't warn if the error type has a type parameter
-    // (but it would be nice if we did)
     let res3: Result<u32, MyErrorWithParam<u8>>= Ok(0);
-    res3.ok().expect("whoof");
+    res3.ok().expect("whoof"); //~ERROR called `ok().expect()`
     let res4: Result<u32, io::Error> = Ok(0);
     res4.ok().expect("argh"); //~ERROR called `ok().expect()`
     let res5: io::Result<u32> = Ok(0);

--- a/tests/compile-fail/methods.rs
+++ b/tests/compile-fail/methods.rs
@@ -22,6 +22,8 @@ impl T {
     fn into_u16(&self) -> u16 { 0 } //~ERROR methods called `into_*` usually take self by value
 
     fn to_something(self) -> u32 { 0 } //~ERROR methods called `to_*` usually take self by reference
+
+    fn new(self) {} //~ERROR methods called `new` usually take no self
 }
 
 #[derive(Clone,Copy)]

--- a/tests/compile-fail/methods.rs
+++ b/tests/compile-fail/methods.rs
@@ -23,14 +23,25 @@ impl T {
 
     fn to_something(self) -> u32 { 0 } //~ERROR methods called `to_*` usually take self by reference
 
-    fn new(self) {} //~ERROR methods called `new` usually take no self
+    fn new(self) {}
+    //~^ ERROR methods called `new` usually take no self
+    //~| ERROR methods called `new` usually return `Self`
 }
 
 #[derive(Clone,Copy)]
 struct U;
 
 impl U {
+    fn new() -> Self { U }
     fn to_something(self) -> u32 { 0 } // ok because U is Copy
+}
+
+struct V<T> {
+    _dummy: T
+}
+
+impl<T> V<T> {
+    fn new() -> Option<V<T>> { None }
 }
 
 impl Mul<T> for T {


### PR DESCRIPTION
Fix #618.

Edit: hum, should we allow:
```rust
impl Foo {
    fn new(..) -> Result<Foo, Error> { .. }
}
```
too?