### PR TITLE
Fix ICE in `EXPL_IMPL_CLONE_ON_COPY`

### DIFF
--- a/tests/ice-666.rs
+++ b/tests/ice-666.rs
@@ -1,0 +1,24 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+pub struct Lt<'a> {
+    _foo: &'a u8,
+}
+
+impl<'a> Copy for Lt<'a> {}
+impl<'a> Clone for Lt<'a> {
+    fn clone(&self) -> Lt<'a> {
+        unimplemented!();
+    }
+}
+
+pub struct Ty<A> {
+    _foo: A,
+}
+
+impl<A: Copy> Copy for Ty<A> {}
+impl<A> Clone for Ty<A> {
+    fn clone(&self) -> Ty<A> {
+        unimplemented!();
+    }
+}


### PR DESCRIPTION
Ignores generics with lifetimes. The built-in `MISSING_COPY_IMPLEMENTATIONS` lint ignores lifetimes¹, I guess there must be reasons we can’t use them.

Closes #666.

--
1 : ignores all generics really, but we have tests for generics without lts and it works™.