### PR TITLE
needless_borrow reported on &&T when only &T implements Trait and &Trait is required

### DIFF
--- a/tests/compile-fail/needless_borrow.rs
+++ b/tests/compile-fail/needless_borrow.rs
@@ -16,6 +16,7 @@ fn main() {
     let g_val = g(&Vec::new()); // should not error, because `&Vec<T>` derefs to `&[T]`
     let vec = Vec::new();
     let vec_val = g(&vec); // should not error, because `&Vec<T>` derefs to `&[T]`
+    h(&"foo"); // should not error, because the `&&str` is required, due to `&Trait`
 }
 
 fn f<T:Copy>(y: &T) -> T {
@@ -25,3 +26,9 @@ fn f<T:Copy>(y: &T) -> T {
 fn g(y: &[u8]) -> u8 {
     y[0]
 }
+
+trait Trait {}
+
+impl<'a> Trait for &'a str {}
+
+fn h(_: &Trait) {}


### PR DESCRIPTION
This was found by [Zr40 on irc](https://botbot.me/mozilla/rust/2016-05-27/?msg=66815390&page=9)

I *almost* had a test for this, but I made it generic, and that didn't trigger