### PR TITLE
Rustup to *1.9.0-nightly (c66d2380a 2016-03-15)*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.53"
+version = "0.0.54"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -3,6 +3,7 @@ use rustc::lint::*;
 use rustc::middle::expr_use_visitor::*;
 use rustc::middle::infer;
 use rustc::middle::mem_categorization::{cmt, Categorization};
+use rustc::middle::traits::ProjectionMode;
 use rustc::middle::ty::adjustment::AutoAdjustment;
 use rustc::middle::ty;
 use rustc::util::nodemap::NodeSet;
@@ -54,7 +55,7 @@ impl LintPass for EscapePass {
 impl LateLintPass for EscapePass {
     fn check_fn(&mut self, cx: &LateContext, _: visit::FnKind, decl: &FnDecl, body: &Block, _: Span, id: NodeId) {
         let param_env = ty::ParameterEnvironment::for_item(cx.tcx, id);
-        let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, Some(param_env));
+        let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, Some(param_env), ProjectionMode::Any);
         let mut v = EscapeDelegate {
             cx: cx,
             set: NodeSet(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@ use reexport::*;
 use rustc::front::map::Node;
 use rustc::lint::{LintContext, LateContext, Level, Lint};
 use rustc::middle::def_id::DefId;
+use rustc::middle::traits::ProjectionMode;
 use rustc::middle::{cstore, def, infer, ty, traits};
 use rustc::session::Session;
 use rustc_front::hir::*;
@@ -269,7 +270,7 @@ pub fn implements_trait<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: ty::Ty<'tcx>, 
                                   -> bool {
     cx.tcx.populate_implementations_for_trait_if_necessary(trait_id);
 
-    let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, None);
+    let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, None, ProjectionMode::Any);
     let obligation = traits::predicate_for_trait_def(cx.tcx,
                                                      traits::ObligationCause::dummy(),
                                                      trait_id,
@@ -753,6 +754,6 @@ pub fn return_ty(fun: ty::Ty) -> Option<ty::Ty> {
 // FIXME: this works correctly for lifetimes bounds (`for <'a> Foo<'a>` == `for <'b> Foo<'b>` but
 // not for type parameters.
 pub fn same_tys<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, a: ty::Ty<'tcx>, b: ty::Ty<'tcx>) -> bool {
-    let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, None);
+    let infcx = infer::new_infer_ctxt(cx.tcx, &cx.tcx.tables, None, ProjectionMode::Any);
     infcx.can_equate(&cx.tcx.erase_regions(&a), &cx.tcx.erase_regions(&b)).is_ok()
 }

--- a/tests/compile-fail/derive.rs
+++ b/tests/compile-fail/derive.rs
@@ -3,6 +3,7 @@
 
 #![deny(warnings)]
 #![allow(dead_code)]
+#![allow(unused_variables)] // Temporary fix for rustc false positive. To be removed.
 
 use std::hash::{Hash, Hasher};
 


### PR DESCRIPTION
Will have to wait on https://github.com/laumann/compiletest-rs/pull/34. Ref https://github.com/rust-lang/rust/pull/30652.