### PR TITLE
fix cargo clippy when using with `--manifest-path`

### DIFF
--- a/clippy_lints/src/utils/cargo.rs
+++ b/clippy_lints/src/utils/cargo.rs
@@ -65,8 +65,13 @@ impl From<json::DecoderError> for Error {
     }
 }
 
-pub fn metadata() -> Result<Metadata, Error> {
-    let output = Command::new("cargo").args(&["metadata", "--no-deps"]).output()?;
+pub fn metadata(manifest_path: Option<String>) -> Result<Metadata, Error> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("metadata").arg("--no-deps");
+    if let Some(ref mani) = manifest_path {
+        cmd.arg(mani);
+    }
+    let output = cmd.output()?;
     let stdout = from_utf8(&output.stdout)?;
     Ok(json::decode(stdout)?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,8 @@ pub fn main() {
     };
 
     if let Some("clippy") = std::env::args().nth(1).as_ref().map(AsRef::as_ref) {
-        let mut metadata = cargo::metadata().expect("could not obtain cargo metadata");
+        let manifest_path = std::env::args().skip(2).find(|val| val.starts_with("--manifest-path="));
+        let mut metadata = cargo::metadata(manifest_path).expect("could not obtain cargo metadata");
         assert_eq!(metadata.version, 1);
         for target in metadata.packages.remove(0).targets {
             let args = std::env::args().skip(2);


### PR DESCRIPTION
fixes #1023

There might be more flags we need to pass, the problem is, that I don't think we can pass ALL arguments, so we need to start adding them one by one.