### PR TITLE
Don’t fail tests when regex_macros does not compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ script:
  - python util/update_lints.py -c
  - cargo build --features debugging
  - cargo test --features debugging
+
+ # only test regex_macros if it compiles
+ - if [[ "$(cargo build --features 'debugging test-regex_macros')" = 101 ]]; then cargo test --features 'debugging test-regex_macros'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ sudo: false
 
 script:
  - python util/update_lints.py -c
+ - cargo build --features debugging
  - cargo test --features debugging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ name = "clippy"
 plugin = true
 
 [dependencies]
-unicode-normalization = "0.1"
-semver = "0.2.1"
 regex-syntax = "0.2.2"
+regex_macros = { version = "0.1.28", optional = true }
+semver = "0.2.1"
+unicode-normalization = "0.1"
 
 [dev-dependencies]
 compiletest_rs = "0.0.11"
-regex = "0.1.47"
-regex_macros = "0.1.28"
 lazy_static = "0.1.15"
+regex = "0.1.47"
 rustc-serialize = "0.3"
 
 [features]
-
 debugging = []
+test-regex_macros = ["regex_macros"]

--- a/tests/compile-fail-regex_macros/regex.rs
+++ b/tests/compile-fail-regex_macros/regex.rs
@@ -1,0 +1,12 @@
+#![feature(plugin)]
+#![plugin(clippy, regex_macros)]
+
+#![allow(unused)]
+#![deny(invalid_regex, trivial_regex, regex_macro)]
+
+extern crate regex;
+
+fn main() {
+    let some_regex = regex!("for real!"); //~ERROR `regex!(_)`
+    let other_regex = regex!("[a-z]_[A-Z]"); //~ERROR `regex!(_)`
+}

--- a/tests/compile-fail/regex.rs
+++ b/tests/compile-fail/regex.rs
@@ -1,5 +1,5 @@
 #![feature(plugin)]
-#![plugin(clippy, regex_macros)]
+#![plugin(clippy)]
 
 #![allow(unused)]
 #![deny(invalid_regex, trivial_regex, regex_macro)]
@@ -70,14 +70,7 @@ fn trivial_regex() {
     let non_trivial_ends_with = Regex::new("foo|bar");
 }
 
-fn regex_macro() {
-    let some_regex = regex!("for real!"); //~ERROR `regex!(_)`
-    let other_regex = regex!("[a-z]_[A-Z]"); //~ERROR `regex!(_)`
-}
-
-
 fn main() {
-    regex_macro();
     syntax_error();
     trivial_regex();
 }

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -20,7 +20,15 @@ fn run_mode(mode: &'static str) {
 }
 
 #[test]
+#[cfg(not(feature = "test-regex_macros"))]
 fn compile_test() {
     run_mode("run-pass");
     run_mode("compile-fail");
+}
+
+#[test]
+#[cfg(feature = "test-regex_macros")]
+fn compile_test() {
+    run_mode("run-pass-regex_macros");
+    run_mode("compile-fail-regex_macros");
 }

--- a/tests/run-pass-regex_macros/mut_mut_macro.rs
+++ b/tests/run-pass-regex_macros/mut_mut_macro.rs
@@ -1,0 +1,12 @@
+#![feature(plugin)]
+#![plugin(clippy, regex_macros)]
+
+#[macro_use]
+extern crate regex;
+
+#[deny(mut_mut)]
+#[allow(regex_macro)]
+fn main() {
+    let pattern = regex!(r"^(?P<level>[#]+)\s(?P<title>.+)$");
+    assert!(pattern.is_match("# headline"));
+}

--- a/tests/run-pass/mut_mut_macro.rs
+++ b/tests/run-pass/mut_mut_macro.rs
@@ -1,24 +1,14 @@
 #![feature(plugin)]
-#![plugin(clippy, regex_macros)]
+#![plugin(clippy)]
 
 #[macro_use]
 extern crate lazy_static;
-extern crate regex;
 
 use std::collections::HashMap;
 
-#[test]
-#[deny(mut_mut)]
-#[allow(regex_macro)]
-fn test_regex() {
-    let pattern = regex!(r"^(?P<level>[#]+)\s(?P<title>.+)$");
-    assert!(pattern.is_match("# headline"));
-}
-
-#[test]
 #[deny(mut_mut)]
 #[allow(unused_variables, unused_mut)]
-fn test_lazy_static() {
+fn main() {
     lazy_static! {
         static ref MUT_MAP : HashMap<usize, &'static str> = {
             let mut m = HashMap::new();


### PR DESCRIPTION
:warning: This moves `regex_macros` from `[dev-dependencies]` to `[dependencies]` but as `optional = true`. For some reason `[dev-dependencies]` aren’t allowed to be optional. I don’t know if that a good thing.
At least we won’t be without Travis when `regex_macros` does not compile.