### PR TITLE
Rust upgrade to 2016-03-02

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.44"
+version = "0.0.45"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",

--- a/src/types.rs
+++ b/src/types.rs
@@ -432,7 +432,7 @@ impl LateLintPass for TypeComplexityPass {
 
     fn check_struct_field(&mut self, cx: &LateContext, field: &StructField) {
         // enum variants are also struct fields now
-        check_type(cx, &field.node.ty);
+        check_type(cx, &field.ty);
     }
 
     fn check_item(&mut self, cx: &LateContext, item: &Item) {


### PR DESCRIPTION
The nightly doesn't exist yet, but it's good to have this PR ready for when it does.