### PR TITLE
No warning when file is opened with read truncate and write

### DIFF
--- a/clippy_lints/src/open_options.rs
+++ b/clippy_lints/src/open_options.rs
@@ -178,7 +178,7 @@ fn check_open_options(cx: &LateContext, options: &[(OpenOption, Argument)], span
         }
     }
 
-    if read && truncate && read_arg && truncate_arg {
+    if read && truncate && read_arg && truncate_arg && !(write && write_arg) {
         span_lint(cx, NONSENSICAL_OPEN_OPTIONS, span, "file opened with \"truncate\" and \"read\"");
     }
     if append && truncate && append_arg && truncate_arg {


### PR DESCRIPTION
It makes sense to open a file with read, truncate and write so remove that warning.
E.g. opening an existing file, truncating it, writing to it, reading from it.