### PR TITLE
don't lint `unused_attribute` if snippet is shorter than 1 character

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -109,14 +109,16 @@ impl LateLintPass for AttrPass {
                     if let MetaItemKind::List(ref name, _) = attr.node.value.node {
                         match &**name {
                             "allow" | "warn" | "deny" | "forbid" => {
-                                span_lint_and_then(cx, USELESS_ATTRIBUTE, attr.span,
-                                                   "useless lint attribute",
-                                                   |db| {
-                                    if let Some(mut sugg) = snippet_opt(cx, attr.span) {
-                                        sugg.insert(1, '!');
-                                        db.span_suggestion(attr.span, "if you just forgot a `!`, use", sugg);
+                                if let Some(mut sugg) = snippet_opt(cx, attr.span) {
+                                    if sugg.len() > 1 {
+                                        span_lint_and_then(cx, USELESS_ATTRIBUTE, attr.span,
+                                                           "useless lint attribute",
+                                                           |db| {
+                                            sugg.insert(1, '!');
+                                            db.span_suggestion(attr.span, "if you just forgot a `!`, use", sugg);
+                                        });
                                     }
-                                });
+                                }
                             },
                             _ => {},
                         }

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -106,9 +106,19 @@ impl LateLintPass for AttrPass {
             ItemExternCrate(_) |
             ItemUse(_) => {
                 for attr in &item.attrs {
-                    if let MetaItemKind::List(ref name, _) = attr.node.value.node {
+                    if let MetaItemKind::List(ref name, ref lint_list) = attr.node.value.node {
                         match &**name {
                             "allow" | "warn" | "deny" | "forbid" => {
+                                // whitelist `unused_imports`
+                                for lint in lint_list {
+                                    if let MetaItemKind::Word(ref word) = lint.node {
+                                        if word == "unused_imports" {
+                                            if let ItemUse(_) = item.node {
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }
                                 if let Some(mut sugg) = snippet_opt(cx, attr.span) {
                                     if sugg.len() > 1 {
                                         span_lint_and_then(cx, USELESS_ATTRIBUTE, attr.span,

--- a/tests/compile-fail/useless_attribute.rs
+++ b/tests/compile-fail/useless_attribute.rs
@@ -7,4 +7,8 @@
 //~| SUGGESTION #![allow(dead_code)]
 extern crate clippy_lints;
 
+// don't lint on unused_import for `use` items
+#[allow(unused_imports)]
+use std::collections;
+
 fn main() {}


### PR DESCRIPTION
This happens with various combinations of cfg attributes and macros expansion.
Not linting here is the safe route, as everything else might produce false positives.