### PR TITLE
 Rustup to rustc 1.12.0-nightly (1225e122f 2016-07-30)  and bump to 0.0.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.80 — 2016-07-31
+* Rustup to *rustc 1.12.0-nightly (1225e122f 2016-07-30)*
+
 ## 0.0.79 — 2016-07-10
 * Rustup to *rustc 1.12.0-nightly (f93aaf84c 2016-07-09)*
 * Major suggestions refactoring

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.79"
+version = "0.0.80"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -25,7 +25,7 @@ test = false
 
 [dependencies]
 # begin automatic update
-clippy_lints = { version = "0.0.79", path = "clippy_lints" }
+clippy_lints = { version = "0.0.80", path = "clippy_lints" }
 # end automatic update
 
 [dev-dependencies]

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.79"
+version = "0.0.80"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",

--- a/clippy_lints/src/unused_label.rs
+++ b/clippy_lints/src/unused_label.rs
@@ -47,13 +47,13 @@ impl LintPass for UnusedLabel {
 }
 
 impl LateLintPass for UnusedLabel {
-    fn check_fn(&mut self, cx: &LateContext, kind: FnKind, decl: &hir::FnDecl, body: &hir::Block, span: Span, _: ast::NodeId) {
+    fn check_fn(&mut self, cx: &LateContext, kind: FnKind, decl: &hir::FnDecl, body: &hir::Block, span: Span, fn_id: ast::NodeId) {
         if in_macro(cx, span) {
             return;
         }
 
         let mut v = UnusedLabelVisitor::new();
-        walk_fn(&mut v, kind, decl, body, span);
+        walk_fn(&mut v, kind, decl, body, span, fn_id);
 
         for (label, span) in v.labels {
             span_lint(cx, UNUSED_LABEL, span, &format!("unused label `{}`", label));


### PR DESCRIPTION
Yup, there's been another problem after  #1119.
Fix #1120.
Ref https://github.com/rust-lang/rust/pull/35090.