### PR TITLE
Add link to lint list on readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Table of contents:
 
 ## Lints
 
-There are 160 lints included in this crate:
+There are 160 lints included in this crate. You can see a list of them [on the web](https://manishearth.github.io/rust-clippy/master/) or in the table below:
 
 name                                                                                                                 | default | meaning
 ---------------------------------------------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add link in the readme to the awesome new page listing the lints.

I think it would be nice to be more agressive and remove the list from the readme, keeping it only in the web page and in the wiki.