### PR TITLE
lint `a += a + b` (possible mis-refactoring of `a = a + b`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@ All notable changes to this project will be documented in this file.
 [`match_same_arms`]: https://github.com/Manishearth/rust-clippy/wiki#match_same_arms
 [`mem_forget`]: https://github.com/Manishearth/rust-clippy/wiki#mem_forget
 [`min_max`]: https://github.com/Manishearth/rust-clippy/wiki#min_max
+[`misrefactored_assign_op`]: https://github.com/Manishearth/rust-clippy/wiki#misrefactored_assign_op
 [`modulo_one`]: https://github.com/Manishearth/rust-clippy/wiki#modulo_one
 [`mut_mut`]: https://github.com/Manishearth/rust-clippy/wiki#mut_mut
 [`mutex_atomic`]: https://github.com/Manishearth/rust-clippy/wiki#mutex_atomic

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Table of contents:
 
 ## Lints
 
-There are 159 lints included in this crate:
+There are 160 lints included in this crate:
 
 name                                                                                                                 | default | meaning
 ---------------------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -97,6 +97,7 @@ name                                                                            
 [match_same_arms](https://github.com/Manishearth/rust-clippy/wiki#match_same_arms)                                   | warn    | `match` with identical arm bodies
 [mem_forget](https://github.com/Manishearth/rust-clippy/wiki#mem_forget)                                             | allow   | `mem::forget` usage on `Drop` types is likely to cause memory leaks
 [min_max](https://github.com/Manishearth/rust-clippy/wiki#min_max)                                                   | warn    | `min(_, max(_, _))` (or vice versa) with bounds clamping the result to a constant
+[misrefactored_assign_op](https://github.com/Manishearth/rust-clippy/wiki#misrefactored_assign_op)                   | warn    | having a variable on both sides of an assign op
 [modulo_one](https://github.com/Manishearth/rust-clippy/wiki#modulo_one)                                             | warn    | taking a number modulo 1, which always returns 0
 [mut_mut](https://github.com/Manishearth/rust-clippy/wiki#mut_mut)                                                   | allow   | usage of double-mut refs, e.g. `&mut &mut ...`
 [mutex_atomic](https://github.com/Manishearth/rust-clippy/wiki#mutex_atomic)                                         | warn    | using a mutex where an atomic value could be used instead

--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -1,6 +1,6 @@
 use rustc::hir;
 use rustc::lint::*;
-use utils::{span_lint_and_then, span_lint, snippet_opt, SpanlessEq, get_trait_def_id, implements_trait};
+use utils::{span_lint_and_then, snippet_opt, SpanlessEq, get_trait_def_id, implements_trait};
 use utils::{higher, sugg};
 
 /// **What it does:** This lint checks for `+=` operations and similar.
@@ -104,23 +104,18 @@ impl LateLintPass for AssignOps {
                                 BitXor: BiBitXor,
                                 Shr: BiShr,
                                 Shl: BiShl) {
-                            if let (Some(snip_a), Some(snip_r)) = (snippet_opt(cx, assignee.span),
-                                                                   snippet_opt(cx, rhs.span)) {
-                                span_lint_and_then(cx,
-                                                   ASSIGN_OP_PATTERN,
-                                                   expr.span,
-                                                   "manual implementation of an assign operation",
-                                                   |db| {
+                            span_lint_and_then(cx,
+                                               ASSIGN_OP_PATTERN,
+                                               expr.span,
+                                               "manual implementation of an assign operation",
+                                               |db| {
+                                                   if let (Some(snip_a), Some(snip_r)) = (snippet_opt(cx, assignee.span),
+                                                                                          snippet_opt(cx, rhs.span)) {
                                                        db.span_suggestion(expr.span,
                                                                           "replace it with",
                                                                           format!("{} {}= {}", snip_a, op.node.as_str(), snip_r));
-                                                   });
-                            } else {
-                                span_lint(cx,
-                                          ASSIGN_OP_PATTERN,
-                                          expr.span,
-                                          "manual implementation of an assign operation");
-                            }
+                                                   }
+                                               });
                         }
                     };
                     // a = a op b

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -300,6 +300,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         approx_const::APPROX_CONSTANT,
         array_indexing::OUT_OF_BOUNDS_INDEXING,
         assign_ops::ASSIGN_OP_PATTERN,
+        assign_ops::MISREFACTORED_ASSIGN_OP,
         attrs::DEPRECATED_SEMVER,
         attrs::INLINE_ALWAYS,
         bit_mask::BAD_BIT_MASK,

--- a/tests/compile-fail/assign_ops2.rs
+++ b/tests/compile-fail/assign_ops2.rs
@@ -1,0 +1,36 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+#[allow(unused_assignments)]
+#[deny(misrefactored_assign_op)]
+fn main() {
+    let mut a = 5;
+    a += a + 1; //~ ERROR variable appears on both sides of an assignment operation
+    //~^ HELP replace it with
+    //~| SUGGESTION a += 1
+    a += 1 + a; //~ ERROR variable appears on both sides of an assignment operation
+    //~^ HELP replace it with
+    //~| SUGGESTION a += 1
+    a -= a - 1; //~ ERROR variable appears on both sides of an assignment operation
+    //~^ HELP replace it with
+    //~| SUGGESTION a -= 1
+    a *= a * 99; //~ ERROR variable appears on both sides of an assignment operation
+    //~^ HELP replace it with
+    //~| SUGGESTION a *= 99
+    a *= 42 * a; //~ ERROR variable appears on both sides of an assignment operation
+    //~^ HELP replace it with
+    //~| SUGGESTION a *= 42
+    a /= a / 2; //~ ERROR variable appears on both sides of an assignment operation
+    //~^ HELP replace it with
+    //~| SUGGESTION a /= 2
+    a %= a % 5; //~ ERROR variable appears on both sides of an assignment operation
+    //~^ HELP replace it with
+    //~| SUGGESTION a %= 5
+    a &= a & 1; //~ ERROR variable appears on both sides of an assignment operation
+    //~^ HELP replace it with
+    //~| SUGGESTION a &= 1
+    a -= 1 - a;
+    a /= 5 / a;
+    a %= 42 % a;
+    a <<= 6 << a;
+}


### PR DESCRIPTION
fixes #1097 

the real world occurrence was in a software [PID controller](https://en.wikipedia.org/wiki/PID_controller)'s update cycle.

If this causes false positives I'd be happy to turn it into an allow-by-default lint, but `a += a + b` is unreadable enough as it is. We might consider linting `a op= a otherop b` in the future, too.