### PR TITLE
Fix position of mut in toplevel-ref-arg (fixes #1100, again)

### DIFF
--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -62,29 +62,28 @@ impl LateLintPass for TopLevelRefPass {
             let PatKind::Binding(BindByRef(mt), i, None) = l.pat.node,
             let Some(ref init) = l.init
         ], {
+            let init = Sugg::hir(cx, init, "..");
+            let (mutopt,initref) = if mt == Mutability::MutMutable {
+                ("mut ", init.mut_addr())
+            } else {
+                ("", init.addr())
+            };
             let tyopt = if let Some(ref ty) = l.ty {
-                format!(": &{}", snippet(cx, ty.span, "_"))
+                format!(": &{mutopt}{ty}", mutopt=mutopt, ty=snippet(cx, ty.span, "_"))
             } else {
                 "".to_owned()
-            };
-            let mutopt = if mt == Mutability::MutMutable {
-                "mut "
-            } else {
-                ""
             };
             span_lint_and_then(cx,
                 TOPLEVEL_REF_ARG,
                 l.pat.span,
                 "`ref` on an entire `let` pattern is discouraged, take a reference with `&` instead",
                 |db| {
-                    let init = Sugg::hir(cx, init, "..");
                     db.span_suggestion(s.span,
                                        "try",
-                                       format!("let {}{}{} = {};",
-                                               mutopt,
-                                               snippet(cx, i.span, "_"),
-                                               tyopt,
-                                               init.addr()));
+                                       format!("let {name}{tyopt} = {initref};",
+                                               name=snippet(cx, i.span, "_"),
+                                               tyopt=tyopt,
+                                               initref=initref));
                 }
             );
         }}

--- a/tests/compile-fail/toplevel_ref_arg.rs
+++ b/tests/compile-fail/toplevel_ref_arg.rs
@@ -33,7 +33,7 @@ fn main() {
   let ref mut z = 1 + 2;
   //~^ ERROR `ref` on an entire `let` pattern is discouraged
   //~| HELP try
-  //~| SUGGESTION let mut z = &(1 + 2);
+  //~| SUGGESTION let z = &mut (1 + 2);
 
   let (ref x, _) = (1,2); // okay, not top level
   println!("The answer is {}.", x);


### PR DESCRIPTION
r? @mcarton