### PR TITLE
Warn about calling a closure in the same expression where it's defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of lints to catch common mistakes and improve your Rust code.
 [Jump to usage instructions](#usage)
 
 ##Lints
-There are 129 lints included in this crate:
+There are 130 lints included in this crate:
 
 name                                                                                                                 | default | meaning
 ---------------------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -99,6 +99,7 @@ name                                                                            
 [range_step_by_zero](https://github.com/Manishearth/rust-clippy/wiki#range_step_by_zero)                             | warn    | using Range::step_by(0), which produces an infinite iterator
 [range_zip_with_len](https://github.com/Manishearth/rust-clippy/wiki#range_zip_with_len)                             | warn    | zipping iterator with a range when enumerate() would do
 [redundant_closure](https://github.com/Manishearth/rust-clippy/wiki#redundant_closure)                               | warn    | using redundant closures, i.e. `|a| foo(a)` (which can be written as just `foo`)
+[redundant_closure_call](https://github.com/Manishearth/rust-clippy/wiki#redundant_closure_call)                     | warn    | Closures should not be called in the expression they are defined
 [redundant_pattern](https://github.com/Manishearth/rust-clippy/wiki#redundant_pattern)                               | warn    | using `name @ _` in a pattern
 [regex_macro](https://github.com/Manishearth/rust-clippy/wiki#regex_macro)                                           | warn    | finds use of `regex!(_)`, suggests `Regex::new(_)` instead
 [result_unwrap_used](https://github.com/Manishearth/rust-clippy/wiki#result_unwrap_used)                             | allow   | using `Result.unwrap()`, which might be better handled

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         misc::TOPLEVEL_REF_ARG,
         misc::USED_UNDERSCORE_BINDING,
         misc_early::DUPLICATE_UNDERSCORE_ARGUMENT,
+        misc_early::REDUNDANT_CLOSURE_CALL,
         misc_early::UNNEEDED_FIELD_PATTERN,
         mut_reference::UNNECESSARY_MUT_PASSED,
         mutex_atomic::MUTEX_ATOMIC,

--- a/tests/compile-fail/eta.rs
+++ b/tests/compile-fail/eta.rs
@@ -1,6 +1,6 @@
 #![feature(plugin)]
 #![plugin(clippy)]
-#![allow(unknown_lints, unused, no_effect)]
+#![allow(unknown_lints, unused, no_effect, redundant_closure_call)]
 #![deny(redundant_closure)]
 
 fn main() {

--- a/tests/compile-fail/redundant_closure_call.rs
+++ b/tests/compile-fail/redundant_closure_call.rs
@@ -1,0 +1,25 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+#![deny(redundant_closure_call)]
+
+fn main() {
+	let a = (|| 42)();
+	//~^ ERROR Try not to call a closure in the expression where it is declared.
+	//~| HELP Try doing something like:
+	//~| SUGGESTION let a = 42;
+
+	let mut i = 1;
+	let k = (|m| m+1)(i); //~ERROR Try not to call a closure in the expression where it is declared.
+
+	k = (|a,b| a*b)(1,5); //~ERROR Try not to call a closure in the expression where it is declared.
+
+	let closure = || 32;
+	i = closure(); //~ERROR Closure called just once immediately after it was declared
+
+	let closure = |i| i+1;
+	i = closure(3); //~ERROR Closure called just once immediately after it was declared
+
+	i = closure(4);
+}
+


### PR DESCRIPTION
Tries to solve #476 
So I've done a bit of work following the blog and `CONTRIBUTING.md`. I managed to print the AST node tree of my test file to be [url](https://pastebin.mozilla.org/8862081). The really nested part seems to be the interesting part containing the variants "Paren", "Closure", "Literal" and basically everything I'm interested in. Could someone give tell me about the `struct` I should `if let` my `expr.node` with? Would [`TyKind::Paren`](http://manishearth.github.io/rust-internals-docs/syntax/ast/enum.TyKind.html#variant.Paren) be relevant? @Manishearth @mcarton 