### PR TITLE
s/npm install remark/npm install remark-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - . $HOME/.nvm/nvm.sh
   - nvm install stable
   - nvm use stable
-  - npm install remark remark-lint
+  - npm install remark-cli remark-lint
 
 script:
  - set -e


### PR DESCRIPTION
Travis build currently fails with the [following message](https://travis-ci.org/Manishearth/rust-clippy/builds/137192232#L234-L240):
```
$ remark -f README.md > /dev/null

Whoops, `remark` is mistakenly installed instead of `remark-cli`

    npm uninstall remark

    npm install remark-cli

See https://git.io/vonyG for more information.
```