### PR TITLE
Rustup to *1.11.0-nightly (7d2f75a95 2016-06-09)*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 0.0.76 — TBD
+* Rustup to *rustc 1.11.0-nightly (7d2f75a95 2016-06-09)*
 * `cargo clippy` now automatically defines the `clippy` feature
 
 ## 0.0.75 — 2016-06-08

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.75"
+version = "0.0.76"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -25,7 +25,7 @@ test = false
 [dependencies]
 regex_macros = { version = "0.1.33", optional = true }
 # begin automatic update
-clippy_lints = { version = "0.0.75", path = "clippy_lints" }
+clippy_lints = { version = "0.0.76", path = "clippy_lints" }
 # end automatic update
 
 [dev-dependencies]

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.75"
+version = "0.0.76"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",

--- a/clippy_lints/src/drop_ref.rs
+++ b/clippy_lints/src/drop_ref.rs
@@ -35,7 +35,7 @@ impl LateLintPass for DropRefPass {
     fn check_expr(&mut self, cx: &LateContext, expr: &Expr) {
         if let ExprCall(ref path, ref args) = expr.node {
             if let ExprPath(None, _) = path.node {
-                let def_id = cx.tcx.def_map.borrow()[&path.id].def_id();
+                let def_id = cx.tcx.expect_def(path.id).def_id();
                 if match_def_path(cx, def_id, &paths::DROP) {
                     if args.len() != 1 {
                         return;

--- a/clippy_lints/src/enum_glob_use.rs
+++ b/clippy_lints/src/enum_glob_use.rs
@@ -44,14 +44,14 @@ impl EnumGlobUse {
         if let ItemUse(ref item_use) = item.node {
             if let ViewPath_::ViewPathGlob(_) = item_use.node {
                 if let Some(def) = cx.tcx.def_map.borrow().get(&item.id) {
-                    if let Some(node_id) = cx.tcx.map.as_local_node_id(def.def_id()) {
+                    if let Some(node_id) = cx.tcx.map.as_local_node_id(def.full_def().def_id()) {
                         if let Some(NodeItem(it)) = cx.tcx.map.find(node_id) {
                             if let ItemEnum(..) = it.node {
                                 span_lint(cx, ENUM_GLOB_USE, item.span, "don't use glob imports for enum variants");
                             }
                         }
                     } else {
-                        let child = cx.sess().cstore.item_children(def.def_id());
+                        let child = cx.sess().cstore.item_children(def.full_def().def_id());
                         if let Some(child) = child.first() {
                             if let DefLike::DlDef(Def::Variant(..)) = child.def {
                                 span_lint(cx, ENUM_GLOB_USE, item.span, "don't use glob imports for enum variants");

--- a/clippy_lints/src/mem_forget.rs
+++ b/clippy_lints/src/mem_forget.rs
@@ -27,7 +27,7 @@ impl LateLintPass for MemForget {
     fn check_expr(&mut self, cx: &LateContext, e: &Expr) {
         if let ExprCall(ref path_expr, ref args) = e.node {
             if let ExprPath(None, _) = path_expr.node {
-                let def_id = cx.tcx.def_map.borrow()[&path_expr.id].def_id();
+                let def_id = cx.tcx.expect_def(path_expr.id).def_id();
                 if match_def_path(cx, def_id, &paths::MEM_FORGET) {
                     let forgot_ty = cx.tcx.expr_ty(&args[0]);
 

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -55,7 +55,7 @@ enum MinMax {
 fn min_max<'a>(cx: &LateContext, expr: &'a Expr) -> Option<(MinMax, Constant, &'a Expr)> {
     if let ExprCall(ref path, ref args) = expr.node {
         if let ExprPath(None, _) = path.node {
-            let def_id = cx.tcx.def_map.borrow()[&path.id].def_id();
+            let def_id = cx.tcx.expect_def(path.id).def_id();
 
             if match_def_path(cx, def_id, &paths::CMP_MIN) {
                 fetch_const(args, MinMax::Min)

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -155,8 +155,8 @@ enum Expression {
 
 fn fetch_bool_block(block: &Block) -> Expression {
     match (&*block.stmts, block.expr.as_ref()) {
-        ([], Some(e)) => fetch_bool_expr(&**e),
-        ([ref e], None) => {
+        (&[], Some(e)) => fetch_bool_expr(&**e),
+        (&[ref e], None) => {
             if let StmtSemi(ref e, _) = e.node {
                 if let ExprRet(_) = e.node {
                     fetch_bool_expr(&**e)

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -103,7 +103,7 @@ impl LateLintPass for RegexPass {
             args.len() == 1,
             let Some(def) = cx.tcx.def_map.borrow().get(&fun.id),
         ], {
-            let def_id = def.def_id();
+            let def_id = def.full_def().def_id();
             if match_def_path(cx, def_id, &paths::REGEX_NEW) ||
                match_def_path(cx, def_id, &paths::REGEX_BUILDER_NEW) {
                 check_regex(cx, &args[0], true);

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -60,7 +60,7 @@ impl LateLintPass for Transmute {
     fn check_expr(&mut self, cx: &LateContext, e: &Expr) {
         if let ExprCall(ref path_expr, ref args) = e.node {
             if let ExprPath(None, _) = path_expr.node {
-                let def_id = cx.tcx.def_map.borrow()[&path_expr.id].def_id();
+                let def_id = cx.tcx.expect_def(path_expr.id).def_id();
 
                 if match_def_path(cx, def_id, &paths::TRANSMUTE) {
                     let from_ty = cx.tcx.expr_ty(&args[0]);

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -56,7 +56,7 @@ impl LateLintPass for TypePass {
         }
         if let Some(did) = cx.tcx.def_map.borrow().get(&ast_ty.id) {
             if let def::Def::Struct(..) = did.full_def() {
-                if Some(did.def_id()) == cx.tcx.lang_items.owned_box() {
+                if Some(did.full_def().def_id()) == cx.tcx.lang_items.owned_box() {
                     if_let_chain! {[
                         let TyPath(_, ref path) = ast_ty.node,
                         let Some(ref last) = path.segments.last(),
@@ -64,7 +64,7 @@ impl LateLintPass for TypePass {
                         let Some(ref vec) = ag.types.get(0),
                         let Some(did) = cx.tcx.def_map.borrow().get(&vec.id),
                         let def::Def::Struct(..) = did.full_def(),
-                        match_def_path(cx, did.def_id(), &paths::VEC),
+                        match_def_path(cx, did.full_def().def_id(), &paths::VEC),
                     ], {
                         span_help_and_lint(cx,
                                            BOX_VEC,
@@ -72,7 +72,7 @@ impl LateLintPass for TypePass {
                                            "you seem to be trying to use `Box<Vec<T>>`. Consider using just `Vec<T>`",
                                            "`Vec<T>` is already on the heap, `Box<Vec<T>>` makes an extra allocation.");
                     }}
-                } else if match_def_path(cx, did.def_id(), &paths::LINKED_LIST) {
+                } else if match_def_path(cx, did.full_def().def_id(), &paths::LINKED_LIST) {
                     span_help_and_lint(cx,
                                        LINKEDLIST,
                                        ast_ty.span,


### PR DESCRIPTION
Ref https://github.com/rust-lang/rust/pull/34095.
The error is in `regex_macros`: https://github.com/rust-lang-nursery/regex/pull/248.