### PR TITLE
Fix false positive in `MATCH_SAME_ARMS` and guards

### DIFF
--- a/src/copies.rs
+++ b/src/copies.rs
@@ -132,13 +132,15 @@ fn lint_match_arms(cx: &LateContext, expr: &Expr) {
     };
 
     let eq = |lhs: &Arm, rhs: &Arm| -> bool {
-        SpanlessEq::new(cx).eq_expr(&lhs.body, &rhs.body) &&
+        // Arms with a guard are ignored, those can’t always be merged together
+        lhs.guard.is_none() && rhs.guard.is_none() &&
+            SpanlessEq::new(cx).eq_expr(&lhs.body, &rhs.body) &&
             // all patterns should have the same bindings
             bindings(cx, &lhs.pats[0]) == bindings(cx, &rhs.pats[0])
     };
 
     if let ExprMatch(_, ref arms, MatchSource::Normal) = expr.node {
-        if let Some((i, j)) = search_same(&**arms, hash, eq) {
+        if let Some((i, j)) = search_same(&arms, hash, eq) {
             span_note_and_lint(cx,
                                MATCH_SAME_ARMS,
                                j.body.span,

--- a/tests/compile-fail/copies.rs
+++ b/tests/compile-fail/copies.rs
@@ -143,8 +143,19 @@ fn if_same_then_else() -> Result<&'static str, ()> {
     };
 
     let _ = match Some(42) {
+        Some(_) => 24,
+        None => 24,
+    };
+
+    let _ = match Some(42) {
         Some(42) => 24,
         Some(a) => 24, // bindings are different
+        None => 0,
+    };
+
+    let _ = match Some(42) {
+        Some(a) if a > 0 => 24,
+        Some(a) => 24, // one arm has a guard
         None => 0,
     };
 


### PR DESCRIPTION
Found it the crate of the week *gfx*. The new behavior just doesn’t consider arms with a guard any more since I don’t think you can always merge those together.
The example on *gfx* was:
```rust
match *self {
    Source { glsl_430: s, .. } if s != EMPTY && v >= 430 => s,
    Source { glsl_150: s, .. } if s != EMPTY && v >= 150 => s, // linted: hey that’s the same as the above
    …
    _ => return Err(())
}
```
