### PR TITLE
Revert "Automatically defines the `clippy` feature"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## 0.0.78 - TBA
 * New lints: [`wrong_transmute`]
+* For compatibility, `cargo clippy` does not defines the `clippy` feature
+  introduced in 0.0.76 anymore
 
 ## 0.0.77 — 2016-06-21
 * Rustup to *rustc 1.11.0-nightly (5522e678b 2016-06-20)*

--- a/README.md
+++ b/README.md
@@ -326,13 +326,6 @@ You can add options  to `allow`/`warn`/`deny`:
 
 Note: `deny` produces errors instead of warnings.
 
-For convenience, `cargo clippy` automatically defines a `clippy` features. This
-lets you set lints level and compile with or without clippy transparently:
-
-```rust
-#[cfg_attr(feature = "clippy", allow(needless_lifetimes))]
-```
-
 ## Link with clippy service
 
 `clippy-service` is a rust web initiative providing `rust-clippy` as a web service.

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,14 +149,11 @@ pub fn main() {
             }
         }
     } else {
-        let mut args: Vec<String> = if env::args().any(|s| s == "--sysroot") {
+        let args: Vec<String> = if env::args().any(|s| s == "--sysroot") {
             env::args().collect()
         } else {
             env::args().chain(Some("--sysroot".to_owned())).chain(Some(sys_root)).collect()
         };
-
-        args.extend_from_slice(&["--cfg".to_owned(), r#"feature="clippy""#.to_owned()]);
-
         let (result, _) = rustc_driver::run_compiler(&args, &mut ClippyCompilerCalls::new());
 
         if let Err(err_count) = result {
@@ -187,8 +184,6 @@ fn process<P, I>(old_args: I, dep_path: P, sysroot: &str) -> Result<(), i32>
     args.push(String::from("--sysroot"));
     args.push(sysroot.to_owned());
     args.push("-Zno-trans".to_owned());
-    args.push("--cfg".to_owned());
-    args.push(r#"feature="clippy""#.to_owned());
 
     let path = std::env::current_exe().expect("current executable path invalid");
     let exit_status = std::process::Command::new("cargo")


### PR DESCRIPTION
This reverts commit d7ba66bf44f993e64114e17cc15f1b0d56ae8f70.

It was causing problems with crates with:

```rust
#![cfg_attr(feature="clippy", plugin(clippy))]
```

Close #1055.