### PR TITLE
Allow invalid upcast comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ name                                                                            
 [inline_always](https://github.com/Manishearth/rust-clippy/wiki#inline_always)                                       | warn    | `#[inline(always)]` is a bad idea in most cases
 [integer_arithmetic](https://github.com/Manishearth/rust-clippy/wiki#integer_arithmetic)                             | allow   | Any integer arithmetic statement
 [invalid_regex](https://github.com/Manishearth/rust-clippy/wiki#invalid_regex)                                       | deny    | finds invalid regular expressions in `Regex::new(_)` invocations
-[invalid_upcast_comparisons](https://github.com/Manishearth/rust-clippy/wiki#invalid_upcast_comparisons)             | warn    | a comparison involving an upcast which is always true or false
+[invalid_upcast_comparisons](https://github.com/Manishearth/rust-clippy/wiki#invalid_upcast_comparisons)             | allow   | a comparison involving an upcast which is always true or false
 [items_after_statements](https://github.com/Manishearth/rust-clippy/wiki#items_after_statements)                     | allow   | finds blocks where an item comes after a statement
 [iter_next_loop](https://github.com/Manishearth/rust-clippy/wiki#iter_next_loop)                                     | warn    | for-looping over `_.next()` which is probably not intended
 [len_without_is_empty](https://github.com/Manishearth/rust-clippy/wiki#len_without_is_empty)                         | warn    | traits and impls that have `.len()` but not `.is_empty()`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,6 +427,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
         types::CAST_POSSIBLE_WRAP,
         types::CAST_PRECISION_LOSS,
         types::CAST_SIGN_LOSS,
+        types::INVALID_UPCAST_COMPARISONS,
         unicode::NON_ASCII_LITERAL,
         unicode::UNICODE_NOT_NFC,
     ]);
@@ -543,7 +544,6 @@ pub fn plugin_registrar(reg: &mut Registry) {
         types::ABSURD_EXTREME_COMPARISONS,
         types::BOX_VEC,
         types::CHAR_LIT_AS_U8,
-        types::INVALID_UPCAST_COMPARISONS,
         types::LET_UNIT_VALUE,
         types::LINKEDLIST,
         types::TYPE_COMPLEXITY,

--- a/src/types.rs
+++ b/src/types.rs
@@ -777,11 +777,11 @@ impl LateLintPass for AbsurdExtremeComparisons {
 ///
 /// **Why is this bad?** An expression like `let x : u8 = ...; (x as u32) > 300` will mistakenly imply that it is possible for `x` to be outside the range of `u8`.
 ///
-/// **Known problems:** None
+/// **Known problems:** https://github.com/Manishearth/rust-clippy/issues/886
 ///
 /// **Example:** `let x : u8 = ...; (x as u32) > 300`
 declare_lint! {
-    pub INVALID_UPCAST_COMPARISONS, Warn,
+    pub INVALID_UPCAST_COMPARISONS, Allow,
     "a comparison involving an upcast which is always true or false"
 }
 


### PR DESCRIPTION
Until we decide on how to solve
https://github.com/Manishearth/rust-clippy/issues/886 (either by changing the
meaning of the lint or making it not error for unsigned to signed)