### PR TITLE
Clarify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Add in your `Cargo.toml`:
 clippy = "*"
 ```
 
-You may also use [`cargo clippy`](https://github.com/arcnmx/cargo-clippy), a custom cargo subcommand that runs clippy on a given project.
+You then need to add `#![feature(plugin)]` and `#![plugin(clippy)]` to the top of your crate entry point (`main.rs` or `lib.rs`).
 
 Sample `main.rs`:
 ```rust
@@ -171,6 +171,9 @@ src/main.rs:11     }
 src/main.rs:8:5: 11:6 help: Try
 if let Some(y) = x { println!("{:?}", y) }
 ```
+
+
+An alternate way to use clippy is by compiling and using [`cargo clippy`](https://github.com/arcnmx/cargo-clippy), a custom cargo subcommand that runs clippy on a given project.
 
 You can add options  to `allow`/`warn`/`deny`:
 - the whole set of `Warn` lints using the `clippy` lint group (`#![deny(clippy)]`)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #rust-clippy
 [![Build Status](https://travis-ci.org/Manishearth/rust-clippy.svg?branch=master)](https://travis-ci.org/Manishearth/rust-clippy)
+[![Current Version](http://meritbadge.herokuapp.com/optional)](https://crates.io/crates/clippy)
+[![License: MIT/Apache](https://img.shields.io/crates/l/clippy.svg)](#License)
 
 A collection of lints to catch common mistakes and improve your Rust code.
 


### PR DESCRIPTION
It may read as "change this cargo.toml *and* use cargo-clippy"