### PR TITLE
add suggestions to clone_on_copy

### DIFF
--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -161,7 +161,13 @@ impl<'a> Sugg<'a> {
     pub fn maybe_par(self) -> Self {
         match self {
             Sugg::NonParen(..) => self,
-            Sugg::MaybeParen(sugg) | Sugg::BinOp(_, sugg) => Sugg::NonParen(format!("({})", sugg).into()),
+            // (x) and (x).y() both don't need additional parens
+            Sugg::MaybeParen(sugg) => if sugg.starts_with('(') && sugg.ends_with(')') {
+                Sugg::MaybeParen(sugg)
+            } else {
+                Sugg::NonParen(format!("({})", sugg).into())
+            },
+            Sugg::BinOp(_, sugg) => Sugg::NonParen(format!("({})", sugg).into()),
         }
     }
 }

--- a/tests/compile-fail/methods.rs
+++ b/tests/compile-fail/methods.rs
@@ -435,13 +435,22 @@ fn use_extend_from_slice() {
 
 fn clone_on_copy() {
     42.clone(); //~ERROR using `clone` on a `Copy` type
+                //~| HELP try removing the `clone` call
+                //~| SUGGESTION 42
     vec![1].clone(); // ok, not a Copy type
     Some(vec![1]).clone(); // ok, not a Copy type
+    (&42).clone(); //~ERROR using `clone` on a `Copy` type
+                   //~| HELP try dereferencing it
+                   //~| SUGGESTION *(&42)
 }
 
 fn clone_on_copy_generic<T: Copy>(t: T) {
     t.clone(); //~ERROR using `clone` on a `Copy` type
+               //~| HELP try removing the `clone` call
+               //~| SUGGESTION t
     Some(t).clone(); //~ERROR using `clone` on a `Copy` type
+                     //~| HELP try removing the `clone` call
+                     //~| SUGGESTION Some(t)
 }
 
 fn clone_on_double_ref() {
@@ -450,7 +459,6 @@ fn clone_on_double_ref() {
     let z: &Vec<_> = y.clone(); //~ERROR using `clone` on a double
                                 //~| HELP try dereferencing it
                                 //~| SUGGESTION let z: &Vec<_> = (*y).clone();
-                                //~^^^ERROR using `clone` on a `Copy` type
     println!("{:p} {:p}",*y, z);
 }
 


### PR DESCRIPTION
also:

* don't report clone_on_copy when reporting clone_on_double_ref
* don't suggest `((x))`

fixes #1139