### PR TITLE
[WIP] Rustup to rustc 1.9.0-nightly (998a6720b 2016-03-07)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.46"
+version = "0.0.47"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",

--- a/src/loops.rs
+++ b/src/loops.rs
@@ -12,8 +12,10 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use utils::{snippet, span_lint, get_parent_expr, match_trait_method, match_type, in_external_macro,
-            span_help_and_lint, is_integer_literal, get_enclosing_block, span_lint_and_then, walk_ptrs_ty};
+            span_help_and_lint, is_integer_literal, get_enclosing_block, span_lint_and_then,
+            unsugar_range, walk_ptrs_ty};
 use utils::{BTREEMAP_PATH, HASHMAP_PATH, LL_PATH, OPTION_PATH, RESULT_PATH, VEC_PATH};
+use utils::UnsugaredRange;
 
 /// **What it does:** This lint checks for looping over the range of `0..len` of some collection just to get the values by index.
 ///
@@ -323,10 +325,9 @@ fn check_for_loop(cx: &LateContext, pat: &Pat, arg: &Expr, body: &Expr, expr: &E
 /// Check for looping over a range and then indexing a sequence with it.
 /// The iteratee must be a range literal.
 fn check_for_loop_range(cx: &LateContext, pat: &Pat, arg: &Expr, body: &Expr, expr: &Expr) {
-    if let ExprRange(Some(ref l), ref r) = arg.node {
+    if let Some(UnsugaredRange { start: Some(ref start), ref end, .. }) = unsugar_range(&arg) {
         // the var must be a single name
         if let PatKind::Ident(_, ref ident, _) = pat.node {
-
             let mut visitor = VarVisitor {
                 cx: cx,
                 var: ident.node.name,
@@ -348,19 +349,19 @@ fn check_for_loop_range(cx: &LateContext, pat: &Pat, arg: &Expr, body: &Expr, ex
                     return;
                 }
 
-                let starts_at_zero = is_integer_literal(l, 0);
+                let starts_at_zero = is_integer_literal(start, 0);
 
                 let skip: Cow<_> = if starts_at_zero {
                     "".into()
                 } else {
-                    format!(".skip({})", snippet(cx, l.span, "..")).into()
+                    format!(".skip({})", snippet(cx, start.span, "..")).into()
                 };
 
-                let take: Cow<_> = if let Some(ref r) = *r {
-                    if is_len_call(&r, &indexed) {
+                let take: Cow<_> = if let Some(ref end) = *end {
+                    if is_len_call(&end, &indexed) {
                         "".into()
                     } else {
-                        format!(".take({})", snippet(cx, r.span, "..")).into()
+                        format!(".take({})", snippet(cx, end.span, "..")).into()
                     }
                 } else {
                     "".into()
@@ -416,27 +417,27 @@ fn is_len_call(expr: &Expr, var: &Name) -> bool {
 
 fn check_for_loop_reverse_range(cx: &LateContext, arg: &Expr, expr: &Expr) {
     // if this for loop is iterating over a two-sided range...
-    if let ExprRange(Some(ref start_expr), Some(ref stop_expr)) = arg.node {
+    if let Some(UnsugaredRange { start: Some(ref start), end: Some(ref end), .. }) = unsugar_range(&arg) {
         // ...and both sides are compile-time constant integers...
-        if let Ok(start_idx) = eval_const_expr_partial(&cx.tcx, start_expr, ExprTypeChecked, None) {
-            if let Ok(stop_idx) = eval_const_expr_partial(&cx.tcx, stop_expr, ExprTypeChecked, None) {
-                // ...and the start index is greater than the stop index,
+        if let Ok(start_idx) = eval_const_expr_partial(&cx.tcx, start, ExprTypeChecked, None) {
+            if let Ok(end_idx) = eval_const_expr_partial(&cx.tcx, end, ExprTypeChecked, None) {
+                // ...and the start index is greater than the end index,
                 // this loop will never run. This is often confusing for developers
                 // who think that this will iterate from the larger value to the
                 // smaller value.
-                let (sup, eq) = match (start_idx, stop_idx) {
-                    (ConstVal::Int(start_idx), ConstVal::Int(stop_idx)) => {
-                        (start_idx > stop_idx, start_idx == stop_idx)
+                let (sup, eq) = match (start_idx, end_idx) {
+                    (ConstVal::Int(start_idx), ConstVal::Int(end_idx)) => {
+                        (start_idx > end_idx, start_idx == end_idx)
                     }
-                    (ConstVal::Uint(start_idx), ConstVal::Uint(stop_idx)) => {
-                        (start_idx > stop_idx, start_idx == stop_idx)
+                    (ConstVal::Uint(start_idx), ConstVal::Uint(end_idx)) => {
+                        (start_idx > end_idx, start_idx == end_idx)
                     }
                     _ => (false, false),
                 };
 
                 if sup {
-                    let start_snippet = snippet(cx, start_expr.span, "_");
-                    let stop_snippet = snippet(cx, stop_expr.span, "_");
+                    let start_snippet = snippet(cx, start.span, "_");
+                    let end_snippet = snippet(cx, end.span, "_");
 
                     span_lint_and_then(cx,
                                        REVERSE_RANGE_LOOP,
@@ -447,7 +448,7 @@ fn check_for_loop_reverse_range(cx: &LateContext, arg: &Expr, expr: &Expr) {
                                                               "consider using the following if \
                                                                you are attempting to iterate \
                                                                over this range in reverse",
-                                                              format!("({}..{}).rev()` ", stop_snippet, start_snippet));
+                                                              format!("({}..{}).rev()` ", end_snippet, start_snippet));
                                        });
                 } else if eq {
                     // if they are equal, it's also problematic - this loop

--- a/src/utils/hir.rs
+++ b/src/utils/hir.rs
@@ -109,9 +109,6 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
                 !self.ignore_fn && lname.node == rname.node && ltys.is_empty() && rtys.is_empty() &&
                 self.eq_exprs(largs, rargs)
             }
-            (&ExprRange(ref lb, ref le), &ExprRange(ref rb, ref re)) => {
-                both(lb, rb, |l, r| self.eq_expr(l, r)) && both(le, re, |l, r| self.eq_expr(l, r))
-            }
             (&ExprRepeat(ref le, ref ll), &ExprRepeat(ref re, ref rl)) => self.eq_expr(le, re) && self.eq_expr(ll, rl),
             (&ExprRet(ref l), &ExprRet(ref r)) => both(l, r, |l, r| self.eq_expr(l, r)),
             (&ExprPath(ref lqself, ref lsubpath), &ExprPath(ref rqself, ref rsubpath)) => {
@@ -383,16 +380,6 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 c.hash(&mut self.s);
                 self.hash_name(&name.node);
                 self.hash_exprs(args);
-            }
-            ExprRange(ref b, ref e) => {
-                let c: fn(_, _) -> _ = ExprRange;
-                c.hash(&mut self.s);
-                if let Some(ref b) = *b {
-                    self.hash_expr(b);
-                }
-                if let Some(ref e) = *e {
-                    self.hash_expr(e);
-                }
             }
             ExprRepeat(ref e, ref l) => {
                 let c: fn(_, _) -> _ = ExprRepeat;

--- a/src/utils/hir.rs
+++ b/src/utils/hir.rs
@@ -117,6 +117,11 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
             (&ExprPath(ref lqself, ref lsubpath), &ExprPath(ref rqself, ref rsubpath)) => {
                 both(lqself, rqself, |l, r| self.eq_qself(l, r)) && self.eq_path(lsubpath, rsubpath)
             }
+            (&ExprStruct(ref lpath, ref lf, ref lo), &ExprStruct(ref rpath, ref rf, ref ro)) => {
+                self.eq_path(lpath, rpath) &&
+                    both(lo, ro, |l, r| self.eq_expr(l, r)) &&
+                    over(lf, rf, |l, r| self.eq_field(l, r))
+            }
             (&ExprTup(ref ltup), &ExprTup(ref rtup)) => self.eq_exprs(ltup, rtup),
             (&ExprTupField(ref le, li), &ExprTupField(ref re, ri)) => li.node == ri.node && self.eq_expr(le, re),
             (&ExprUnary(lop, ref le), &ExprUnary(rop, ref re)) => lop == rop && self.eq_expr(le, re),
@@ -130,6 +135,10 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
 
     fn eq_exprs(&self, left: &[P<Expr>], right: &[P<Expr>]) -> bool {
         over(left, right, |l, r| self.eq_expr(l, r))
+    }
+
+    fn eq_field(&self, left: &Field, right: &Field) -> bool {
+        left.name.node == right.name.node && self.eq_expr(&left.expr, &right.expr)
     }
 
     /// Check whether two patterns are the same.

--- a/tests/compile-fail/copies.rs
+++ b/tests/compile-fail/copies.rs
@@ -1,4 +1,4 @@
-#![feature(plugin)]
+#![feature(plugin, inclusive_range_syntax)]
 #![plugin(clippy)]
 
 #![allow(dead_code, no_effect)]
@@ -10,14 +10,44 @@
 fn bar<T>(_: T) {}
 fn foo() -> bool { unimplemented!() }
 
+struct Foo {
+    bar: u8,
+}
+
 #[deny(if_same_then_else)]
 #[deny(match_same_arms)]
 fn if_same_then_else() -> Result<&'static str, ()> {
     if true {
+        Foo { bar: 42 };
+        0..10;
+        ..;
+        0..;
+        ..10;
+        0...10;
         foo();
     }
     else { //~ERROR this `if` has identical blocks
+        Foo { bar: 42 };
+        0..10;
+        ..;
+        0..;
+        ..10;
+        0...10;
         foo();
+    }
+
+    if true {
+        Foo { bar: 42 };
+    }
+    else {
+        Foo { bar: 43 };
+    }
+
+    if true {
+        0..10;
+    }
+    else {
+        0...10;
     }
 
     if true {

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, step_by)]
+#![feature(plugin, step_by, inclusive_range_syntax)]
 #![plugin(clippy)]
 
 use std::collections::*;
@@ -118,7 +118,17 @@ fn main() {
         println!("{}", vec[i]);
     }
 
+    for i in 0...MAX_LEN {
+        //~^ ERROR `i` is only used to index `vec`. Consider using `for item in vec.iter().take(MAX_LEN)`
+        println!("{}", vec[i]);
+    }
+
     for i in 5..10 {
+        //~^ ERROR `i` is only used to index `vec`. Consider using `for item in vec.iter().take(10).skip(5)`
+        println!("{}", vec[i]);
+    }
+
+    for i in 5...10 {
         //~^ ERROR `i` is only used to index `vec`. Consider using `for item in vec.iter().take(10).skip(5)`
         println!("{}", vec[i]);
     }
@@ -140,6 +150,13 @@ fn main() {
         println!("{}", i);
     }
 
+    for i in 10...0 {
+        //~^ERROR this range is empty so this for loop will never run
+        //~|HELP consider
+        //~|SUGGESTION (0..10).rev()
+        println!("{}", i);
+    }
+
     for i in MAX_LEN..0 { //~ERROR this range is empty so this for loop will never run
         //~|HELP consider
         //~|SUGGESTION (0..MAX_LEN).rev()
@@ -147,6 +164,10 @@ fn main() {
     }
 
     for i in 5..5 { //~ERROR this range is empty so this for loop will never run
+        println!("{}", i);
+    }
+
+    for i in 5...5 { // not an error, this is the range with only one element “5”
         println!("{}", i);
     }
 

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -158,10 +158,6 @@ fn main() {
         println!("{}", i);
     }
 
-    for i in (10..0).rev() { // not an error, this is an established idiom for looping backwards on a range
-        println!("{}", i);
-    }
-
     for i in (10..0).map(|x| x * 2) { // not an error, it can't be known what arbitrary methods do to a range
         println!("{}", i);
     }

--- a/tests/compile-fail/no_effect.rs
+++ b/tests/compile-fail/no_effect.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, box_syntax)]
+#![feature(plugin, box_syntax, inclusive_range_syntax)]
 #![plugin(clippy)]
 
 #![deny(no_effect)]
@@ -39,6 +39,7 @@ fn main() {
     5..; //~ERROR statement with no effect
     ..5; //~ERROR statement with no effect
     5..6; //~ERROR statement with no effect
+    5...6; //~ERROR statement with no effect
     [42, 55]; //~ERROR statement with no effect
     [42, 55][1]; //~ERROR statement with no effect
     (42, 55).1; //~ERROR statement with no effect


### PR DESCRIPTION
`ExprRange` was removed by https://github.com/rust-lang/rust/pull/30884.