### PR TITLE
CompilerCalls trait changed in latest nightly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use rustc::session::{config, Session};
 use rustc::session::config::{Input, ErrorOutputType};
 use std::path::PathBuf;
 use std::process::Command;
+use syntax::{ast};
 
 use clippy_lints::utils::cargo;
 
@@ -36,28 +37,31 @@ impl<'a> CompilerCalls<'a> for ClippyCompilerCalls {
     fn early_callback(&mut self,
                       matches: &getopts::Matches,
                       sopts: &config::Options,
+                      cfg: &ast::CrateConfig,
                       descriptions: &rustc_errors::registry::Registry,
                       output: ErrorOutputType)
                       -> Compilation {
-        self.default.early_callback(matches, sopts, descriptions, output)
+        self.default.early_callback(matches, sopts, cfg, descriptions, output)
     }
     fn no_input(&mut self,
                 matches: &getopts::Matches,
                 sopts: &config::Options,
+                cfg: &ast::CrateConfig,
                 odir: &Option<PathBuf>,
                 ofile: &Option<PathBuf>,
                 descriptions: &rustc_errors::registry::Registry)
                 -> Option<(Input, Option<PathBuf>)> {
-        self.default.no_input(matches, sopts, odir, ofile, descriptions)
+        self.default.no_input(matches, sopts, cfg, odir, ofile, descriptions)
     }
     fn late_callback(&mut self,
                      matches: &getopts::Matches,
                      sess: &Session,
+                     cfg: &ast::CrateConfig,
                      input: &Input,
                      odir: &Option<PathBuf>,
                      ofile: &Option<PathBuf>)
                      -> Compilation {
-        self.default.late_callback(matches, sess, input, odir, ofile)
+        self.default.late_callback(matches, sess, cfg, input, odir, ofile)
     }
     fn build_controller(&mut self, sess: &Session, matches: &getopts::Matches) -> driver::CompileController<'a> {
         let mut control = self.default.build_controller(sess, matches);


### PR DESCRIPTION
This patch makes clippy compile again. Hope this is the proper way about handling this.

Only problem being that the `compiletest` crate is broken because of a change in the test module.

See: rust-lang/rust@65eb024542835c0235c31ef0e2381d155c797b03