### PR TITLE
fix cyclomatic complexity lint triggering because of short circuit operations

### DIFF
--- a/src/overflow_check_conditional.rs
+++ b/src/overflow_check_conditional.rs
@@ -1,4 +1,3 @@
-#![allow(cyclomatic_complexity)]
 use rustc::lint::*;
 use rustc_front::hir::*;
 use utils::{span_lint};
@@ -38,12 +37,12 @@ impl LateLintPass for OverflowCheckConditional {
         ], {
             if let BinOp_::BiLt = op.node {
                 if let BinOp_::BiAdd = op2.node {
-                    span_lint(cx, OVERFLOW_CHECK_CONDITIONAL, expr.span, "You are trying to use classic C overflow conditons that will fail in Rust.");
+                    span_lint(cx, OVERFLOW_CHECK_CONDITIONAL, expr.span, "You are trying to use classic C overflow conditions that will fail in Rust.");
                 }
             }
             if let BinOp_::BiGt = op.node {
                 if let BinOp_::BiSub = op2.node {
-                    span_lint(cx, OVERFLOW_CHECK_CONDITIONAL, expr.span, "You are trying to use classic C underflow conditons that will fail in Rust.");
+                    span_lint(cx, OVERFLOW_CHECK_CONDITIONAL, expr.span, "You are trying to use classic C underflow conditions that will fail in Rust.");
                 }
             }
         }}
@@ -60,12 +59,12 @@ impl LateLintPass for OverflowCheckConditional {
         ], {
             if let BinOp_::BiGt = op.node {
                 if let BinOp_::BiAdd = op2.node {
-                    span_lint(cx, OVERFLOW_CHECK_CONDITIONAL, expr.span, "You are trying to use classic C overflow conditons that will fail in Rust.");
+                    span_lint(cx, OVERFLOW_CHECK_CONDITIONAL, expr.span, "You are trying to use classic C overflow conditions that will fail in Rust.");
                 }
             }
             if let BinOp_::BiLt = op.node {
                 if let BinOp_::BiSub = op2.node {
-                    span_lint(cx, OVERFLOW_CHECK_CONDITIONAL, expr.span, "You are trying to use classic C underflow conditons that will fail in Rust.");
+                    span_lint(cx, OVERFLOW_CHECK_CONDITIONAL, expr.span, "You are trying to use classic C underflow conditions that will fail in Rust.");
                 }
             }
         }}

--- a/src/utils/hir.rs
+++ b/src/utils/hir.rs
@@ -55,8 +55,6 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
         both(&left.expr, &right.expr, |l, r| self.eq_expr(l, r))
     }
 
-    // ok, it’s a big function, but mostly one big match with simples cases
-    #[allow(cyclomatic_complexity)]
     pub fn eq_expr(&self, left: &Expr, right: &Expr) -> bool {
         if self.ignore_fn && differing_macro_contexts(left.span, right.span) {
             return false;

--- a/tests/compile-fail/cyclomatic_complexity.rs
+++ b/tests/compile-fail/cyclomatic_complexity.rs
@@ -1,6 +1,6 @@
 #![feature(plugin, custom_attribute)]
 #![plugin(clippy)]
-#![deny(clippy)]
+#![allow(clippy)]
 #![deny(cyclomatic_complexity)]
 #![allow(unused)]
 
@@ -90,7 +90,7 @@ fn main() { //~ERROR the function has a cyclomatic complexity of 28
 }
 
 #[cyclomatic_complexity = "0"]
-fn kaboom() {  //~ ERROR: the function has a cyclomatic complexity of 8
+fn kaboom() {  //~ ERROR: the function has a cyclomatic complexity of 7
     let n = 0;
     'a: for i in 0..20 {
         'b: for j in i..20 {
@@ -133,6 +133,16 @@ fn bloo() {
         55 | 57 | 59 | 61 | 63 | 65 | 67 | 69 | 71 | 73 => println!("I know borrow-fu"),
         _ => println!("bye"),
     }
+}
+
+#[cyclomatic_complexity = "0"]
+fn lots_of_short_circuits() -> bool { //~ ERROR: the function has a cyclomatic complexity of 1
+    true && false && true && false && true && false && true
+}
+
+#[cyclomatic_complexity = "0"]
+fn lots_of_short_circuits2() -> bool { //~ ERROR: the function has a cyclomatic complexity of 1
+    true || false || true || false || true || false || true
 }
 
 #[cyclomatic_complexity = "0"]

--- a/tests/compile-fail/overflow_check_conditional.rs
+++ b/tests/compile-fail/overflow_check_conditional.rs
@@ -7,28 +7,28 @@ fn main() {
 	let a: u32 = 1;
 	let b: u32 = 2;
 	let c: u32 = 3;
-	if a + b < a { //~ERROR You are trying to use classic C overflow conditons that will fail in Rust.
+	if a + b < a { //~ERROR You are trying to use classic C overflow conditions that will fail in Rust.
 
 	}
-	if a > a + b { //~ERROR You are trying to use classic C overflow conditons that will fail in Rust.
+	if a > a + b { //~ERROR You are trying to use classic C overflow conditions that will fail in Rust.
 
 	}
-	if a + b < b { //~ERROR You are trying to use classic C overflow conditons that will fail in Rust.
+	if a + b < b { //~ERROR You are trying to use classic C overflow conditions that will fail in Rust.
 
 	}
-	if b > a + b { //~ERROR You are trying to use classic C overflow conditons that will fail in Rust.
+	if b > a + b { //~ERROR You are trying to use classic C overflow conditions that will fail in Rust.
 
 	}
-	if a - b > b { //~ERROR You are trying to use classic C underflow conditons that will fail in Rust.
+	if a - b > b { //~ERROR You are trying to use classic C underflow conditions that will fail in Rust.
 
 	}
-	if b < a - b { //~ERROR You are trying to use classic C underflow conditons that will fail in Rust.
+	if b < a - b { //~ERROR You are trying to use classic C underflow conditions that will fail in Rust.
 
 	}
-	if a - b > a { //~ERROR You are trying to use classic C underflow conditons that will fail in Rust.
+	if a - b > a { //~ERROR You are trying to use classic C underflow conditions that will fail in Rust.
 
 	}
-	if a < a - b { //~ERROR You are trying to use classic C underflow conditons that will fail in Rust.
+	if a < a - b { //~ERROR You are trying to use classic C underflow conditions that will fail in Rust.
 
 	}
 	if a + b < c {
@@ -58,4 +58,3 @@ fn main() {
 
 	}
 }
-


### PR DESCRIPTION
every `&&` or `||` operation increased the cyclomatic complexity of a function by 1. This is very noticable in functions that implement a boolean operation on an enum, because many match arms will contain these operations.

While technically `&&` can have side effects through the rhs not executing depending on the lhs, this is not the intended use of the operator. It's supposed to have a fast-path in evaluating the operation, not conditionally execute side-effecting code.

Maybe we should additionally have a lint that checks for calls to methods that take `&mut` in the rhs of short circuit bool ops?

### no more cyclomatic complexity hits in `rustful`
compared to the previous
```
     31 : 2 fn
     41 : 1 fn
     51 : 8 fn
     61 : 2 fn
```

### no more cc hits in `racer`
compared to the previous 

```
     27 : 1 fn
     29 : 1 fn
     30 : 1 fn
     32 : 1 fn
```

cargo has 2 functions triggering the cc lint, but they are quite long.