### PR TITLE
Rustup to *rustc 1.10.0-nightly (62e2b2fb7 2016-05-06)*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.65 — 2016-05-08
+* Rustup to *rustc 1.10.0-nightly (62e2b2fb7 2016-05-06)*
+* New lints: [`float_arithmetic`], [`integer_arithmetic`]
+
 ## 0.0.64 — 2016-04-26
 * Rustup to *rustc 1.10.0-nightly (645dd013a 2016-04-24)*
 * New lints: [`temporary_cstring_as_ptr`], [`unsafe_removed_from_name`], and [`mem_forget`]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.64"
+version = "0.0.65"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",

--- a/src/len_zero.rs
+++ b/src/len_zero.rs
@@ -113,14 +113,9 @@ fn check_impl_items(cx: &LateContext, item: &Item, impl_items: &[ImplItem]) {
             if is_named_self(i, "len") {
                 let ty = cx.tcx.node_id_to_type(item.id);
 
-                let s = i.span;
                 span_lint(cx,
                           LEN_WITHOUT_IS_EMPTY,
-                          Span {
-                              lo: s.lo,
-                              hi: s.lo,
-                              expn_id: s.expn_id,
-                          },
+                          i.span,
                           &format!("item `{}` has a `.len(_: &Self)` method, but no `.is_empty(_: &Self)` method. \
                                     Consider adding one",
                                    ty));

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -602,7 +602,7 @@ fn lint_cstring_as_ptr(cx: &LateContext, expr: &Expr, new: &Expr, unwrap: &Expr)
         span_lint_and_then(cx, TEMPORARY_CSTRING_AS_PTR, expr.span,
                            "you are getting the inner pointer of a temporary `CString`",
                            |db| {
-                               db.fileline_note(expr.span, "that pointer will be invalid outside this expression");
+                               db.note("that pointer will be invalid outside this expression");
                                db.span_help(unwrap.span, "assign the `CString` to a variable to extend its lifetime");
                            });
     }}

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -143,14 +143,17 @@ impl LateLintPass for RegexPass {
 
 #[allow(cast_possible_truncation)]
 fn str_span(base: Span, s: &str, c: usize) -> Span {
-    let lo = match s.char_indices().nth(c) {
-        Some((b, _)) => base.lo + BytePos(b as u32),
-        _ => base.hi,
-    };
-    Span {
-        lo: lo,
-        hi: lo,
-        ..base
+    let mut si = s.char_indices().skip(c);
+
+    match (si.next(), si.next())  {
+        (Some((l, _)), Some((h, _))) => {
+            Span {
+                lo: base.lo + BytePos(l as u32),
+                hi: base.lo + BytePos(h as u32),
+                ..base
+            }
+        }
+        _ => base,
     }
 }
 

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -95,7 +95,7 @@ fn check_manual_swap(cx: &LateContext, block: &Block) {
                                    if !what.is_empty() {
                                        db.span_suggestion(span, "try",
                                                           format!("std::mem::swap(&mut {}, &mut {})", lhs, rhs));
-                                       db.fileline_note(span, "or maybe you should use `std::mem::replace`?");
+                                       db.note("or maybe you should use `std::mem::replace`?");
                                    }
                                });
         }}
@@ -130,7 +130,7 @@ fn check_suspicious_swap(cx: &LateContext, block: &Block) {
                                    if !what.is_empty() {
                                        db.span_suggestion(span, "try",
                                                           format!("std::mem::swap(&mut {}, &mut {})", lhs, rhs));
-                                       db.fileline_note(span, "or maybe you should use `std::mem::replace`?");
+                                       db.note("or maybe you should use `std::mem::replace`?");
                                    }
                                });
         }}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -471,44 +471,44 @@ impl<'a> Deref for DiagnosticWrapper<'a> {
     }
 }
 
-pub fn span_lint<'a, T: LintContext>(cx: &'a T, lint: &'static Lint, sp: Span, msg: &str) -> DiagnosticWrapper<'a> {
-    let mut db = cx.struct_span_lint(lint, sp, msg);
-    if cx.current_level(lint) != Level::Allow {
-        db.fileline_help(sp,
-                         &format!("for further information visit https://github.com/Manishearth/rust-clippy/wiki#{}",
-                                  lint.name_lower()));
+impl<'a> DiagnosticWrapper<'a> {
+    fn wiki_link(&mut self, lint: &'static Lint) {
+        self.help(&format!("for further information visit https://github.com/Manishearth/rust-clippy/wiki#{}",
+                           lint.name_lower()));
     }
-    DiagnosticWrapper(db)
+}
+
+pub fn span_lint<'a, T: LintContext>(cx: &'a T, lint: &'static Lint, sp: Span, msg: &str) -> DiagnosticWrapper<'a> {
+    let mut db = DiagnosticWrapper(cx.struct_span_lint(lint, sp, msg));
+    if cx.current_level(lint) != Level::Allow {
+        db.wiki_link(lint);
+    }
+    db
 }
 
 pub fn span_help_and_lint<'a, T: LintContext>(cx: &'a T, lint: &'static Lint, span: Span, msg: &str, help: &str)
                                               -> DiagnosticWrapper<'a> {
-    let mut db = cx.struct_span_lint(lint, span, msg);
+    let mut db = DiagnosticWrapper(cx.struct_span_lint(lint, span, msg));
     if cx.current_level(lint) != Level::Allow {
-        db.fileline_help(span,
-                         &format!("{}\nfor further information visit \
-                                   https://github.com/Manishearth/rust-clippy/wiki#{}",
-                                  help,
-                                  lint.name_lower()));
+        db.help(help);
+        db.wiki_link(lint);
     }
-    DiagnosticWrapper(db)
+    db
 }
 
 pub fn span_note_and_lint<'a, T: LintContext>(cx: &'a T, lint: &'static Lint, span: Span, msg: &str, note_span: Span,
                                               note: &str)
                                               -> DiagnosticWrapper<'a> {
-    let mut db = cx.struct_span_lint(lint, span, msg);
+    let mut db = DiagnosticWrapper(cx.struct_span_lint(lint, span, msg));
     if cx.current_level(lint) != Level::Allow {
         if note_span == span {
-            db.fileline_note(note_span, note);
+            db.note(note);
         } else {
             db.span_note(note_span, note);
         }
-        db.fileline_help(span,
-                         &format!("for further information visit https://github.com/Manishearth/rust-clippy/wiki#{}",
-                                  lint.name_lower()));
+        db.wiki_link(lint);
     }
-    DiagnosticWrapper(db)
+    db
 }
 
 pub fn span_lint_and_then<'a, T: LintContext, F>(cx: &'a T, lint: &'static Lint, sp: Span, msg: &str, f: F)
@@ -518,9 +518,7 @@ pub fn span_lint_and_then<'a, T: LintContext, F>(cx: &'a T, lint: &'static Lint,
     let mut db = DiagnosticWrapper(cx.struct_span_lint(lint, sp, msg));
     if cx.current_level(lint) != Level::Allow {
         f(&mut db);
-        db.fileline_help(sp,
-                         &format!("for further information visit https://github.com/Manishearth/rust-clippy/wiki#{}",
-                                  lint.name_lower()));
+        db.wiki_link(lint);
     }
     db
 }

--- a/tests/compile-fail/for_loop.rs
+++ b/tests/compile-fail/for_loop.rs
@@ -340,7 +340,7 @@ fn main() {
     for (_, v) in &m {
         //~^ you seem to want to iterate on a map's values
         //~| HELP use the corresponding method
-        //~| SUGGESTION for v in &m.values()
+        //~| SUGGESTION for v in m.values()
         let _v = v;
     }
 

--- a/tests/compile-fail/matches.rs
+++ b/tests/compile-fail/matches.rs
@@ -140,7 +140,7 @@ fn ref_pats() {
         match v {
             //~^ERROR add `&` to all patterns
             //~|HELP instead of
-            //~|SUGGESTION `match *v { .. }`
+            //~|SUGGESTION match *v { .. }
             &Some(v) => println!("{:?}", v),
             &None => println!("none"),
         }
@@ -153,7 +153,7 @@ fn ref_pats() {
     match tup {
         //~^ERROR add `&` to all patterns
         //~|HELP instead of
-        //~|SUGGESTION `match *tup { .. }`
+        //~|SUGGESTION match *tup { .. }
         &(v, 1) => println!("{}", v),
         _ => println!("none"),
     }
@@ -162,7 +162,7 @@ fn ref_pats() {
     match &w {
         //~^ERROR add `&` to both
         //~|HELP try
-        //~|SUGGESTION `match w { .. }`
+        //~|SUGGESTION match w { .. }
         &Some(v) => println!("{:?}", v),
         &None => println!("none"),
     }
@@ -176,7 +176,7 @@ fn ref_pats() {
     if let &None = a {
         //~^ERROR add `&` to all patterns
         //~|HELP instead of
-        //~|SUGGESTION `if let ... = *a { .. }`
+        //~|SUGGESTION if let .. = *a { .. }
         println!("none");
     }
 
@@ -184,7 +184,7 @@ fn ref_pats() {
     if let &None = &b {
         //~^ERROR add `&` to both
         //~|HELP try
-        //~|SUGGESTION `if let ... = b { .. }`
+        //~|SUGGESTION if let .. = b { .. }
         println!("none");
     }
 }

--- a/tests/compile-fail/regex.rs
+++ b/tests/compile-fail/regex.rs
@@ -16,6 +16,8 @@ fn syntax_error() {
     //~^ERROR: regex syntax error: empty alternate
     let wrong_char_ranice = Regex::new("[z-a]");
     //~^ERROR: regex syntax error: invalid character class range
+    let some_unicode = Regex::new("[é-è]");
+    //~^ERROR: regex syntax error: invalid character class range
 
     let some_regex = Regex::new(OPENING_PAREN);
     //~^ERROR: regex syntax error on position 0: unclosed


### PR DESCRIPTION
Fix  #896. Fix #905.
Some tests looked like they were not actually tested ([like here](https://github.com/Manishearth/rust-clippy/pull/906/files#diff-618e04fdcebc4356586d510c594d5814L179)). Some other errors were because of 0 bytes long spans.