### PR TITLE
`vec!` now uses `box`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.45"
+version = "0.0.46"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",

--- a/src/cyclomatic_complexity.rs
+++ b/src/cyclomatic_complexity.rs
@@ -116,7 +116,7 @@ impl<'a> Visitor<'a> for MatchArmCounter {
     }
 }
 
-struct DivergenceCounter<'a, 'tcx: 'a>(u64, &'a ty::ctxt<'tcx>);
+struct DivergenceCounter<'a, 'tcx: 'a>(u64, &'a ty::TyCtxt<'tcx>);
 
 impl<'a, 'b, 'tcx> Visitor<'a> for DivergenceCounter<'b, 'tcx> {
     fn visit_expr(&mut self, e: &'a Expr) {


### PR DESCRIPTION
It’s not even been merged yet, but https://github.com/rust-lang/rust/pull/31797 will break the `useless_vec` lint.