### PR TITLE
Improve the `MAP_ENTRY` lint

### DIFF
--- a/tests/compile-fail/entry.rs
+++ b/tests/compile-fail/entry.rs
@@ -19,29 +19,37 @@ fn insert_if_absent0<K: Eq + Hash, V>(m: &mut HashMap<K, V>, k: K, v: V) {
 fn insert_if_absent1<K: Eq + Hash, V>(m: &mut HashMap<K, V>, k: K, v: V) {
     if !m.contains_key(&k) { foo(); m.insert(k, v); }
     //~^ ERROR usage of `contains_key` followed by `insert` on `HashMap`
-    //~| HELP Consider
-    //~| SUGGESTION m.entry(k)
+    //~| NOTE Consider using `m.entry(k)`
 }
 
 fn insert_if_absent2<K: Eq + Hash, V>(m: &mut HashMap<K, V>, k: K, v: V) {
     if !m.contains_key(&k) { m.insert(k, v) } else { None };
     //~^ ERROR usage of `contains_key` followed by `insert` on `HashMap`
-    //~| HELP Consider
-    //~| SUGGESTION m.entry(k).or_insert(v)
+    //~| NOTE Consider using `m.entry(k)`
+}
+
+fn insert_if_present2<K: Eq + Hash, V>(m: &mut HashMap<K, V>, k: K, v: V) {
+    if m.contains_key(&k) { None } else { m.insert(k, v) };
+    //~^ ERROR usage of `contains_key` followed by `insert` on `HashMap`
+    //~| NOTE Consider using `m.entry(k)`
 }
 
 fn insert_if_absent3<K: Eq + Hash, V>(m: &mut HashMap<K, V>, k: K, v: V) {
     if !m.contains_key(&k) { foo(); m.insert(k, v) } else { None };
     //~^ ERROR usage of `contains_key` followed by `insert` on `HashMap`
-    //~| HELP Consider
-    //~| SUGGESTION m.entry(k)
+    //~| NOTE Consider using `m.entry(k)`
+}
+
+fn insert_if_present3<K: Eq + Hash, V>(m: &mut HashMap<K, V>, k: K, v: V) {
+    if m.contains_key(&k) { None } else { foo(); m.insert(k, v) };
+    //~^ ERROR usage of `contains_key` followed by `insert` on `HashMap`
+    //~| NOTE Consider using `m.entry(k)`
 }
 
 fn insert_in_btreemap<K: Ord, V>(m: &mut BTreeMap<K, V>, k: K, v: V) {
     if !m.contains_key(&k) { foo(); m.insert(k, v) } else { None };
     //~^ ERROR usage of `contains_key` followed by `insert` on `BTreeMap`
-    //~| HELP Consider
-    //~| SUGGESTION m.entry(k)
+    //~| NOTE Consider using `m.entry(k)`
 }
 
 fn insert_other_if_absent<K: Eq + Hash, V>(m: &mut HashMap<K, V>, k: K, o: K, v: V) {


### PR DESCRIPTION
Don’t span a suggestion when not appropriate but use a note and don’t force it to be `if !cond`.

Fix #433 again.