### PR TITLE
Remove redundant labels in tests

### DIFF
--- a/tests/run-pass/deprecated.rs
+++ b/tests/run-pass/deprecated.rs
@@ -2,11 +2,11 @@
 #![plugin(clippy)]
 
 #[warn(str_to_string)]
-//~^WARNING: warning: lint str_to_string has been removed: using `str::to_string`
+//~^WARNING: lint str_to_string has been removed: using `str::to_string`
 #[warn(string_to_string)]
-//~^WARNING: warning: lint string_to_string has been removed: using `string::to_string`
+//~^WARNING: lint string_to_string has been removed: using `string::to_string`
 #[warn(unstable_as_slice)]
-//~^WARNING: warning: lint unstable_as_slice has been removed: `Vec::as_slice` has been stabilized
+//~^WARNING: lint unstable_as_slice has been removed: `Vec::as_slice` has been stabilized
 #[warn(unstable_as_mut_slice)]
-//~^WARNING: warning: lint unstable_as_mut_slice has been removed: `Vec::as_mut_slice` has been stabilized
+//~^WARNING: lint unstable_as_mut_slice has been removed: `Vec::as_mut_slice` has been stabilized
 fn main() {}


### PR DESCRIPTION
See https://github.com/laumann/compiletest-rs/pull/47.