### PR TITLE
Automatically defines the `clippy` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.76 — TBD
+* `cargo clippy` now automatically defines the `clippy` feature
+
 ## 0.0.75 — 2016-06-08
 * Rustup to *rustc 1.11.0-nightly (763f9234b 2016-06-06)*
 

--- a/README.md
+++ b/README.md
@@ -245,22 +245,6 @@ similar crates.
 SYSROOT=/path/to/rustc/sysroot cargo install clippy
 ```
 
-### Configuring clippy
-
-You can add options  to `allow`/`warn`/`deny`:
-
-*   the whole set of `Warn` lints using the `clippy` lint group (`#![deny(clippy)]`)
-
-*   all lints using both the `clippy` and `clippy_pedantic` lint groups (`#![deny(clippy)]`,
-    `#![deny(clippy_pedantic)]`). Note that `clippy_pedantic` contains some very aggressive
-    lints prone to false positives.
-
-*   only some lints (`#![deny(single_match, box_vec)]`, etc)
-
-*   `allow`/`warn`/`deny` can be limited to a single function or module using `#[allow(...)]`, etc
-
-Note: `deny` produces errors instead of warnings
-
 ### Running clippy from the command line without installing
 
 To have cargo compile your crate with clippy without needing `#![plugin(clippy)]`
@@ -320,6 +304,29 @@ You can also specify the path to the configuration file with:
 
 To deactivate the “for further information visit *wiki-link*” message you can
 define the `CLIPPY_DISABLE_WIKI_LINKS` environment variable.
+
+### Allowing/denying lints
+
+You can add options  to `allow`/`warn`/`deny`:
+
+*   the whole set of `Warn` lints using the `clippy` lint group (`#![deny(clippy)]`)
+
+*   all lints using both the `clippy` and `clippy_pedantic` lint groups (`#![deny(clippy)]`,
+    `#![deny(clippy_pedantic)]`). Note that `clippy_pedantic` contains some very aggressive
+    lints prone to false positives.
+
+*   only some lints (`#![deny(single_match, box_vec)]`, etc)
+
+*   `allow`/`warn`/`deny` can be limited to a single function or module using `#[allow(...)]`, etc
+
+Note: `deny` produces errors instead of warnings.
+
+For convenience, `cargo clippy` automatically defines a `clippy` features. This
+lets you set lints level and compile with or without clippy transparently:
+
+```rust
+#[cfg_attr(feature = "clippy", allow(needless_lifetimes))]
+```
 
 ## Link with clippy service
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,11 +141,14 @@ pub fn main() {
             }
         }
     } else {
-        let args: Vec<String> = if env::args().any(|s| s == "--sysroot") {
+        let mut args: Vec<String> = if env::args().any(|s| s == "--sysroot") {
             env::args().collect()
         } else {
             env::args().chain(Some("--sysroot".to_owned())).chain(Some(sys_root)).collect()
         };
+
+        args.extend_from_slice(&["--cfg".to_owned(), r#"feature="clippy""#.to_owned()]);
+
         let (result, _) = rustc_driver::run_compiler(&args, &mut ClippyCompilerCalls::new());
 
         if let Err(err_count) = result {
@@ -174,6 +177,8 @@ fn process<P, I>(old_args: I, dep_path: P, sysroot: &str) -> Result<(), i32>
     args.push(String::from("--sysroot"));
     args.push(sysroot.to_owned());
     args.push("-Zno-trans".to_owned());
+    args.push("--cfg".to_owned());
+    args.push(r#"feature="clippy""#.to_owned());
 
     let path = std::env::current_exe().expect("current executable path invalid");
     let exit_status = std::process::Command::new("cargo")


### PR DESCRIPTION
Since we wrap *rustc* and *cargo*, we can define features automatically!
Fix #574, but only when using as `cargo clippy`.