### PR TITLE
split pub_enum_variant_names to new lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,7 @@ All notable changes to this project will be documented in this file.
 [`print_stdout`]: https://github.com/Manishearth/rust-clippy/wiki#print_stdout
 [`print_with_newline`]: https://github.com/Manishearth/rust-clippy/wiki#print_with_newline
 [`ptr_arg`]: https://github.com/Manishearth/rust-clippy/wiki#ptr_arg
+[`pub_enum_variant_names`]: https://github.com/Manishearth/rust-clippy/wiki#pub_enum_variant_names
 [`range_step_by_zero`]: https://github.com/Manishearth/rust-clippy/wiki#range_step_by_zero
 [`range_zip_with_len`]: https://github.com/Manishearth/rust-clippy/wiki#range_zip_with_len
 [`redundant_closure`]: https://github.com/Manishearth/rust-clippy/wiki#redundant_closure

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ transparently:
 
 ## Lints
 
-There are 179 lints included in this crate:
+There are 180 lints included in this crate:
 
 name                                                                                                                   | default | triggers on
 -----------------------------------------------------------------------------------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------
@@ -305,6 +305,7 @@ name                                                                            
 [print_stdout](https://github.com/Manishearth/rust-clippy/wiki#print_stdout)                                           | allow   | printing on stdout
 [print_with_newline](https://github.com/Manishearth/rust-clippy/wiki#print_with_newline)                               | warn    | using `print!()` with a format string that ends in a newline
 [ptr_arg](https://github.com/Manishearth/rust-clippy/wiki#ptr_arg)                                                     | warn    | fn arguments of the type `&Vec<...>` or `&String`, suggesting to use `&[...]` or `&str` instead, respectively
+[pub_enum_variant_names](https://github.com/Manishearth/rust-clippy/wiki#pub_enum_variant_names)                       | allow   | enums where all variants share a prefix/postfix
 [range_step_by_zero](https://github.com/Manishearth/rust-clippy/wiki#range_step_by_zero)                               | warn    | using `Range::step_by(0)`, which produces an infinite iterator
 [range_zip_with_len](https://github.com/Manishearth/rust-clippy/wiki#range_zip_with_len)                               | warn    | zipping iterator with a range when `enumerate()` would do
 [redundant_closure](https://github.com/Manishearth/rust-clippy/wiki#redundant_closure)                                 | warn    | redundant closures, i.e. `|a| foo(a)` (which can be written as just `foo`)

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -28,6 +28,27 @@ declare_lint! {
     "enums where all variants share a prefix/postfix"
 }
 
+/// **What it does:** Detects enumeration variants that are prefixed or suffixed
+/// by the same characters.
+///
+/// **Why is this bad?** Enumeration variant names should specify their variant,
+/// not repeat the enumeration name.
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rust
+/// enum Cake {
+///     BlackForestCake,
+///     HummingbirdCake,
+/// }
+/// ```
+declare_lint! {
+    pub PUB_ENUM_VARIANT_NAMES,
+    Allow,
+    "enums where all variants share a prefix/postfix"
+}
+
 /// **What it does:** Detects type names that are prefixed or suffixed by the
 /// containing module's name.
 ///
@@ -90,7 +111,7 @@ impl EnumVariantNames {
 
 impl LintPass for EnumVariantNames {
     fn get_lints(&self) -> LintArray {
-        lint_array!(ENUM_VARIANT_NAMES, STUTTER, MODULE_INCEPTION)
+        lint_array!(ENUM_VARIANT_NAMES, PUB_ENUM_VARIANT_NAMES, STUTTER, MODULE_INCEPTION)
     }
 }
 
@@ -120,7 +141,8 @@ fn check_variant(
     def: &EnumDef,
     item_name: &str,
     item_name_chars: usize,
-    span: Span
+    span: Span,
+    lint: &'static Lint
 ) {
     if (def.variants.len() as u64) < threshold {
         return;
@@ -128,10 +150,10 @@ fn check_variant(
     for var in &def.variants {
         let name = var2str(var);
         if partial_match(item_name, &name) == item_name_chars {
-            span_lint(cx, ENUM_VARIANT_NAMES, var.span, "Variant name starts with the enum's name");
+            span_lint(cx, lint, var.span, "Variant name starts with the enum's name");
         }
         if partial_rmatch(item_name, &name) == item_name_chars {
-            span_lint(cx, ENUM_VARIANT_NAMES, var.span, "Variant name ends with the enum's name");
+            span_lint(cx, lint, var.span, "Variant name ends with the enum's name");
         }
     }
     let first = var2str(&def.variants[0]);
@@ -166,7 +188,7 @@ fn check_variant(
         (true, false) => ("post", post),
     };
     span_help_and_lint(cx,
-                       ENUM_VARIANT_NAMES,
+                       lint,
                        span,
                        &format!("All variants have the same {}fix: `{}`", what, value),
                        &format!("remove the {}fixes and use full paths to \
@@ -233,7 +255,11 @@ impl EarlyLintPass for EnumVariantNames {
             }
         }
         if let ItemKind::Enum(ref def, _) = item.node {
-            check_variant(cx, self.threshold, def, &item_name, item_name_chars, item.span);
+            let lint = match item.vis {
+                Visibility::Public => PUB_ENUM_VARIANT_NAMES,
+                _ => ENUM_VARIANT_NAMES,
+            };
+            check_variant(cx, self.threshold, def, &item_name, item_name_chars, item.span, lint);
         }
         self.modules.push((item_name, item_camel));
     }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -294,6 +294,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_lint_group("clippy_pedantic", vec![
         booleans::NONMINIMAL_BOOL,
         enum_glob_use::ENUM_GLOB_USE,
+        enum_variants::PUB_ENUM_VARIANT_NAMES,
         enum_variants::STUTTER,
         if_not_else::IF_NOT_ELSE,
         items_after_statements::ITEMS_AFTER_STATEMENTS,

--- a/tests/compile-fail/enum_variants.rs
+++ b/tests/compile-fail/enum_variants.rs
@@ -1,6 +1,6 @@
 #![feature(plugin, non_ascii_idents)]
 #![plugin(clippy)]
-#![deny(clippy)]
+#![deny(clippy, pub_enum_variant_names)]
 
 enum FakeCallType {
     CALL, CREATE
@@ -85,6 +85,21 @@ enum NonCaps { //~ ERROR: All variants have the same prefix: `Prefix`
     Prefix的,
     PrefixTea,
     PrefixCake,
+}
+
+pub enum PubSeall { //~ ERROR: All variants have the same prefix:
+    WithOutCake,
+    WithOutTea,
+    WithOut,
+}
+
+#[allow(pub_enum_variant_names)]
+mod allowed {
+    pub enum PubAllowed {
+        SomeThis,
+        SomeThat,
+        SomeOtherWhat,
+    }
 }
 
 fn main() {}


### PR DESCRIPTION
The rationale for this is that changing a public API is a breaking change and "having a nice name" is insufficient motivation to do so.
