### PR TITLE
fix #820

### DIFF
--- a/src/methods.rs
+++ b/src/methods.rs
@@ -302,7 +302,8 @@ impl LintPass for MethodsPass {
                     CLONE_ON_COPY,
                     CLONE_DOUBLE_REF,
                     NEW_RET_NO_SELF,
-                    SINGLE_CHAR_PATTERN)
+                    SINGLE_CHAR_PATTERN,
+                    SEARCH_IS_SOME)
     }
 }
 


### PR DESCRIPTION
The lint was just missing in the `lint_array` of its lint-pass.

This fixes #820 