### PR TITLE
disallow lint attributes on `use` and `extern crate` items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,7 @@ All notable changes to this project will be documented in this file.
 [`unused_lifetimes`]: https://github.com/Manishearth/rust-clippy/wiki#unused_lifetimes
 [`use_debug`]: https://github.com/Manishearth/rust-clippy/wiki#use_debug
 [`used_underscore_binding`]: https://github.com/Manishearth/rust-clippy/wiki#used_underscore_binding
+[`useless_attribute`]: https://github.com/Manishearth/rust-clippy/wiki#useless_attribute
 [`useless_format`]: https://github.com/Manishearth/rust-clippy/wiki#useless_format
 [`useless_let_if_seq`]: https://github.com/Manishearth/rust-clippy/wiki#useless_let_if_seq
 [`useless_transmute`]: https://github.com/Manishearth/rust-clippy/wiki#useless_transmute

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Table of contents:
 
 ## Lints
 
-There are 165 lints included in this crate:
+There are 166 lints included in this crate:
 
 name                                                                                                                 | default | triggers on
 ---------------------------------------------------------------------------------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------
@@ -175,6 +175,7 @@ name                                                                            
 [unused_lifetimes](https://github.com/Manishearth/rust-clippy/wiki#unused_lifetimes)                                 | warn    | unused lifetimes in function definitions
 [use_debug](https://github.com/Manishearth/rust-clippy/wiki#use_debug)                                               | allow   | use of `Debug`-based formatting
 [used_underscore_binding](https://github.com/Manishearth/rust-clippy/wiki#used_underscore_binding)                   | allow   | using a binding which is prefixed with an underscore
+[useless_attribute](https://github.com/Manishearth/rust-clippy/wiki#useless_attribute)                               | warn    | use of lint attributes on `extern crate` items
 [useless_format](https://github.com/Manishearth/rust-clippy/wiki#useless_format)                                     | warn    | useless use of `format!`
 [useless_let_if_seq](https://github.com/Manishearth/rust-clippy/wiki#useless_let_if_seq)                             | warn    | unidiomatic `let mut` declaration followed by initialization in `if`
 [useless_transmute](https://github.com/Manishearth/rust-clippy/wiki#useless_transmute)                               | warn    | transmutes that have the same to and from types or could be a cast/coercion

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -308,6 +308,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         assign_ops::MISREFACTORED_ASSIGN_OP,
         attrs::DEPRECATED_SEMVER,
         attrs::INLINE_ALWAYS,
+        attrs::USELESS_ATTRIBUTE,
         bit_mask::BAD_BIT_MASK,
         bit_mask::INEFFECTIVE_BIT_MASK,
         blacklisted_name::BLACKLISTED_NAME,

--- a/tests/compile-fail/useless_attribute.rs
+++ b/tests/compile-fail/useless_attribute.rs
@@ -1,0 +1,10 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+#![deny(useless_attribute)]
+
+#[allow(dead_code)] //~ ERROR useless lint attribute
+//~| HELP if you just forgot a `!`, use
+//~| SUGGESTION #![allow(dead_code)]
+extern crate clippy_lints;
+
+fn main() {}


### PR DESCRIPTION
mitgates #1165