### PR TITLE
Release 0.0.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.72 — 2016-06-04
+* Fix false positives in [`useless_let_if_seq`]
+
 ## 0.0.71 — 2016-05-31
 * Rustup to *rustc 1.11.0-nightly (a967611d8 2016-05-30)*
 * New lint: [`useless_let_if_seq`]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.71"
+version = "0.0.72"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -30,7 +30,7 @@ toml = "0.1"
 unicode-normalization = "0.1"
 quine-mc_cluskey = "0.2.2"
 # begin automatic update
-clippy_lints = { version = "0.0.71", path = "clippy_lints" }
+clippy_lints = { version = "0.0.72", path = "clippy_lints" }
 # end automatic update
 rustc-serialize = "0.3"
 

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.71"
+version = "0.0.72"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",


### PR DESCRIPTION
#975 is breaking Serde builds. It was recently fixed in #979.