### PR TITLE
Fix Travis not pushing gh-pages for tags

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -35,8 +35,11 @@ fi
 
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
-    echo "Generated, won't push"
-    exit 0
+    # Tags should deploy
+    if [ -z "$TRAVIS_TAG" ]; then
+        echo "Generated, won't push"
+        exit 0
+    fi
 fi
 
 # Get the deploy key by using Travis's stored variables to decrypt deploy_key.enc


### PR DESCRIPTION
Turns out `$TRAVIS_BRANCH` is the tag name for tags.