### PR TITLE
Include `consts` in the approx_consts lint for easier copypasting

### DIFF
--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -69,7 +69,7 @@ fn check_known_consts(cx: &LateContext, e: &Expr, s: &str, module: &str) {
                 span_lint(cx,
                           APPROX_CONSTANT,
                           e.span,
-                          &format!("approximate value of `{}::{}` found. Consider using it directly", module, &name));
+                          &format!("approximate value of `{}::consts::{}` found. Consider using it directly", module, &name));
                 return;
             }
         }

--- a/tests/compile-fail/approx_const.rs
+++ b/tests/compile-fail/approx_const.rs
@@ -4,54 +4,54 @@
 #[deny(approx_constant)]
 #[allow(unused, shadow_unrelated, similar_names)]
 fn main() {
-    let my_e = 2.7182; //~ERROR approximate value of `f{32, 64}::E` found
-    let almost_e = 2.718; //~ERROR approximate value of `f{32, 64}::E` found
+    let my_e = 2.7182; //~ERROR approximate value of `f{32, 64}::consts::E` found
+    let almost_e = 2.718; //~ERROR approximate value of `f{32, 64}::consts::E` found
     let no_e = 2.71;
 
-    let my_1_frac_pi = 0.3183; //~ERROR approximate value of `f{32, 64}::FRAC_1_PI` found
+    let my_1_frac_pi = 0.3183; //~ERROR approximate value of `f{32, 64}::consts::FRAC_1_PI` found
     let no_1_frac_pi = 0.31;
 
-    let my_frac_1_sqrt_2 = 0.70710678; //~ERROR approximate value of `f{32, 64}::FRAC_1_SQRT_2` found
-    let almost_frac_1_sqrt_2 = 0.70711; //~ERROR approximate value of `f{32, 64}::FRAC_1_SQRT_2` found
+    let my_frac_1_sqrt_2 = 0.70710678; //~ERROR approximate value of `f{32, 64}::consts::FRAC_1_SQRT_2` found
+    let almost_frac_1_sqrt_2 = 0.70711; //~ERROR approximate value of `f{32, 64}::consts::FRAC_1_SQRT_2` found
     let my_frac_1_sqrt_2 = 0.707;
 
-    let my_frac_2_pi = 0.63661977; //~ERROR approximate value of `f{32, 64}::FRAC_2_PI` found
+    let my_frac_2_pi = 0.63661977; //~ERROR approximate value of `f{32, 64}::consts::FRAC_2_PI` found
     let no_frac_2_pi = 0.636;
 
-    let my_frac_2_sq_pi = 1.128379; //~ERROR approximate value of `f{32, 64}::FRAC_2_SQRT_PI` found
+    let my_frac_2_sq_pi = 1.128379; //~ERROR approximate value of `f{32, 64}::consts::FRAC_2_SQRT_PI` found
     let no_frac_2_sq_pi = 1.128;
 
-    let my_frac_pi_2 = 1.57079632679; //~ERROR approximate value of `f{32, 64}::FRAC_PI_2` found
+    let my_frac_pi_2 = 1.57079632679; //~ERROR approximate value of `f{32, 64}::consts::FRAC_PI_2` found
     let no_frac_pi_2 = 1.5705;
 
-    let my_frac_pi_3 = 1.04719755119; //~ERROR approximate value of `f{32, 64}::FRAC_PI_3` found
+    let my_frac_pi_3 = 1.04719755119; //~ERROR approximate value of `f{32, 64}::consts::FRAC_PI_3` found
     let no_frac_pi_3 = 1.047;
 
-    let my_frac_pi_4 = 0.785398163397; //~ERROR approximate value of `f{32, 64}::FRAC_PI_4` found
+    let my_frac_pi_4 = 0.785398163397; //~ERROR approximate value of `f{32, 64}::consts::FRAC_PI_4` found
     let no_frac_pi_4 = 0.785;
 
-    let my_frac_pi_6 = 0.523598775598; //~ERROR approximate value of `f{32, 64}::FRAC_PI_6` found
+    let my_frac_pi_6 = 0.523598775598; //~ERROR approximate value of `f{32, 64}::consts::FRAC_PI_6` found
     let no_frac_pi_6 = 0.523;
 
-    let my_frac_pi_8 = 0.3926990816987; //~ERROR approximate value of `f{32, 64}::FRAC_PI_8` found
+    let my_frac_pi_8 = 0.3926990816987; //~ERROR approximate value of `f{32, 64}::consts::FRAC_PI_8` found
     let no_frac_pi_8 = 0.392;
 
-    let my_ln_10 = 2.302585092994046; //~ERROR approximate value of `f{32, 64}::LN_10` found
+    let my_ln_10 = 2.302585092994046; //~ERROR approximate value of `f{32, 64}::consts::LN_10` found
     let no_ln_10 = 2.303;
 
-    let my_ln_2 = 0.6931471805599453; //~ERROR approximate value of `f{32, 64}::LN_2` found
+    let my_ln_2 = 0.6931471805599453; //~ERROR approximate value of `f{32, 64}::consts::LN_2` found
     let no_ln_2 = 0.693;
 
-    let my_log10_e = 0.43429448190325182; //~ERROR approximate value of `f{32, 64}::LOG10_E` found
+    let my_log10_e = 0.43429448190325182; //~ERROR approximate value of `f{32, 64}::consts::LOG10_E` found
     let no_log10_e = 0.434;
 
-    let my_log2_e = 1.4426950408889634; //~ERROR approximate value of `f{32, 64}::LOG2_E` found
+    let my_log2_e = 1.4426950408889634; //~ERROR approximate value of `f{32, 64}::consts::LOG2_E` found
     let no_log2_e = 1.442;
 
-    let my_pi = 3.1415; //~ERROR approximate value of `f{32, 64}::PI` found
-    let almost_pi = 3.14; //~ERROR approximate value of `f{32, 64}::PI` found
+    let my_pi = 3.1415; //~ERROR approximate value of `f{32, 64}::consts::PI` found
+    let almost_pi = 3.14; //~ERROR approximate value of `f{32, 64}::consts::PI` found
     let no_pi = 3.15;
 
-    let my_sq2 = 1.4142; //~ERROR approximate value of `f{32, 64}::SQRT_2` found
+    let my_sq2 = 1.4142; //~ERROR approximate value of `f{32, 64}::consts::SQRT_2` found
     let no_sq2 = 1.414;
 }


### PR DESCRIPTION
OMG I LOVE YOU ALL CLIPPY IS AWESOME!!! ❤️ 💓 💜 💓 💚 

The only teeny tiny little thing I've noticed so far is I got this warning:

```
src/squeeze.rs:20:30: 20:45 warning: approximate value of `f{32, 64}::LOG2_E` found. Consider using it directly, #[warn(approx_constant)] on by default
src/squeeze.rs:20 const K_INV_LOG2: c_double = 1.4426950408889;  // 1.0 / log(2.0)
                                               ^~~~~~~~~~~~~~~
src/squeeze.rs:20:30: 20:45 help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#approx_constant
```

which, OMG, I love this!! I was wondering if this was some sort of special number and IT IS!!!! So, happy me, tries to go change the code as I *thought* was directed in the message:

```diff
use std::f64; // already had this

-const K_INV_LOG2: c_double = 1.4426950408889;  // 1.0 / log(2.0)
+const K_INV_LOG2: c_double = f64::LOG2_E;  // 1.0 / log(2.0)
```

Buuut this gave me this error:

```
src/squeeze.rs:20:30: 20:41 error: no associated item named `LOG2_E` found for type `f64` in the current scope
src/squeeze.rs:20 const K_INV_LOG2: c_double = f64::LOG2_E;  // 1.0 / log(2.0)
                                               ^~~~~~~~~~~
```

Turns out I needed `consts` in there, which, y'know, I figured out by looking at the linked wiki page and the docs:

```diff
-const K_INV_LOG2: c_double = f64::LOG2_E;  // 1.0 / log(2.0)
+const K_INV_LOG2: c_double = f64::consts::LOG2_E;  // 1.0 / log(2.0)
```

So I think the message should have `consts` in there:

```
 warning: approximate value of `f{32, 64}::consts::LOG2_E` found. Consider using it directly, #[warn(approx_constant)] on by default
```

Unless there's a reason for leaving this out that I'm missing??