### PR TITLE
Check for constant expression in useless_vec lint

### DIFF
--- a/tests/compile-fail/vec.rs
+++ b/tests/compile-fail/vec.rs
@@ -7,6 +7,16 @@ fn on_slice(_: &[u8]) {}
 #[allow(ptr_arg)]
 fn on_vec(_: &Vec<u8>) {}
 
+struct Line {
+    length: usize,
+}
+
+impl Line {
+    fn length(&self) -> usize {
+        self.length
+    }
+}
+
 fn main() {
     on_slice(&vec![]);
     //~^ ERROR useless use of `vec!`
@@ -41,6 +51,12 @@ fn main() {
     on_vec(&vec![]);
     on_vec(&vec![1, 2]);
     on_vec(&vec![1; 2]);
+
+    // Now with non-constant expressions
+    let line = Line { length: 2 };
+
+    on_slice(&vec![2; line.length]);
+    on_slice(&vec![2; line.length()]);
 
     for a in vec![1, 2, 3] {
         //~^ ERROR useless use of `vec!`


### PR DESCRIPTION
This PR resolves issue #1063 .

The PR includes a new check on the length expression - ensuring that it is a constant expression. It also adds new tests to the compile-fail suite for `vec.rs`. These tests check the length against a struct field and method.