### PR TITLE
optimize booleans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ regex_macros = { version = "0.1.33", optional = true }
 semver = "0.2.1"
 toml = "0.1"
 unicode-normalization = "0.1"
-quine-mc_cluskey = "0.2.1"
+quine-mc_cluskey = "0.2.2"
 
 [dev-dependencies]
 compiletest_rs = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ regex_macros = { version = "0.1.33", optional = true }
 semver = "0.2.1"
 toml = "0.1"
 unicode-normalization = "0.1"
+quine-mc_cluskey = "0.2"
 
 [dev-dependencies]
 compiletest_rs = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ regex_macros = { version = "0.1.33", optional = true }
 semver = "0.2.1"
 toml = "0.1"
 unicode-normalization = "0.1"
-quine-mc_cluskey = "0.2"
+quine-mc_cluskey = "0.2.1"
 
 [dev-dependencies]
 compiletest_rs = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ name                                                                            
 [new_without_default](https://github.com/Manishearth/rust-clippy/wiki#new_without_default)                           | warn    | `fn new() -> Self` method without `Default` implementation
 [no_effect](https://github.com/Manishearth/rust-clippy/wiki#no_effect)                                               | warn    | statements with no effect
 [non_ascii_literal](https://github.com/Manishearth/rust-clippy/wiki#non_ascii_literal)                               | allow   | using any literal non-ASCII chars in a string literal; suggests using the \\u escape instead
-[nonminimal_bool](https://github.com/Manishearth/rust-clippy/wiki#nonminimal_bool)                                   | warn    | checks for boolean expressions that can be written more concisely
+[nonminimal_bool](https://github.com/Manishearth/rust-clippy/wiki#nonminimal_bool)                                   | allow   | checks for boolean expressions that can be written more concisely
 [nonsensical_open_options](https://github.com/Manishearth/rust-clippy/wiki#nonsensical_open_options)                 | warn    | nonsensical combination of options for opening a file
 [ok_expect](https://github.com/Manishearth/rust-clippy/wiki#ok_expect)                                               | warn    | using `ok().expect()`, which gives worse error messages than calling `expect` directly on the Result
 [option_map_unwrap_or](https://github.com/Manishearth/rust-clippy/wiki#option_map_unwrap_or)                         | warn    | using `Option.map(f).unwrap_or(a)`, which is more succinctly expressed as `map_or(a, f)`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Table of contents:
 * [License](#license)
 
 ##Lints
-There are 137 lints included in this crate:
+There are 138 lints included in this crate:
 
 name                                                                                                                 | default | meaning
 ---------------------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -97,6 +97,7 @@ name                                                                            
 [new_without_default](https://github.com/Manishearth/rust-clippy/wiki#new_without_default)                           | warn    | `fn new() -> Self` method without `Default` implementation
 [no_effect](https://github.com/Manishearth/rust-clippy/wiki#no_effect)                                               | warn    | statements with no effect
 [non_ascii_literal](https://github.com/Manishearth/rust-clippy/wiki#non_ascii_literal)                               | allow   | using any literal non-ASCII chars in a string literal; suggests using the \\u escape instead
+[nonminimal_bool](https://github.com/Manishearth/rust-clippy/wiki#nonminimal_bool)                                   | warn    | checks for boolean expressions that can be written more concisely
 [nonsensical_open_options](https://github.com/Manishearth/rust-clippy/wiki#nonsensical_open_options)                 | warn    | nonsensical combination of options for opening a file
 [ok_expect](https://github.com/Manishearth/rust-clippy/wiki#ok_expect)                                               | warn    | using `ok().expect()`, which gives worse error messages than calling `expect` directly on the Result
 [option_map_unwrap_or](https://github.com/Manishearth/rust-clippy/wiki#option_map_unwrap_or)                         | warn    | using `Option.map(f).unwrap_or(a)`, which is more succinctly expressed as `map_or(a, f)`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Table of contents:
 * [License](#license)
 
 ##Lints
-There are 138 lints included in this crate:
+There are 139 lints included in this crate:
 
 name                                                                                                                 | default | meaning
 ---------------------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -75,6 +75,7 @@ name                                                                            
 [let_and_return](https://github.com/Manishearth/rust-clippy/wiki#let_and_return)                                     | warn    | creating a let-binding and then immediately returning it like `let x = expr; x` at the end of a block
 [let_unit_value](https://github.com/Manishearth/rust-clippy/wiki#let_unit_value)                                     | warn    | creating a let binding to a value of unit type, which usually can't be used afterwards
 [linkedlist](https://github.com/Manishearth/rust-clippy/wiki#linkedlist)                                             | warn    | usage of LinkedList, usually a vector is faster, or a more specialized data structure like a VecDeque
+[logic_bug](https://github.com/Manishearth/rust-clippy/wiki#logic_bug)                                               | warn    | checks for boolean expressions that contain terminals which can be eliminated
 [manual_swap](https://github.com/Manishearth/rust-clippy/wiki#manual_swap)                                           | warn    | manual swap
 [many_single_char_names](https://github.com/Manishearth/rust-clippy/wiki#many_single_char_names)                     | warn    | too many single character bindings
 [map_clone](https://github.com/Manishearth/rust-clippy/wiki#map_clone)                                               | warn    | using `.map(|x| x.clone())` to clone an iterator or option's contents (recommends `.cloned()` instead)

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -275,7 +275,7 @@ impl<'a, 'tcx> NonminimalBoolVisitor<'a, 'tcx> {
                         return;
                     }
                     // if the number of occurrences of a terminal decreases or any of the stats decreases while none increases
-                    improvement = (stats.terminals[i] > simplified_stats.terminals[i]) ||
+                    improvement |= (stats.terminals[i] > simplified_stats.terminals[i]) ||
                         (stats.negations > simplified_stats.negations && stats.ops == simplified_stats.ops) ||
                         (stats.ops > simplified_stats.ops && stats.negations == simplified_stats.negations);
                 }

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -1,4 +1,4 @@
-use rustc::lint::*;
+use rustc::lint::{LintArray, LateLintPass, LateContext, LintPass};
 use rustc_front::hir::*;
 use rustc_front::intravisit::*;
 use syntax::ast::LitKind;
@@ -110,11 +110,11 @@ fn suggest(cx: &LateContext, suggestion: &Bool, terminals: &[&Expr]) -> String {
         use quine_mc_cluskey::Bool::*;
         match *suggestion {
             True => {
-                s.extend("true".chars());
+                s.push_str("true");
                 s
             },
             False => {
-                s.extend("false".chars());
+                s.push_str("false");
                 s
             },
             Not(ref inner) => {
@@ -127,7 +127,7 @@ fn suggest(cx: &LateContext, suggestion: &Bool, terminals: &[&Expr]) -> String {
                 }
                 s = recurse(true, cx, &v[0], terminals, s);
                 for inner in &v[1..] {
-                    s.extend(" && ".chars());
+                    s.push_str(" && ");
                     s = recurse(true, cx, inner, terminals, s);
                 }
                 if brackets {
@@ -141,7 +141,7 @@ fn suggest(cx: &LateContext, suggestion: &Bool, terminals: &[&Expr]) -> String {
                 }
                 s = recurse(true, cx, &v[0], terminals, s);
                 for inner in &v[1..] {
-                    s.extend(" || ".chars());
+                    s.push_str(" || ");
                     s = recurse(true, cx, inner, terminals, s);
                 }
                 if brackets {
@@ -150,7 +150,7 @@ fn suggest(cx: &LateContext, suggestion: &Bool, terminals: &[&Expr]) -> String {
                 s
             },
             Term(n) => {
-                s.extend(snippet_opt(cx, terminals[n as usize].span).expect("don't try to improve booleans created by macros").chars());
+                s.push_str(&snippet_opt(cx, terminals[n as usize].span).expect("don't try to improve booleans created by macros"));
                 s
             }
         }

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -26,8 +26,8 @@ impl LintPass for NonminimalBool {
 }
 
 impl LateLintPass for NonminimalBool {
-    fn check_crate(&mut self, cx: &LateContext, krate: &Crate) {
-        krate.visit_all_items(&mut NonminimalBoolVisitor(cx))
+    fn check_item(&mut self, cx: &LateContext, item: &Item) {
+        NonminimalBoolVisitor(cx).visit_item(item)
     }
 }
 

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -87,12 +87,11 @@ impl<'a, 'tcx, 'v> Hir2Qmm<'a, 'tcx, 'v> {
                 _ => {},
             }
         }
-        if let Some((n, _)) = self.terminals
-                                  .iter()
-                                  .enumerate()
-                                  .find(|&(_, expr)| SpanlessEq::new(self.cx).ignore_fn().eq_expr(e, expr)) {
-            #[allow(cast_possible_truncation)]
-            return Ok(Bool::Term(n as u8));
+        for (n, expr) in self.terminals.iter().enumerate() {
+            if SpanlessEq::new(self.cx).ignore_fn().eq_expr(e, expr) {
+                #[allow(cast_possible_truncation)]
+                return Ok(Bool::Term(n as u8));
+            }
         }
         let n = self.terminals.len();
         self.terminals.push(e);

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -149,29 +149,26 @@ fn suggest(cx: &LateContext, suggestion: &Bool, terminals: &[&Expr]) -> String {
                         recurse(true, cx, inner, terminals, s)
                     },
                     Term(n) => {
-                        match terminals[n as usize].node {
-                            ExprBinary(binop, ref lhs, ref rhs) => {
-                                let op = match binop.node {
-                                    BiEq => " != ",
-                                    BiNe => " == ",
-                                    BiLt => " >= ",
-                                    BiGt => " <= ",
-                                    BiLe => " > ",
-                                    BiGe => " < ",
-                                    _ => {
-                                        s.push('!');
-                                        return recurse(true, cx, inner, terminals, s)
-                                    },
-                                };
-                                s.push_str(&snip(lhs));
-                                s.push_str(op);
-                                s.push_str(&snip(rhs));
-                                s
-                            },
-                            _ => {
-                                s.push('!');
-                                recurse(false, cx, inner, terminals, s)
-                            },
+                        if let ExprBinary(binop, ref lhs, ref rhs) = terminals[n as usize].node {
+                            let op = match binop.node {
+                                BiEq => " != ",
+                                BiNe => " == ",
+                                BiLt => " >= ",
+                                BiGt => " <= ",
+                                BiLe => " > ",
+                                BiGe => " < ",
+                                _ => {
+                                    s.push('!');
+                                    return recurse(true, cx, inner, terminals, s)
+                                },
+                            };
+                            s.push_str(&snip(lhs));
+                            s.push_str(op);
+                            s.push_str(&snip(rhs));
+                            s
+                        } else {
+                            s.push('!');
+                            recurse(false, cx, inner, terminals, s)
                         }
                     },
                     _ => {

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -1,0 +1,155 @@
+use rustc::lint::*;
+use rustc_front::hir::*;
+use rustc_front::intravisit::*;
+use syntax::ast::LitKind;
+use utils::{span_lint_and_then, in_macro, snippet_opt};
+
+/// **What it does:** This lint checks for boolean expressions that can be written more concisely
+///
+/// **Why is this bad?** Readability of boolean expressions suffers from unnecesessary duplication
+///
+/// **Known problems:** None
+///
+/// **Example:** `if a && b || a` should be `if a`
+declare_lint! {
+    pub NONMINIMAL_BOOL, Warn,
+    "checks for boolean expressions that can be written more concisely"
+}
+
+#[derive(Copy,Clone)]
+pub struct NonminimalBool;
+
+impl LintPass for NonminimalBool {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(NONMINIMAL_BOOL)
+    }
+}
+
+impl LateLintPass for NonminimalBool {
+    fn check_crate(&mut self, cx: &LateContext, krate: &Crate) {
+        krate.visit_all_items(&mut NonminimalBoolVisitor(cx))
+    }
+}
+
+struct NonminimalBoolVisitor<'a, 'tcx: 'a>(&'a LateContext<'a, 'tcx>);
+
+use quine_mc_cluskey::Bool;
+struct Hir2Qmm<'tcx>(Vec<&'tcx Expr>);
+
+impl<'tcx> Hir2Qmm<'tcx> {
+    fn extract(&mut self, op: BinOp_, a: &[&'tcx Expr], mut v: Vec<Bool>) -> Result<Vec<Bool>, String> {
+        for a in a {
+            if let ExprBinary(binop, ref lhs, ref rhs) = a.node {
+                if binop.node == op {
+                    v = self.extract(op, &[lhs, rhs], v)?;
+                    continue;
+                }
+            }
+            v.push(self.run(a)?);
+        }
+        Ok(v)
+    }
+
+    fn run(&mut self, e: &'tcx Expr) -> Result<Bool, String> {
+        match e.node {
+            ExprUnary(UnNot, ref inner) => return Ok(Bool::Not(box self.run(inner)?)),
+            ExprBinary(binop, ref lhs, ref rhs) => {
+                match binop.node {
+                    BiOr => return Ok(Bool::Or(self.extract(BiOr, &[lhs, rhs], Vec::new())?)),
+                    BiAnd => return Ok(Bool::And(self.extract(BiAnd, &[lhs, rhs], Vec::new())?)),
+                    _ => {},
+                }
+            },
+            ExprLit(ref lit) => {
+                match lit.node {
+                    LitKind::Bool(true) => return Ok(Bool::True),
+                    LitKind::Bool(false) => return Ok(Bool::False),
+                    _ => {},
+                }
+            },
+            _ => {},
+        }
+        let n = self.0.len();
+        self.0.push(e);
+        if n < 32 {
+            #[allow(cast_possible_truncation)]
+            Ok(Bool::Term(n as u8))
+        } else {
+            Err("too many literals".to_owned())
+        }
+    }
+}
+
+fn suggest(cx: &LateContext, suggestion: &Bool, terminals: &[&Expr]) -> String {
+    fn recurse(cx: &LateContext, suggestion: &Bool, terminals: &[&Expr], mut s: String) -> String {
+        use quine_mc_cluskey::Bool::*;
+        match *suggestion {
+            True => {
+                s.extend("true".chars());
+                s
+            },
+            False => {
+                s.extend("false".chars());
+                s
+            },
+            Not(ref inner) => {
+                s.push('!');
+                recurse(cx, inner, terminals, s)
+            },
+            And(ref v) => {
+                s = recurse(cx, &v[0], terminals, s);
+                for inner in &v[1..] {
+                    s.extend(" && ".chars());
+                    s = recurse(cx, inner, terminals, s);
+                }
+                s
+            },
+            Or(ref v) => {
+                s = recurse(cx, &v[0], terminals, s);
+                for inner in &v[1..] {
+                    s.extend(" || ".chars());
+                    s = recurse(cx, inner, terminals, s);
+                }
+                s
+            },
+            Term(n) => {
+                s.extend(snippet_opt(cx, terminals[n as usize].span).expect("don't try to improve booleans created by macros").chars());
+                s
+            }
+        }
+    }
+    recurse(cx, suggestion, terminals, String::new())
+}
+
+impl<'a, 'tcx> NonminimalBoolVisitor<'a, 'tcx> {
+    fn bool_expr(&self, e: &Expr) {
+        let mut h2q = Hir2Qmm(Vec::new());
+        if let Ok(expr) = h2q.run(e) {
+            let simplified = expr.simplify();
+            if !simplified.iter().any(|s| *s == expr) {
+                span_lint_and_then(self.0, NONMINIMAL_BOOL, e.span, "this boolean expression can be simplified", |db| {
+                    for suggestion in &simplified {
+                        db.span_suggestion(e.span, "try", suggest(self.0, suggestion, &h2q.0));
+                    }
+                });
+            }
+        }
+    }
+}
+
+impl<'a, 'v, 'tcx> Visitor<'v> for NonminimalBoolVisitor<'a, 'tcx> {
+    fn visit_expr(&mut self, e: &'v Expr) {
+        if in_macro(self.0, e.span) { return }
+        match e.node {
+            ExprBinary(binop, _, _) if binop.node == BiOr || binop.node == BiAnd => self.bool_expr(e),
+            ExprUnary(UnNot, ref inner) => {
+                if self.0.tcx.node_types()[&inner.id].is_bool() {
+                    self.bool_expr(e);
+                } else {
+                    walk_expr(self, e);
+                }
+            },
+            _ => walk_expr(self, e),
+        }
+    }
+}

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -207,6 +207,10 @@ impl<'a, 'tcx> NonminimalBoolVisitor<'a, 'tcx> {
             let stats = terminal_stats(&expr);
             let mut simplified = expr.simplify();
             for simple in Bool::Not(Box::new(expr.clone())).simplify() {
+                match simple {
+                    Bool::Not(_) | Bool::True | Bool::False => {},
+                    _ => simplified.push(Bool::Not(Box::new(simple.clone()))),
+                }
                 let simple_negated = simple_negate(simple);
                 if simplified.iter().any(|s| *s == simple_negated) {
                     continue;

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -9,11 +9,11 @@ use utils::{span_lint_and_then, in_macro, snippet_opt, SpanlessEq};
 ///
 /// **Why is this bad?** Readability of boolean expressions suffers from unnecesessary duplication
 ///
-/// **Known problems:** Ignores short circuting behavior, bitwise and/or and xor. Ends up suggesting things like !(a == b)
+/// **Known problems:** Ignores short circuting behavior of `||` and `&&`. Ignores `|`, `&` and `^`.
 ///
-/// **Example:** `if a && true` should be `if a`
+/// **Example:** `if a && true` should be `if a` and `!(a == b)` should be `a != b`
 declare_lint! {
-    pub NONMINIMAL_BOOL, Warn,
+    pub NONMINIMAL_BOOL, Allow,
     "checks for boolean expressions that can be written more concisely"
 }
 

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -2,17 +2,17 @@ use rustc::lint::*;
 use rustc_front::hir::*;
 use rustc_front::intravisit::*;
 use syntax::ast::LitKind;
-use utils::{span_lint_and_then, in_macro, snippet_opt};
+use utils::{span_lint_and_then, in_macro, snippet_opt, SpanlessEq};
 
 /// **What it does:** This lint checks for boolean expressions that can be written more concisely
 ///
 /// **Why is this bad?** Readability of boolean expressions suffers from unnecesessary duplication
 ///
-/// **Known problems:** None
+/// **Known problems:** Ignores short circuting behavior, bitwise and/or and xor. Ends up suggesting things like !(a == b)
 ///
 /// **Example:** `if a && b || a` should be `if a`
 declare_lint! {
-    pub NONMINIMAL_BOOL, Warn,
+    pub NONMINIMAL_BOOL, Allow,
     "checks for boolean expressions that can be written more concisely"
 }
 

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -227,10 +227,8 @@ impl<'a, 'tcx> NonminimalBoolVisitor<'a, 'tcx> {
                         if stats[i] < simplified_stats[i] {
                             continue 'simplified;
                         }
-                        // if the number of occurrences of a terminal decreases, this expression is a candidate for improvement
-                        if stats[i] >= simplified_stats[i] {
-                            improvement = true;
-                        }
+                        // if the number of occurrences of a terminal doesn't increase, this expression is a candidate for improvement
+                        improvement = true;
                         if stats[i] != 0 && simplified_stats[i] == 0 {
                             span_lint_and_then(self.0, LOGIC_BUG, e.span, "this boolean expression contains a logic bug", |db| {
                                 db.span_help(h2q.terminals[i].span, "this expression can be optimized out by applying boolean operations to the outer expression");

--- a/src/booleans.rs
+++ b/src/booleans.rs
@@ -12,7 +12,7 @@ use utils::{span_lint_and_then, in_macro, snippet_opt, SpanlessEq};
 ///
 /// **Example:** `if a && true` should be `if a`
 declare_lint! {
-    pub NONMINIMAL_BOOL, Allow,
+    pub NONMINIMAL_BOOL, Warn,
     "checks for boolean expressions that can be written more concisely"
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 #![feature(iter_arith)]
 #![feature(custom_attribute)]
 #![feature(slice_patterns)]
+#![feature(question_mark)]
+#![feature(stmt_expr_attributes)]
 #![allow(indexing_slicing, shadow_reuse, unknown_lints)]
 
 // this only exists to allow the "dogfood" integration test to work
@@ -35,6 +37,9 @@ extern crate semver;
 // for regex checking
 extern crate regex_syntax;
 
+// for finding minimal boolean expressions
+extern crate quine_mc_cluskey;
+
 extern crate rustc_plugin;
 extern crate rustc_const_eval;
 use rustc_plugin::Registry;
@@ -50,6 +55,7 @@ pub mod attrs;
 pub mod bit_mask;
 pub mod blacklisted_name;
 pub mod block_in_if_condition;
+pub mod booleans;
 pub mod collapsible_if;
 pub mod copies;
 pub mod cyclomatic_complexity;
@@ -149,6 +155,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     // end deprecated lints, do not remove this comment, it’s used in `update_lints`
 
     reg.register_late_lint_pass(box types::TypePass);
+    reg.register_late_lint_pass(box booleans::NonminimalBool);
     reg.register_late_lint_pass(box misc::TopLevelRefPass);
     reg.register_late_lint_pass(box misc::CmpNan);
     reg.register_late_lint_pass(box eq_op::EqOp);
@@ -260,6 +267,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         blacklisted_name::BLACKLISTED_NAME,
         block_in_if_condition::BLOCK_IN_IF_CONDITION_EXPR,
         block_in_if_condition::BLOCK_IN_IF_CONDITION_STMT,
+        booleans::NONMINIMAL_BOOL,
         collapsible_if::COLLAPSIBLE_IF,
         copies::IF_SAME_THEN_ELSE,
         copies::IFS_SAME_COND,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
 
     reg.register_lint_group("clippy_pedantic", vec![
         array_indexing::INDEXING_SLICING,
+        booleans::NONMINIMAL_BOOL,
         enum_glob_use::ENUM_GLOB_USE,
         matches::SINGLE_MATCH_ELSE,
         methods::OPTION_UNWRAP_USED,
@@ -268,7 +269,6 @@ pub fn plugin_registrar(reg: &mut Registry) {
         block_in_if_condition::BLOCK_IN_IF_CONDITION_EXPR,
         block_in_if_condition::BLOCK_IN_IF_CONDITION_STMT,
         booleans::LOGIC_BUG,
-        booleans::NONMINIMAL_BOOL,
         collapsible_if::COLLAPSIBLE_IF,
         copies::IF_SAME_THEN_ELSE,
         copies::IFS_SAME_COND,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         blacklisted_name::BLACKLISTED_NAME,
         block_in_if_condition::BLOCK_IN_IF_CONDITION_EXPR,
         block_in_if_condition::BLOCK_IN_IF_CONDITION_STMT,
+        booleans::LOGIC_BUG,
         booleans::NONMINIMAL_BOOL,
         collapsible_if::COLLAPSIBLE_IF,
         copies::IF_SAME_THEN_ELSE,

--- a/src/non_expressive_names.rs
+++ b/src/non_expressive_names.rs
@@ -262,7 +262,7 @@ fn levenstein_not_1(a_name: &str, b_name: &str) -> bool {
         }
         if let Some(b2) = b_chars.next() {
             // check if there's just one character inserted
-            return !(a == b2 && a_chars.eq(b_chars));
+            return a != b2 || a_chars.ne(b_chars);
         } else {
             // tuple
             // ntuple

--- a/tests/compile-fail/block_in_if_condition.rs
+++ b/tests/compile-fail/block_in_if_condition.rs
@@ -67,7 +67,7 @@ fn pred_test() {
 
 fn condition_is_normal() -> i32 {
     let x = 3;
-    if true && x == 3 {
+    if true && x == 3 { //~ WARN this boolean expression can be simplified
         6
     } else {
         10

--- a/tests/compile-fail/block_in_if_condition.rs
+++ b/tests/compile-fail/block_in_if_condition.rs
@@ -4,6 +4,7 @@
 #![deny(block_in_if_condition_expr)]
 #![deny(block_in_if_condition_stmt)]
 #![allow(unused, let_and_return)]
+#![warn(nonminimal_bool)]
 
 
 macro_rules! blocky {

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -77,5 +77,8 @@ fn equality_stuff() {
     //|~ SUGGESTION let _ = false;
     let _ = a > b && a == b;
 
-    let _ = a != b || !(a != b || c == d);
+    let _ = a != b || !(a != b || c == d); //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = !c == d || a != b;
+    //|~ SUGGESTION let _ = !(!a != b && c == d);
 }

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -29,4 +29,7 @@ fn main() {
     let _ = false || a; //~ ERROR this boolean expression can be simplified
     //|~ HELP for further information visit
     //|~ SUGGESTION let _ = a;
+
+    // don't lint on cfgs
+    let _ = cfg!(you_shall_not_not_pass) && a;
 }

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -76,4 +76,6 @@ fn equality_stuff() {
     //|~ HELP it would look like the following
     //|~ SUGGESTION let _ = false;
     let _ = a > b && a == b;
+
+    let _ = a != b || !(a != b || c == d);
 }

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -1,13 +1,15 @@
 #![feature(plugin)]
 #![plugin(clippy)]
-#![deny(nonminimal_bool)]
+#![deny(nonminimal_bool, logic_bug)]
 
 #[allow(unused)]
 fn main() {
     let a: bool = unimplemented!();
     let b: bool = unimplemented!();
-    let _ = a && b || a; //~ ERROR this boolean expression can be simplified
+    let _ = a && b || a; //~ ERROR this boolean expression contains a logic bug
     //|~ HELP for further information visit
+    //|~ HELP this expression can be optimized out
+    //|~ HELP it would look like the following
     //|~ SUGGESTION let _ = a;
     let _ = !(a && b); //~ ERROR this boolean expression can be simplified
     //|~ HELP for further information visit
@@ -22,8 +24,10 @@ fn main() {
     //|~ HELP for further information visit
     //|~ SUGGESTION let _ = a;
 
-    let _ = false && a; //~ ERROR this boolean expression can be simplified
+    let _ = false && a; //~ ERROR this boolean expression contains a logic bug
     //|~ HELP for further information visit
+    //|~ HELP this expression can be optimized out
+    //|~ HELP it would look like the following
     //|~ SUGGESTION let _ = false;
 
     let _ = false || a; //~ ERROR this boolean expression can be simplified

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -2,11 +2,13 @@
 #![plugin(clippy)]
 #![deny(nonminimal_bool, logic_bug)]
 
-#[allow(unused)]
+#[allow(unused, many_single_char_names)]
 fn main() {
     let a: bool = unimplemented!();
     let b: bool = unimplemented!();
     let c: bool = unimplemented!();
+    let d: bool = unimplemented!();
+    let e: bool = unimplemented!();
     let _ = a && b || a; //~ ERROR this boolean expression contains a logic bug
     //|~ HELP for further information visit
     //|~ HELP this expression can be optimized out
@@ -36,5 +38,11 @@ fn main() {
     // don't lint on cfgs
     let _ = cfg!(you_shall_not_not_pass) && a;
 
+    let _ = a || !b || !c || !d || !e;
+
     let _ = !(a && b || c);
+
+    let _ = !(!a && b); //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = !b || a;
 }

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -58,6 +58,9 @@ fn equality_stuff() {
     let _ = a == b && c == 5 && a == b; //~ ERROR this boolean expression can be simplified
     //|~ HELP for further information visit
     //|~ SUGGESTION let _ = c == 5 && a == b;
+    let _ = a == b && c == 5 && b == a; //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = c == 5 && a == b;
     let _ = a < b && a >= b;
     let _ = a > b && a <= b;
     let _ = a > b && a == b;

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -66,7 +66,7 @@ fn equality_stuff() {
     //~| HELP for further information visit
     //~| SUGGESTION let _ = a == b && c == 5;
     //~| HELP try
-    //~| SUGGESTION let _ = !(!(c == 5) || !(a == b));
+    //~| SUGGESTION let _ = !(c != 5 || a != b);
     let _ = a < b && a >= b; //~ ERROR this boolean expression contains a logic bug
     //~| HELP for further information visit
     //~| HELP this expression can be optimized out
@@ -81,7 +81,7 @@ fn equality_stuff() {
 
     let _ = a != b || !(a != b || c == d); //~ ERROR this boolean expression can be simplified
     //~| HELP for further information visit
-    //~| SUGGESTION let _ = !(c == d) || a != b;
+    //~| SUGGESTION let _ = c != d || a != b;
     //~| HELP try
-    //~| SUGGESTION let _ = !(!(a != b) && c == d);
+    //~| SUGGESTION let _ = !(a == b && c == d);
 }

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -10,30 +10,30 @@ fn main() {
     let d: bool = unimplemented!();
     let e: bool = unimplemented!();
     let _ = a && b || a; //~ ERROR this boolean expression contains a logic bug
-    //|~ HELP for further information visit
-    //|~ HELP this expression can be optimized out
-    //|~ HELP it would look like the following
-    //|~ SUGGESTION let _ = a;
+    //~| HELP for further information visit
+    //~| HELP this expression can be optimized out
+    //~| HELP it would look like the following
+    //~| SUGGESTION let _ = a;
     let _ = !(a && b);
     let _ = !true; //~ ERROR this boolean expression can be simplified
-    //|~ HELP for further information visit
-    //|~ SUGGESTION let _ = false;
+    //~| HELP for further information visit
+    //~| SUGGESTION let _ = false;
     let _ = !false; //~ ERROR this boolean expression can be simplified
-    //|~ HELP for further information visit
-    //|~ SUGGESTION let _ = true;
+    //~| HELP for further information visit
+    //~| SUGGESTION let _ = true;
     let _ = !!a; //~ ERROR this boolean expression can be simplified
-    //|~ HELP for further information visit
-    //|~ SUGGESTION let _ = a;
+    //~| HELP for further information visit
+    //~| SUGGESTION let _ = a;
 
     let _ = false && a; //~ ERROR this boolean expression contains a logic bug
-    //|~ HELP for further information visit
-    //|~ HELP this expression can be optimized out
-    //|~ HELP it would look like the following
-    //|~ SUGGESTION let _ = false;
+    //~| HELP for further information visit
+    //~| HELP this expression can be optimized out
+    //~| HELP it would look like the following
+    //~| SUGGESTION let _ = false;
 
     let _ = false || a; //~ ERROR this boolean expression can be simplified
-    //|~ HELP for further information visit
-    //|~ SUGGESTION let _ = a;
+    //~| HELP for further information visit
+    //~| SUGGESTION let _ = a;
 
     // don't lint on cfgs
     let _ = cfg!(you_shall_not_not_pass) && a;
@@ -43,8 +43,8 @@ fn main() {
     let _ = !(a && b || c);
 
     let _ = !(!a && b); //~ ERROR this boolean expression can be simplified
-    //|~ HELP for further information visit
-    //|~ SUGGESTION let _ = !b || a;
+    //~| HELP for further information visit
+    //~| SUGGESTION let _ = !b || a;
 }
 
 #[allow(unused, many_single_char_names)]
@@ -55,30 +55,33 @@ fn equality_stuff() {
     let d: i32 = unimplemented!();
     let e: i32 = unimplemented!();
     let _ = a == b && a != b; //~ ERROR this boolean expression contains a logic bug
-    //|~ HELP for further information visit
-    //|~ HELP this expression can be optimized out
-    //|~ HELP it would look like the following
-    //|~ SUGGESTION let _ = false;
+    //~| HELP for further information visit
+    //~| HELP this expression can be optimized out
+    //~| HELP it would look like the following
+    //~| SUGGESTION let _ = false;
     let _ = a == b && c == 5 && a == b; //~ ERROR this boolean expression can be simplified
-    //|~ HELP for further information visit
-    //|~ SUGGESTION let _ = c == 5 && a == b;
+    //~| HELP for further information visit
+    //~| SUGGESTION let _ = a == b && c == 5;
     let _ = a == b && c == 5 && b == a; //~ ERROR this boolean expression can be simplified
-    //|~ HELP for further information visit
-    //|~ SUGGESTION let _ = c == 5 && a == b;
+    //~| HELP for further information visit
+    //~| SUGGESTION let _ = a == b && c == 5;
+    //~| HELP try
+    //~| SUGGESTION let _ = !(!(c == 5) || !(a == b));
     let _ = a < b && a >= b; //~ ERROR this boolean expression contains a logic bug
-    //|~ HELP for further information visit
-    //|~ HELP this expression can be optimized out
-    //|~ HELP it would look like the following
-    //|~ SUGGESTION let _ = false;
+    //~| HELP for further information visit
+    //~| HELP this expression can be optimized out
+    //~| HELP it would look like the following
+    //~| SUGGESTION let _ = false;
     let _ = a > b && a <= b; //~ ERROR this boolean expression contains a logic bug
-    //|~ HELP for further information visit
-    //|~ HELP this expression can be optimized out
-    //|~ HELP it would look like the following
-    //|~ SUGGESTION let _ = false;
+    //~| HELP for further information visit
+    //~| HELP this expression can be optimized out
+    //~| HELP it would look like the following
+    //~| SUGGESTION let _ = false;
     let _ = a > b && a == b;
 
     let _ = a != b || !(a != b || c == d); //~ ERROR this boolean expression can be simplified
-    //|~ HELP for further information visit
-    //|~ SUGGESTION let _ = !c == d || a != b;
-    //|~ SUGGESTION let _ = !(!a != b && c == d);
+    //~| HELP for further information visit
+    //~| SUGGESTION let _ = !(c == d) || a != b;
+    //~| HELP try
+    //~| SUGGESTION let _ = !(!(a != b) && c == d);
 }

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -54,14 +54,26 @@ fn equality_stuff() {
     let c: i32 = unimplemented!();
     let d: i32 = unimplemented!();
     let e: i32 = unimplemented!();
-    let _ = a == b && a != b;
+    let _ = a == b && a != b; //~ ERROR this boolean expression contains a logic bug
+    //|~ HELP for further information visit
+    //|~ HELP this expression can be optimized out
+    //|~ HELP it would look like the following
+    //|~ SUGGESTION let _ = false;
     let _ = a == b && c == 5 && a == b; //~ ERROR this boolean expression can be simplified
     //|~ HELP for further information visit
     //|~ SUGGESTION let _ = c == 5 && a == b;
     let _ = a == b && c == 5 && b == a; //~ ERROR this boolean expression can be simplified
     //|~ HELP for further information visit
     //|~ SUGGESTION let _ = c == 5 && a == b;
-    let _ = a < b && a >= b;
-    let _ = a > b && a <= b;
+    let _ = a < b && a >= b; //~ ERROR this boolean expression contains a logic bug
+    //|~ HELP for further information visit
+    //|~ HELP this expression can be optimized out
+    //|~ HELP it would look like the following
+    //|~ SUGGESTION let _ = false;
+    let _ = a > b && a <= b; //~ ERROR this boolean expression contains a logic bug
+    //|~ HELP for further information visit
+    //|~ HELP this expression can be optimized out
+    //|~ HELP it would look like the following
+    //|~ SUGGESTION let _ = false;
     let _ = a > b && a == b;
 }

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -6,14 +6,13 @@
 fn main() {
     let a: bool = unimplemented!();
     let b: bool = unimplemented!();
+    let c: bool = unimplemented!();
     let _ = a && b || a; //~ ERROR this boolean expression contains a logic bug
     //|~ HELP for further information visit
     //|~ HELP this expression can be optimized out
     //|~ HELP it would look like the following
     //|~ SUGGESTION let _ = a;
-    let _ = !(a && b); //~ ERROR this boolean expression can be simplified
-    //|~ HELP for further information visit
-    //|~ SUGGESTION let _ = !b || !a;
+    let _ = !(a && b);
     let _ = !true; //~ ERROR this boolean expression can be simplified
     //|~ HELP for further information visit
     //|~ SUGGESTION let _ = false;
@@ -36,4 +35,6 @@ fn main() {
 
     // don't lint on cfgs
     let _ = cfg!(you_shall_not_not_pass) && a;
+
+    let _ = !(a && b || c);
 }

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -46,3 +46,19 @@ fn main() {
     //|~ HELP for further information visit
     //|~ SUGGESTION let _ = !b || a;
 }
+
+#[allow(unused, many_single_char_names)]
+fn equality_stuff() {
+    let a: i32 = unimplemented!();
+    let b: i32 = unimplemented!();
+    let c: i32 = unimplemented!();
+    let d: i32 = unimplemented!();
+    let e: i32 = unimplemented!();
+    let _ = a == b && a != b;
+    let _ = a == b && c == 5 && a == b; //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = c == 5 && a == b;
+    let _ = a < b && a >= b;
+    let _ = a > b && a <= b;
+    let _ = a > b && a == b;
+}

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -1,0 +1,24 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+#![deny(nonminimal_bool)]
+
+#[allow(unused)]
+fn main() {
+    let a: bool = unimplemented!();
+    let b: bool = unimplemented!();
+    let _ = a && b || a; //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = a;
+    let _ = !(a && b); //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = !b || !a;
+    let _ = !true; //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = false;
+    let _ = !false; //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = true;
+    let _ = !!a; //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = a;
+}

--- a/tests/compile-fail/booleans.rs
+++ b/tests/compile-fail/booleans.rs
@@ -21,4 +21,12 @@ fn main() {
     let _ = !!a; //~ ERROR this boolean expression can be simplified
     //|~ HELP for further information visit
     //|~ SUGGESTION let _ = a;
+
+    let _ = false && a; //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = false;
+
+    let _ = false || a; //~ ERROR this boolean expression can be simplified
+    //|~ HELP for further information visit
+    //|~ SUGGESTION let _ = a;
 }

--- a/tests/compile-fail/eq_op.rs
+++ b/tests/compile-fail/eq_op.rs
@@ -38,7 +38,9 @@ fn main() {
     1 - 1; //~ERROR equal expressions
     1 / 1; //~ERROR equal expressions
     true && true; //~ERROR equal expressions
+    //~|WARN this boolean expression can be simplified
     true || true; //~ERROR equal expressions
+    //~|WARN this boolean expression can be simplified
 
     let mut a = vec![1];
     a == a; //~ERROR equal expressions

--- a/tests/compile-fail/eq_op.rs
+++ b/tests/compile-fail/eq_op.rs
@@ -4,6 +4,7 @@
 #[deny(eq_op)]
 #[allow(identity_op)]
 #[allow(no_effect)]
+#[deny(nonminimal_bool)]
 fn main() {
     // simple values and comparisons
     1 == 1; //~ERROR equal expressions
@@ -38,9 +39,9 @@ fn main() {
     1 - 1; //~ERROR equal expressions
     1 / 1; //~ERROR equal expressions
     true && true; //~ERROR equal expressions
-    //~|WARN this boolean expression can be simplified
+    //~|ERROR this boolean expression can be simplified
     true || true; //~ERROR equal expressions
-    //~|WARN this boolean expression can be simplified
+    //~|ERROR this boolean expression can be simplified
 
     let mut a = vec![1];
     a == a; //~ERROR equal expressions

--- a/tests/compile-fail/eq_op.rs
+++ b/tests/compile-fail/eq_op.rs
@@ -3,7 +3,7 @@
 
 #[deny(eq_op)]
 #[allow(identity_op)]
-#[allow(no_effect)]
+#[allow(no_effect, unused_variables)]
 #[deny(nonminimal_bool)]
 fn main() {
     // simple values and comparisons
@@ -41,6 +41,18 @@ fn main() {
     true && true; //~ERROR equal expressions
     //~|ERROR this boolean expression can be simplified
     true || true; //~ERROR equal expressions
+    //~|ERROR this boolean expression can be simplified
+
+    let a: u32 = unimplemented!();
+    let b: u32 = unimplemented!();
+
+    a == b && b == a; //~ERROR equal expressions
+    //~|ERROR this boolean expression can be simplified
+    a != b && b != a; //~ERROR equal expressions
+    //~|ERROR this boolean expression can be simplified
+    a < b && b > a; //~ERROR equal expressions
+    //~|ERROR this boolean expression can be simplified
+    a <= b && b >= a; //~ERROR equal expressions
     //~|ERROR this boolean expression can be simplified
 
     let mut a = vec![1];


### PR DESCRIPTION
TLDR: `a || (a && b)` => `a`, `!!a` => `a`, `(a == b) && !(a == b)` => `false`, but still some quirks, feedback requested

cc #590 

----

So... I implemented the [Quine–McCluskey algorithm](https://en.wikipedia.org/wiki/Quine%E2%80%93McCluskey_algorithm) and [Petrick's Method](https://en.wikipedia.org/wiki/Petrick's_method) which together allow an algorithmic minimization of arbitrary boolean expressions (with fewer than 32 terminals). The full algorithm runs twice. Once for getting the smallest "sum of products" (`a && b && c || d && e || f`) and once for getting the smallest "product of sums" (`(a || b || c) && (d || e) && f`). Then I check the list of smallest representations against the actual boolean expression. If the actual expression is the same (or some permutation of) one of the best ones, then I continue. Otherwise I dump all the better expressions as suggestions.

This is not perfect yet. The algorithms assume mathematical boolean expressions. So they don't know about short circuiting, `xor` or comparison operations. Also every boolean expression with more than 2 levels gets flattened to 2 levels. I plan on tackling those issues in future improvements. I made the lint allow-by-default because of this.

Open Questions:

* [x] Should I detect `a == b` and `a != b` in the same boolean expression and use them (during optimization) as `a == b` and `!(a == b)`. This has some advantages (see below)
* [x] Should I turn `!(a == b)` in the optimized expression into `a != b` or should this be a separate lint?
* [ ] ~~Should stdlib comparison functions with inverses be treated like the builtin comparisons functions for the two previos points?~~ Uncommon
* [ ] ~~Should I keep ignoring short circuiting behavior? Are there any situations where an optimized form of an expression would break?~~ allow by default, except for logic bugs
* [ ] ~~changing `(!a && b) || (a && !b)` to `a ^ b` is fine? there's no short circuiting possible anyway, separate lint?~~ Uncommon
* [ ] ~~unwrapping `a ^ b` to the expanded form for optimization might yield better results in a larger expression, should this be done?~~ Uncommon
* [ ] Should I treat bitwise `and` and bitwise `or` 100% equal to the regular boolean ops? This basically assumes that anyone using the non-fast-forwarding versions doesn't know what they are doing.

some benchmarking on cargo with clippy compiled in release mode says it has (nearly?) no impact:

with `nonminimal_bool`: 
> time: 0.951; rss: 275MB	lint checking

just clippy: 
> time: 0.936; rss: 274MB	lint checking
time: 0.929; rss: 275MB	lint checking
time: 0.950; rss: 274MB	lint checking

no clippy:
> time: 0.255; rss: 271MB	lint checking

How annoying is this lint?

cargo:

```
src/cargo/core/dependency.rs:207         self.name == id.name() &&
src/cargo/core/dependency.rs:208             (self.only_match_name || (self.req.matches(id.version()) &&
src/cargo/core/dependency.rs:209                                       &self.source_id == id.source_id()))
```

suggested to change to 

```
(self.name == id.name() && self.req.matches(id.version()) && &self.source_id == id.source_id()) || (self.name == id.name() && self.only_match_name)
```

or

```
(self.only_match_name || &self.source_id == id.source_id()) && (self.only_match_name || self.req.matches(id.version())) && self.name == id.name()
```

The previous expression was fine imo, but had 3 levels of and/or operations

One bug, must be in `SpanlessEq::expr_eq`:

```
src/cargo/util/config.rs:205             let is_path = val.val.contains("/") ||
src/cargo/util/config.rs:206                           (cfg!(windows) && val.val.contains("\\"));
src/cargo/util/config.rs:205:27: 206:68 help: try
src/cargo/util/config.rs:                let is_path = val.val.contains("/");
```

on racer:
```
src/racer/matchers.rs:417     if (blob.starts_with("pub enum") || (local && blob.starts_with("enum"))) &&
src/racer/matchers.rs:418        txt_matches(search_type, searchstr, blob) {
```

suggests

```
if (local && blob.starts_with("enum") && txt_matches(search_type, searchstr, blob)) || (blob.starts_with("pub enum") && txt_matches(search_type, searchstr, blob)) {
```

and

```
if (blob.starts_with("pub enum") || blob.starts_with("enum")) && (blob.starts_with("pub enum") || local) && txt_matches(search_type, searchstr, blob) {
```