### PR TITLE
don't lint on comparing `*const f32`s

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -523,8 +523,7 @@ pub fn span_lint_and_then<'a, T: LintContext, F>(cx: &'a T, lint: &'static Lint,
 /// Return the base type for references and raw pointers.
 pub fn walk_ptrs_ty(ty: ty::Ty) -> ty::Ty {
     match ty.sty {
-        ty::TyRef(_, ref tm) |
-        ty::TyRawPtr(ref tm) => walk_ptrs_ty(tm.ty),
+        ty::TyRef(_, ref tm) => walk_ptrs_ty(tm.ty),
         _ => ty,
     }
 }
@@ -533,8 +532,7 @@ pub fn walk_ptrs_ty(ty: ty::Ty) -> ty::Ty {
 pub fn walk_ptrs_ty_depth(ty: ty::Ty) -> (ty::Ty, usize) {
     fn inner(ty: ty::Ty, depth: usize) -> (ty::Ty, usize) {
         match ty.sty {
-            ty::TyRef(_, ref tm) |
-            ty::TyRawPtr(ref tm) => inner(tm.ty, depth + 1),
+            ty::TyRef(_, ref tm) => inner(tm.ty, depth + 1),
             _ => (ty, depth),
         }
     }

--- a/tests/compile-fail/float_cmp.rs
+++ b/tests/compile-fail/float_cmp.rs
@@ -63,4 +63,10 @@ fn main() {
     x > 0.0;
     x <= 0.0;
     x >= 0.0;
+
+    let xs : [f32; 1] = [0.0];
+    let a: *const f32 = xs.as_ptr();
+    let b: *const f32 = xs.as_ptr();
+
+    assert!(a == b); // no errors
 }


### PR DESCRIPTION
fixes #1037

`walk_ptrs_ty` is used in many other lints, but I could not find any evidence that skipping raw pointers makes sense wherever the method was used.

I suggest to err on the side of fewer lints triggering, and improve the lints to work with raw pointers where necessary (+ add tests).