### PR TITLE
Match attributes in FnKind patterns

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -39,7 +39,7 @@ impl LintPass for TopLevelRefPass {
 
 impl LateLintPass for TopLevelRefPass {
     fn check_fn(&mut self, cx: &LateContext, k: FnKind, decl: &FnDecl, _: &Block, _: Span, _: NodeId) {
-        if let FnKind::Closure = k {
+        if let FnKind::Closure(_) = k {
             // Does not apply to closures
             return;
         }

--- a/src/new_without_default.rs
+++ b/src/new_without_default.rs
@@ -46,7 +46,7 @@ impl LateLintPass for NewWithoutDefault {
             return;
         }
 
-        if let FnKind::Method(name, _, _) = kind {
+        if let FnKind::Method(name, _, _, _) = kind {
             if decl.inputs.is_empty() && name.as_str() == "new" {
                 let self_ty = cx.tcx.lookup_item_type(cx.tcx.map.local_def_id(cx.tcx.map.get_parent(id))).ty;
 


### PR DESCRIPTION
Fixes breakage with latest nightly compiler by changing the `FnKind` patterns to also match against the newly added attributes field. See https://github.com/rust-lang/rust/pull/32156.