### PR TITLE
Fix false-positive in `USELESS_LET_IF_SEQ`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.73 — 2016-06-05
+* Fix false positives in [`useless_let_if_seq`]
+
 ## 0.0.72 — 2016-06-04
 * Fix false positives in [`useless_let_if_seq`]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.72"
+version = "0.0.73"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -30,7 +30,7 @@ toml = "0.1"
 unicode-normalization = "0.1"
 quine-mc_cluskey = "0.2.2"
 # begin automatic update
-clippy_lints = { version = "0.0.72", path = "clippy_lints" }
+clippy_lints = { version = "0.0.73", path = "clippy_lints" }
 # end automatic update
 rustc-serialize = "0.3"
 

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.72"
+version = "0.0.73"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",

--- a/tests/compile-fail/let_if_seq.rs
+++ b/tests/compile-fail/let_if_seq.rs
@@ -5,6 +5,27 @@
 #![deny(useless_let_if_seq)]
 
 fn f() -> bool { true }
+fn g(x: i32) -> i32 { x + 1 }
+
+fn issue985() -> i32 {
+    let mut x = 42;
+    if f() {
+        x = g(x);
+    }
+
+    x
+}
+
+fn issue985_alt() -> i32 {
+    let mut x = 42;
+    if f() {
+        f();
+    } else {
+        x = g(x);
+    }
+
+    x
+}
 
 fn issue975() -> String {
     let mut udn = "dummy".to_string();
@@ -30,6 +51,8 @@ fn early_return() -> u8 {
 fn main() {
     early_return();
     issue975();
+    issue985();
+    issue985_alt();
 
     let mut foo = 0;
     //~^ ERROR `if _ { .. } else { .. }` is an expression


### PR DESCRIPTION
Fix #985.
The `then` and `else` blocks were tested, but not the `f(x)` in `x = f(x)`.