### PR TITLE
Rustup to *rustc 1.14.0-nightly (289f3a4ca 2016-09-29)* and bump to 0.0.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.92 — 2016-09-30
+* Rustup to *rustc 1.14.0-nightly (289f3a4ca 2016-09-29)*
+
 ## 0.0.91 — 2016-09-28
 * Rustup to *rustc 1.13.0-nightly (d0623cf7b 2016-09-26)*
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.91"
+version = "0.0.92"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -25,7 +25,7 @@ test = false
 
 [dependencies]
 # begin automatic update
-clippy_lints = { version = "0.0.91", path = "clippy_lints" }
+clippy_lints = { version = "0.0.92", path = "clippy_lints" }
 # end automatic update
 
 [dev-dependencies]

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.91"
+version = "0.0.92"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ pub fn main() {
         // this check ensures that dependencies are built but not linted and the final crate is
         // linted but not built
         let mut ccc = ClippyCompilerCalls::new(env::args().any(|s| s == "-Zno-trans"));
-        let (result, _) = rustc_driver::run_compiler(&args, &mut ccc);
+        let (result, _) = rustc_driver::run_compiler(&args, &mut ccc, None, None);
 
         if let Err(err_count) = result {
             if err_count > 0 {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/36760.