### PR TITLE
Add Post-Success script to build clippy-service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,25 @@ script:
 
  # only test regex_macros if it compiles
  - if [[ "$(cargo build --features 'debugging test-regex_macros')" = 101 ]]; then cargo test --features 'debugging test-regex_macros'; fi
+
+# trigger rebuild of the clippy-service
+after_success:
+- |
+    #!/bin/bash
+    set -e
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ] &&
+       [ "$TRAVIS_REPO_SLUG" == "Manishearth/rust-clippy" ] &&
+       [ "$TRAVIS_BRANCH" == "master" ] &&
+       [ "$TRAVIS_TOKEN_CLIPPY_SERVICE" != "" ] ; then
+
+       curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -H "Travis-API-Version: 3" \
+            -H "Authorization: token $TRAVIS_TOKEN_CLIPPY_SERVICE" \
+            -d "{ \"request\": { \"branch\":\"master\" }}" \
+            https://api.travis-ci.org/repo/ligthyear%2Fclippy-service/requests
+
+    else
+      echo "Ignored"
+    fi


### PR DESCRIPTION
This adds a short script to trigger a rebuild of the [clippy-service](https://clippy.bashy.io) when travis successfully build master.

It uses the travis API to trigger a build using my personal access token (which I therefore will not disclose here), which is stored in the `$TRAVIS_TOKEN_CLIPPY_SERVICE` environment variable. Before applying this change, don't forget to add it to the repository configuration.

This follows our discussion at [the clippy service](https://github.com/ligthyear/clippy-service/issues/28).