### PR TITLE
Added ok if let lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,7 @@ All notable changes to this project will be documented in this file.
 [`for_loop_over_option`]: https://github.com/Manishearth/rust-clippy/wiki#for_loop_over_option
 [`for_loop_over_result`]: https://github.com/Manishearth/rust-clippy/wiki#for_loop_over_result
 [`identity_op`]: https://github.com/Manishearth/rust-clippy/wiki#identity_op
+[`if_let_some_result`]: https://github.com/Manishearth/rust-clippy/wiki#if_let_some_result
 [`if_not_else`]: https://github.com/Manishearth/rust-clippy/wiki#if_not_else
 [`if_same_then_else`]: https://github.com/Manishearth/rust-clippy/wiki#if_same_then_else
 [`ifs_same_cond`]: https://github.com/Manishearth/rust-clippy/wiki#ifs_same_cond

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ You can check out this great service at [clippy.bashy.io](https://clippy.bashy.i
 
 ## Lints
 
-There are 171 lints included in this crate:
+There are 172 lints included in this crate:
 
 name                                                                                                                 | default | triggers on
 ---------------------------------------------------------------------------------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------
@@ -230,6 +230,7 @@ name                                                                            
 [for_loop_over_option](https://github.com/Manishearth/rust-clippy/wiki#for_loop_over_option)                         | warn    | for-looping over an `Option`, which is more clearly expressed as an `if let`
 [for_loop_over_result](https://github.com/Manishearth/rust-clippy/wiki#for_loop_over_result)                         | warn    | for-looping over a `Result`, which is more clearly expressed as an `if let`
 [identity_op](https://github.com/Manishearth/rust-clippy/wiki#identity_op)                                           | warn    | using identity operations, e.g. `x + 0` or `y / 1`
+[if_let_some_result](https://github.com/Manishearth/rust-clippy/wiki#if_let_some_result)                             | warn    | usage of `ok()` in `if let Some(x)` statements is unnecessary, match on `Ok(expr)` instead
 [if_not_else](https://github.com/Manishearth/rust-clippy/wiki#if_not_else)                                           | allow   | `if` branches that could be swapped so no negation operation is necessary on the condition
 [if_same_then_else](https://github.com/Manishearth/rust-clippy/wiki#if_same_then_else)                               | warn    | if with the same *then* and *else* blocks
 [ifs_same_cond](https://github.com/Manishearth/rust-clippy/wiki#ifs_same_cond)                                       | warn    | consecutive `ifs` with the same condition

--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -94,13 +94,13 @@ impl LateLintPass for AssignOps {
                                                expr.span,
                                                "variable appears on both sides of an assignment operation",
                                                |db| {
-                                                   if let (Some(snip_a), Some(snip_r)) = (snippet_opt(cx, assignee.span),
-                                                                                          snippet_opt(cx, rhs.span)) {
-                                                       db.span_suggestion(expr.span,
-                                                                          "replace it with",
-                                                                          format!("{} {}= {}", snip_a, op.node.as_str(), snip_r));
-                                                   }
-                                               });
+                                if let (Some(snip_a), Some(snip_r)) = (snippet_opt(cx, assignee.span),
+                                                                       snippet_opt(cx, rhs.span)) {
+                                    db.span_suggestion(expr.span,
+                                                       "replace it with",
+                                                       format!("{} {}= {}", snip_a, op.node.as_str(), snip_r));
+                                }
+                            });
                         };
                         // lhs op= l op r
                         if SpanlessEq::new(cx).ignore_fn().eq_expr(lhs, l) {
@@ -162,13 +162,13 @@ impl LateLintPass for AssignOps {
                                                expr.span,
                                                "manual implementation of an assign operation",
                                                |db| {
-                                                   if let (Some(snip_a), Some(snip_r)) = (snippet_opt(cx, assignee.span),
-                                                                                          snippet_opt(cx, rhs.span)) {
-                                                       db.span_suggestion(expr.span,
-                                                                          "replace it with",
-                                                                          format!("{} {}= {}", snip_a, op.node.as_str(), snip_r));
-                                                   }
-                                               });
+                                if let (Some(snip_a), Some(snip_r)) = (snippet_opt(cx, assignee.span),
+                                                                       snippet_opt(cx, rhs.span)) {
+                                    db.span_suggestion(expr.span,
+                                                       "replace it with",
+                                                       format!("{} {}= {}", snip_a, op.node.as_str(), snip_r));
+                                }
+                            });
                         }
                     };
                     // a = a op b
@@ -195,23 +195,7 @@ impl LateLintPass for AssignOps {
 fn is_commutative(op: hir::BinOp_) -> bool {
     use rustc::hir::BinOp_::*;
     match op {
-        BiAdd |
-        BiMul |
-        BiAnd |
-        BiOr |
-        BiBitXor |
-        BiBitAnd |
-        BiBitOr |
-        BiEq |
-        BiNe => true,
-        BiSub |
-        BiDiv |
-        BiRem |
-        BiShl |
-        BiShr |
-        BiLt |
-        BiLe |
-        BiGe |
-        BiGt => false,
+        BiAdd | BiMul | BiAnd | BiOr | BiBitXor | BiBitAnd | BiBitOr | BiEq | BiNe => true,
+        BiSub | BiDiv | BiRem | BiShl | BiShr | BiLt | BiLe | BiGe | BiGt => false,
     }
 }

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -121,21 +121,25 @@ impl LateLintPass for AttrPass {
                                 }
                                 if let Some(mut sugg) = snippet_opt(cx, attr.span) {
                                     if sugg.len() > 1 {
-                                        span_lint_and_then(cx, USELESS_ATTRIBUTE, attr.span,
+                                        span_lint_and_then(cx,
+                                                           USELESS_ATTRIBUTE,
+                                                           attr.span,
                                                            "useless lint attribute",
                                                            |db| {
-                                            sugg.insert(1, '!');
-                                            db.span_suggestion(attr.span, "if you just forgot a `!`, use", sugg);
-                                        });
+                                                               sugg.insert(1, '!');
+                                                               db.span_suggestion(attr.span,
+                                                                                  "if you just forgot a `!`, use",
+                                                                                  sugg);
+                                                           });
                                     }
                                 }
-                            },
-                            _ => {},
+                            }
+                            _ => {}
                         }
                     }
                 }
-            },
-            _ => {},
+            }
+            _ => {}
         }
     }
 

--- a/clippy_lints/src/bit_mask.rs
+++ b/clippy_lints/src/bit_mask.rs
@@ -247,16 +247,16 @@ fn fetch_int_literal(cx: &LateContext, lit: &Expr) -> Option<u64> {
         }
         ExprPath(_, _) => {
             {
-                // Important to let the borrow expire before the const lookup to avoid double
-                // borrowing.
-                let def_map = cx.tcx.def_map.borrow();
-                match def_map.get(&lit.id) {
-                    Some(&PathResolution { base_def: Def::Const(def_id), .. }) => Some(def_id),
-                    _ => None,
+                    // Important to let the borrow expire before the const lookup to avoid double
+                    // borrowing.
+                    let def_map = cx.tcx.def_map.borrow();
+                    match def_map.get(&lit.id) {
+                        Some(&PathResolution { base_def: Def::Const(def_id), .. }) => Some(def_id),
+                        _ => None,
+                    }
                 }
-            }
-            .and_then(|def_id| lookup_const_by_id(cx.tcx, def_id, None))
-            .and_then(|(l, _ty)| fetch_int_literal(cx, l))
+                .and_then(|def_id| lookup_const_by_id(cx.tcx, def_id, None))
+                .and_then(|(l, _ty)| fetch_int_literal(cx, l))
         }
         _ => None,
     }

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -120,12 +120,7 @@ fn check_collapsible_maybe_if_let(cx: &EarlyContext, else_: &ast::Expr) {
     }}
 }
 
-fn check_collapsible_no_if_let(
-    cx: &EarlyContext,
-    expr: &ast::Expr,
-    check: &ast::Expr,
-    then: &ast::Block,
-) {
+fn check_collapsible_no_if_let(cx: &EarlyContext, expr: &ast::Expr, check: &ast::Expr, then: &ast::Block) {
     if_let_chain! {[
         let Some(inner) = expr_block(then),
         let ast::ExprKind::If(ref check_inner, ref content, None) = inner.node,
@@ -151,7 +146,8 @@ fn expr_block(block: &ast::Block) -> Option<&ast::Expr> {
 
     if let (Some(stmt), None) = (it.next(), it.next()) {
         match stmt.node {
-            ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => Some(expr),
+            ast::StmtKind::Expr(ref expr) |
+            ast::StmtKind::Semi(ref expr) => Some(expr),
             _ => None,
         }
     } else {

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -93,9 +93,7 @@ impl PartialEq for Constant {
                 // `Fw32 == Fw64` so don’t compare them
                 match (ls.parse::<f64>(), rs.parse::<f64>()) {
                     // mem::transmute is required to catch non-matching 0.0, -0.0, and NaNs
-                    (Ok(l), Ok(r)) => unsafe {
-                        mem::transmute::<f64, u64>(l) == mem::transmute::<f64, u64>(r)
-                    },
+                    (Ok(l), Ok(r)) => unsafe { mem::transmute::<f64, u64>(l) == mem::transmute::<f64, u64>(r) },
                     _ => false,
                 }
             }
@@ -162,11 +160,13 @@ impl PartialOrd for Constant {
             (&Constant::Int(l), &Constant::Int(r)) => Some(l.cmp(&r)),
             (&Constant::Float(ref ls, _), &Constant::Float(ref rs, _)) => {
                 match (ls.parse::<f64>(), rs.parse::<f64>()) {
-                    (Ok(ref l), Ok(ref r)) => match (l.partial_cmp(r), l.is_sign_positive() == r.is_sign_positive()) {
-                        // Check for comparison of -0.0 and 0.0
-                        (Some(Ordering::Equal), false) => None,
-                        (x, _) => x
-                    },
+                    (Ok(ref l), Ok(ref r)) => {
+                        match (l.partial_cmp(r), l.is_sign_positive() == r.is_sign_positive()) {
+                            // Check for comparison of -0.0 and 0.0
+                            (Some(Ordering::Equal), false) => None,
+                            (x, _) => x,
+                        }
+                    }
                     _ => None,
                 }
             }
@@ -292,8 +292,8 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
     /// non-constant part
     fn multi<E: Deref<Target = Expr> + Sized>(&mut self, vec: &[E]) -> Option<Vec<Constant>> {
         vec.iter()
-           .map(|elem| self.expr(elem))
-           .collect::<Option<_>>()
+            .map(|elem| self.expr(elem))
+            .collect::<Option<_>>()
     }
 
     /// lookup a possibly constant expression from a ExprPath

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -72,18 +72,15 @@ pub fn strip_doc_comment_decoration((comment, span): (&str, Span)) -> Vec<(&str,
     }
 
     if comment.starts_with("/*") {
-        return comment[3..comment.len() - 2].lines().map(|line| {
-            let offset = line.as_ptr() as usize - comment.as_ptr() as usize;
-            debug_assert_eq!(offset as u32 as usize, offset);
+        return comment[3..comment.len() - 2]
+            .lines()
+            .map(|line| {
+                let offset = line.as_ptr() as usize - comment.as_ptr() as usize;
+                debug_assert_eq!(offset as u32 as usize, offset);
 
-            (
-                line,
-                Span {
-                    lo: span.lo + BytePos(offset as u32),
-                    ..span
-                }
-            )
-        }).collect();
+                (line, Span { lo: span.lo + BytePos(offset as u32), ..span })
+            })
+            .collect();
     }
 
     panic!("not a doc-comment: {}", comment);
@@ -257,7 +254,7 @@ fn check_doc(cx: &EarlyContext, valid_idents: &[String], docs: &[(&str, Span)]) 
                     let mut lookup_parser = parser.clone();
                     if let (Some((false, $c)), Some((false, $c))) = (lookup_parser.next(), lookup_parser.next()) {
                         *parser = lookup_parser;
-                        // 3 or more ` or ~ open a code block to be closed with the same number of ` or ~
+    // 3 or more ` or ~ open a code block to be closed with the same number of ` or ~
                         let mut open_count = 3;
                         while let Some((false, $c)) = parser.next() {
                             open_count += 1;
@@ -297,7 +294,8 @@ fn check_doc(cx: &EarlyContext, valid_idents: &[String], docs: &[(&str, Span)]) 
         match parser.next() {
             Some((new_line, c)) => {
                 match c {
-                    '#' if new_line => { // don’t warn on titles
+                    '#' if new_line => {
+                        // don’t warn on titles
                         parser.next_line();
                     }
                     '`' => {
@@ -384,8 +382,7 @@ fn check_word(cx: &EarlyContext, valid_idents: &[String], word: &str, span: Span
             s
         };
 
-        s.chars().all(char::is_alphanumeric) &&
-        s.chars().filter(|&c| c.is_uppercase()).take(2).count() > 1 &&
+        s.chars().all(char::is_alphanumeric) && s.chars().filter(|&c| c.is_uppercase()).take(2).count() > 1 &&
         s.chars().filter(|&c| c.is_lowercase()).take(1).count() > 0
     }
 

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -78,7 +78,8 @@ impl LateLintPass for HashMapLint {
     }
 }
 
-fn check_cond<'a, 'tcx, 'b>(cx: &'a LateContext<'a, 'tcx>, check: &'b Expr) -> Option<(&'static str, &'b Expr, &'b Expr)> {
+fn check_cond<'a, 'tcx, 'b>(cx: &'a LateContext<'a, 'tcx>, check: &'b Expr)
+                            -> Option<(&'static str, &'b Expr, &'b Expr)> {
     if_let_chain! {[
         let ExprMethodCall(ref name, _, ref params) = check.node,
         params.len() >= 2,

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -78,7 +78,10 @@ pub struct EnumVariantNames {
 
 impl EnumVariantNames {
     pub fn new(threshold: u64) -> EnumVariantNames {
-        EnumVariantNames { modules: Vec::new(), threshold: threshold }
+        EnumVariantNames {
+            modules: Vec::new(),
+            threshold: threshold,
+        }
     }
 }
 
@@ -108,8 +111,8 @@ fn partial_rmatch(post: &str, name: &str) -> usize {
 
 // FIXME: #600
 #[allow(while_let_on_iterator)]
-fn check_variant(cx: &EarlyContext, threshold: u64, def: &EnumDef, item_name: &str,
-                 item_name_chars: usize, span: Span) {
+fn check_variant(cx: &EarlyContext, threshold: u64, def: &EnumDef, item_name: &str, item_name_chars: usize,
+                 span: Span) {
     if (def.variants.len() as u64) < threshold {
         return;
     }
@@ -200,7 +203,10 @@ impl EarlyLintPass for EnumVariantNames {
                 if !mod_camel.is_empty() {
                     if mod_name == &item_name {
                         if let ItemKind::Mod(..) = item.node {
-                            span_lint(cx, MODULE_INCEPTION, item.span, "module has the same name as its containing module");
+                            span_lint(cx,
+                                      MODULE_INCEPTION,
+                                      item.span,
+                                      "module has the same name as its containing module");
                         }
                     }
                     if item.vis == Visibility::Public {

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -48,19 +48,7 @@ impl LateLintPass for EqOp {
 
 fn is_valid_operator(op: &BinOp) -> bool {
     match op.node {
-        BiSub |
-        BiDiv |
-        BiEq |
-        BiLt |
-        BiLe |
-        BiGt |
-        BiGe |
-        BiNe |
-        BiAnd |
-        BiOr |
-        BiBitXor |
-        BiBitAnd |
-        BiBitOr => true,
+        BiSub | BiDiv | BiEq | BiLt | BiLe | BiGt | BiGe | BiNe | BiAnd | BiOr | BiBitXor | BiBitAnd | BiBitOr => true,
         _ => false,
     }
 }

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -47,7 +47,7 @@ fn is_non_trait_box(ty: ty::Ty) -> bool {
     }
 }
 
-struct EscapeDelegate<'a, 'tcx: 'a+'gcx, 'gcx: 'a> {
+struct EscapeDelegate<'a, 'tcx: 'a + 'gcx, 'gcx: 'a> {
     tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
     set: NodeSet,
     infcx: &'a InferCtxt<'a, 'gcx, 'gcx>,
@@ -91,7 +91,7 @@ impl LateLintPass for Pass {
     }
 }
 
-impl<'a, 'tcx: 'a+'gcx, 'gcx: 'a> Delegate<'tcx> for EscapeDelegate<'a, 'tcx, 'gcx> {
+impl<'a, 'tcx: 'a + 'gcx, 'gcx: 'a> Delegate<'tcx> for EscapeDelegate<'a, 'tcx, 'gcx> {
     fn consume(&mut self, _: NodeId, _: Span, cmt: cmt<'tcx>, mode: ConsumeMode) {
         if let Categorization::Local(lid) = cmt.cat {
             if self.set.contains(&lid) {
@@ -150,10 +150,10 @@ impl<'a, 'tcx: 'a+'gcx, 'gcx: 'a> Delegate<'tcx> for EscapeDelegate<'a, 'tcx, 'g
         if let Categorization::Local(lid) = cmt.cat {
             if self.set.contains(&lid) {
                 if let Some(&AutoAdjustment::AdjustDerefRef(adj)) = self.tcx
-                                                                        .tables
-                                                                        .borrow()
-                                                                        .adjustments
-                                                                        .get(&borrow_id) {
+                    .tables
+                    .borrow()
+                    .adjustments
+                    .get(&borrow_id) {
                     if LoanCause::AutoRef == loan_cause {
                         // x.foo()
                         if adj.autoderefs == 0 {
@@ -165,12 +165,12 @@ impl<'a, 'tcx: 'a+'gcx, 'gcx: 'a> Delegate<'tcx> for EscapeDelegate<'a, 'tcx, 'g
                 } else if LoanCause::AddrOf == loan_cause {
                     // &x
                     if let Some(&AutoAdjustment::AdjustDerefRef(adj)) = self.tcx
-                                                                            .tables
-                                                                            .borrow()
-                                                                            .adjustments
-                                                                            .get(&self.tcx
-                                                                                      .map
-                                                                                      .get_parent_node(borrow_id)) {
+                        .tables
+                        .borrow()
+                        .adjustments
+                        .get(&self.tcx
+                            .map
+                            .get_parent_node(borrow_id)) {
                         if adj.autoderefs <= 1 {
                             // foo(&x) where no extra autoreffing is happening
                             self.set.remove(&lid);
@@ -188,7 +188,7 @@ impl<'a, 'tcx: 'a+'gcx, 'gcx: 'a> Delegate<'tcx> for EscapeDelegate<'a, 'tcx, 'g
     fn mutate(&mut self, _: NodeId, _: Span, _: cmt<'tcx>, _: MutateMode) {}
 }
 
-impl<'a, 'tcx: 'a+'gcx, 'gcx: 'a> EscapeDelegate<'a, 'tcx, 'gcx> {
+impl<'a, 'tcx: 'a + 'gcx, 'gcx: 'a> EscapeDelegate<'a, 'tcx, 'gcx> {
     fn is_large_box(&self, ty: ty::Ty<'gcx>) -> bool {
         // Large types need to be boxed to avoid stack
         // overflows.
@@ -200,7 +200,7 @@ impl<'a, 'tcx: 'a+'gcx, 'gcx: 'a> EscapeDelegate<'a, 'tcx, 'gcx> {
                 } else {
                     false
                 }
-            },
+            }
             _ => false,
         }
     }

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -70,8 +70,7 @@ fn check_closure(cx: &LateContext, expr: &Expr) {
                     // Is it an unsafe function? They don't implement the closure traits
                     ty::TyFnDef(_, _, fn_ty) |
                     ty::TyFnPtr(fn_ty) => {
-                        if fn_ty.unsafety == Unsafety::Unsafe ||
-                           fn_ty.sig.skip_binder().output.sty == ty::TyNever {
+                        if fn_ty.unsafety == Unsafety::Unsafe || fn_ty.sig.skip_binder().output.sty == ty::TyNever {
                             return;
                         }
                     }

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -71,8 +71,7 @@ impl LateLintPass for Pass {
 
 /// Returns the slice of format string parts in an `Arguments::new_v1` call.
 /// Public because it's shared with a lint in print.rs.
-pub fn get_argument_fmtstr_parts<'a, 'b>(cx: &LateContext<'a, 'b>, expr: &'a Expr)
-                                         -> Option<Vec<&'a str>> {
+pub fn get_argument_fmtstr_parts<'a, 'b>(cx: &LateContext<'a, 'b>, expr: &'a Expr) -> Option<Vec<&'a str>> {
     if_let_chain! {[
         let ExprBlock(ref block) = expr.node,
         block.stmts.len() == 1,

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -69,7 +69,8 @@ impl LintPass for Functions {
 }
 
 impl LateLintPass for Functions {
-    fn check_fn(&mut self, cx: &LateContext, kind: intravisit::FnKind, decl: &hir::FnDecl, block: &hir::Block, span: Span, nodeid: ast::NodeId) {
+    fn check_fn(&mut self, cx: &LateContext, kind: intravisit::FnKind, decl: &hir::FnDecl, block: &hir::Block,
+                span: Span, nodeid: ast::NodeId) {
         use rustc::hir::map::Node::*;
 
         let is_impl = if let Some(NodeItem(item)) = cx.tcx.map.find(cx.tcx.map.get_parent_node(nodeid)) {
@@ -90,7 +91,7 @@ impl LateLintPass for Functions {
             match kind {
                 hir::intravisit::FnKind::Method(_, &hir::MethodSig { abi: Abi::Rust, .. }, _, _) |
                 hir::intravisit::FnKind::ItemFn(_, _, _, _, Abi::Rust, _, _) => self.check_arg_number(cx, decl, span),
-                _ => {},
+                _ => {}
             }
         }
 
@@ -122,7 +123,8 @@ impl Functions {
         }
     }
 
-    fn check_raw_ptr(&self, cx: &LateContext, unsafety: hir::Unsafety, decl: &hir::FnDecl, block: &hir::Block, nodeid: ast::NodeId) {
+    fn check_raw_ptr(&self, cx: &LateContext, unsafety: hir::Unsafety, decl: &hir::FnDecl, block: &hir::Block,
+                     nodeid: ast::NodeId) {
         if unsafety == hir::Unsafety::Normal && cx.access_levels.is_exported(nodeid) {
             let raw_ptrs = decl.inputs.iter().filter_map(|arg| raw_ptr_arg(cx, arg)).collect::<HashSet<_>>();
 

--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -47,9 +47,10 @@ impl EarlyLintPass for ItemsAfterStatements {
         }
 
         // skip initial items
-        let stmts = item.stmts.iter()
-                              .map(|stmt| &stmt.node)
-                              .skip_while(|s| matches!(**s, StmtKind::Item(..)));
+        let stmts = item.stmts
+            .iter()
+            .map(|stmt| &stmt.node)
+            .skip_while(|s| matches!(**s, StmtKind::Item(..)));
 
         // lint on all further items
         for stmt in stmts {

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -104,8 +104,7 @@ fn check_trait_items(cx: &LateContext, item: &Item, trait_items: &[TraitItem]) {
                 span_lint(cx,
                           LEN_WITHOUT_IS_EMPTY,
                           i.span,
-                          &format!("trait `{}` has a `len` method but no `is_empty` method",
-                                   item.name));
+                          &format!("trait `{}` has a `len` method but no `is_empty` method", item.name));
             }
         }
     }
@@ -138,9 +137,7 @@ fn check_impl_items(cx: &LateContext, item: &Item, impl_items: &[ImplItem]) {
             span_lint(cx,
                       LEN_WITHOUT_IS_EMPTY,
                       i.span,
-                      &format!("item `{}` has a public `len` method but {} `is_empty` method",
-                               ty,
-                               is_empty));
+                      &format!("item `{}` has a public `len` method but {} `is_empty` method", ty, is_empty));
         }
     }
 }
@@ -195,9 +192,7 @@ fn has_is_empty(cx: &LateContext, expr: &Expr) -> bool {
     /// Check the inherent impl's items for an `is_empty(self)` method.
     fn has_is_empty_impl(cx: &LateContext, id: DefId) -> bool {
         cx.tcx.inherent_impls.borrow()[&id].iter().any(|imp| {
-            cx.tcx.impl_or_trait_items(*imp).iter().any(|item| {
-                is_is_empty(&cx.tcx.impl_or_trait_item(*item))
-            })
+            cx.tcx.impl_or_trait_items(*imp).iter().any(|item| is_is_empty(&cx.tcx.impl_or_trait_item(*item)))
         })
     }
 
@@ -205,9 +200,9 @@ fn has_is_empty(cx: &LateContext, expr: &Expr) -> bool {
     match ty.sty {
         ty::TyTrait(_) => {
             cx.tcx
-              .impl_or_trait_items(ty.ty_to_def_id().expect("trait impl not found"))
-              .iter()
-              .any(|item| is_is_empty(&cx.tcx.impl_or_trait_item(*item)))
+                .impl_or_trait_items(ty.ty_to_def_id().expect("trait impl not found"))
+                .iter()
+                .any(|item| is_is_empty(&cx.tcx.impl_or_trait_item(*item)))
         }
         ty::TyProjection(_) => ty.ty_to_def_id().map_or(false, |id| has_is_empty_impl(cx, id)),
         ty::TyAdt(id, _) => has_is_empty_impl(cx, id.did),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -106,6 +106,7 @@ pub mod neg_multiply;
 pub mod new_without_default;
 pub mod no_effect;
 pub mod non_expressive_names;
+pub mod ok_if_let;
 pub mod open_options;
 pub mod overflow_check_conditional;
 pub mod panic;
@@ -254,6 +255,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box let_if_seq::LetIfSeq);
     reg.register_late_lint_pass(box eval_order_dependence::EvalOrderDependence);
     reg.register_late_lint_pass(box missing_doc::MissingDoc::new());
+    reg.register_late_lint_pass(box ok_if_let::OkIfLetPass);
 
     reg.register_lint_group("clippy_restrictions", vec![
         arithmetic::FLOAT_ARITHMETIC,
@@ -403,6 +405,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         no_effect::NO_EFFECT,
         no_effect::UNNECESSARY_OPERATION,
         non_expressive_names::MANY_SINGLE_CHAR_NAMES,
+        ok_if_let::OK_IF_LET,
         open_options::NONSENSICAL_OPEN_OPTIONS,
         overflow_check_conditional::OVERFLOW_CHECK_CONDITIONAL,
         panic::PANIC_PARAMS,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -405,7 +405,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         no_effect::NO_EFFECT,
         no_effect::UNNECESSARY_OPERATION,
         non_expressive_names::MANY_SINGLE_CHAR_NAMES,
-        ok_if_let::OK_IF_LET,
+        ok_if_let::IF_LET_SOME_RESULT,
         open_options::NONSENSICAL_OPEN_OPTIONS,
         overflow_check_conditional::OVERFLOW_CHECK_CONDITIONAL,
         panic::PANIC_PARAMS,

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -87,12 +87,12 @@ enum RefLt {
 fn bound_lifetimes(bound: &TyParamBound) -> HirVec<&Lifetime> {
     if let TraitTyParamBound(ref trait_ref, _) = *bound {
         trait_ref.trait_ref
-                 .path
-                 .segments
-                 .last()
-                 .expect("a path must have at least one segment")
-                 .parameters
-                 .lifetimes()
+            .path
+            .segments
+            .last()
+            .expect("a path must have at least one segment")
+            .parameters
+            .lifetimes()
     } else {
         HirVec::new()
     }
@@ -104,8 +104,8 @@ fn check_fn_inner(cx: &LateContext, decl: &FnDecl, generics: &Generics, span: Sp
     }
 
     let bounds_lts = generics.ty_params
-                             .iter()
-                             .flat_map(|typ| typ.bounds.iter().flat_map(bound_lifetimes));
+        .iter()
+        .flat_map(|typ| typ.bounds.iter().flat_map(bound_lifetimes));
 
     if could_use_elision(cx, decl, &generics.lifetimes, bounds_lts) {
         span_lint(cx,
@@ -344,9 +344,9 @@ impl<'v> Visitor<'v> for LifetimeChecker {
 
 fn report_extra_lifetimes(cx: &LateContext, func: &FnDecl, generics: &Generics) {
     let hs = generics.lifetimes
-                     .iter()
-                     .map(|lt| (lt.lifetime.name, lt.lifetime.span))
-                     .collect();
+        .iter()
+        .map(|lt| (lt.lifetime.name, lt.lifetime.span))
+        .collect();
     let mut checker = LifetimeChecker(hs);
 
     walk_generics(&mut checker, generics);

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -14,9 +14,9 @@ use std::collections::HashMap;
 use syntax::ast;
 use utils::sugg;
 
-use utils::{snippet, span_lint, get_parent_expr, match_trait_method, match_type, multispan_sugg,
-            in_external_macro, is_refutable, span_help_and_lint, is_integer_literal,
-            get_enclosing_block, span_lint_and_then, higher, walk_ptrs_ty};
+use utils::{snippet, span_lint, get_parent_expr, match_trait_method, match_type, multispan_sugg, in_external_macro,
+            is_refutable, span_help_and_lint, is_integer_literal, get_enclosing_block, span_lint_and_then, higher,
+            walk_ptrs_ty};
 use utils::paths;
 
 /// **What it does:** Checks for looping over the range of `0..len` of some
@@ -315,8 +315,7 @@ impl LateLintPass for Pass {
                     match *source {
                         MatchSource::Normal |
                         MatchSource::IfLetDesugar { .. } => {
-                            if arms.len() == 2 &&
-                               arms[0].pats.len() == 1 && arms[0].guard.is_none() &&
+                            if arms.len() == 2 && arms[0].pats.len() == 1 && arms[0].guard.is_none() &&
                                arms[1].pats.len() == 1 && arms[1].guard.is_none() &&
                                is_break_expr(&arms[1].body) {
                                 if in_external_macro(cx, expr.span) {
@@ -351,8 +350,7 @@ impl LateLintPass for Pass {
                     &ExprMethodCall(method_name, _, ref method_args)) = (pat, &match_expr.node) {
                 let iter_expr = &method_args[0];
                 if let Some(lhs_constructor) = path.segments.last() {
-                    if method_name.node.as_str() == "next" &&
-                       match_trait_method(cx, match_expr, &paths::ITERATOR) &&
+                    if method_name.node.as_str() == "next" && match_trait_method(cx, match_expr, &paths::ITERATOR) &&
                        lhs_constructor.name.as_str() == "Some" &&
                        !is_refutable(cx, &pat_args[0]) &&
                        !is_iterator_used_after_while_let(cx, iter_expr) {
@@ -363,10 +361,10 @@ impl LateLintPass for Pass {
                                            expr.span,
                                            "this loop could be written as a `for` loop",
                                            |db| {
-                        db.span_suggestion(expr.span,
+                                               db.span_suggestion(expr.span,
                                            "try",
                                            format!("for {} in {} {{ .. }}", loop_var, iterator));
-                        });
+                                           });
                     }
                 }
             }
@@ -414,9 +412,9 @@ fn check_for_loop_range(cx: &LateContext, pat: &Pat, arg: &Expr, body: &Expr, ex
             // linting condition: we only indexed one variable
             if visitor.indexed.len() == 1 {
                 let (indexed, indexed_extent) = visitor.indexed
-                                                       .into_iter()
-                                                       .next()
-                                                       .unwrap_or_else(|| unreachable!() /* len == 1 */);
+                    .into_iter()
+                    .next()
+                    .unwrap_or_else(|| unreachable!() /* len == 1 */);
 
                 // ensure that the indexed variable was declared before the loop, see #601
                 if let Some(indexed_extent) = indexed_extent {
@@ -443,9 +441,7 @@ fn check_for_loop_range(cx: &LateContext, pat: &Pat, arg: &Expr, body: &Expr, ex
                                 let end = sugg::Sugg::hir(cx, end, "<count>");
                                 format!(".take({})", end + sugg::ONE)
                             }
-                            ast::RangeLimits::HalfOpen => {
-                                format!(".take({})", snippet(cx, end.span, ".."))
-                            }
+                            ast::RangeLimits::HalfOpen => format!(".take({})", snippet(cx, end.span, "..")),
                         }
                     }
                 } else {
@@ -458,10 +454,10 @@ fn check_for_loop_range(cx: &LateContext, pat: &Pat, arg: &Expr, body: &Expr, ex
                                        expr.span,
                                        &format!("the loop variable `{}` is used to index `{}`", ident.node, indexed),
                                        |db| {
-                        multispan_sugg(db, "consider using an iterator".to_string(), &[
-                            (pat.span, &format!("({}, <item>)", ident.node)),
-                            (arg.span, &format!("{}.iter().enumerate(){}{}", indexed, take, skip)),
-                        ]);
+                        multispan_sugg(db,
+                                       "consider using an iterator".to_string(),
+                                       &[(pat.span, &format!("({}, <item>)", ident.node)),
+                                         (arg.span, &format!("{}.iter().enumerate(){}{}", indexed, take, skip))]);
                     });
                 } else {
                     let repl = if starts_at_zero && take.is_empty() {
@@ -532,15 +528,14 @@ fn check_for_loop_reverse_range(cx: &LateContext, arg: &Expr, expr: &Expr) {
                                        expr.span,
                                        "this range is empty so this for loop will never run",
                                        |db| {
-                                           db.span_suggestion(arg.span,
-                                                              "consider using the following if \
-                                                               you are attempting to iterate \
-                                                               over this range in reverse",
-                                                              format!("({end}{dots}{start}).rev()",
+                        db.span_suggestion(arg.span,
+                                           "consider using the following if you are attempting to iterate over this \
+                                            range in reverse",
+                                           format!("({end}{dots}{start}).rev()",
                                                                       end=end_snippet,
                                                                       dots=dots,
                                                                       start=start_snippet));
-                                       });
+                    });
                 } else if eq && limits != ast::RangeLimits::Closed {
                     // if they are equal, it's also problematic - this loop
                     // will never run.
@@ -688,10 +683,10 @@ fn check_for_loop_over_map_kv(cx: &LateContext, pat: &Pat, arg: &Expr, body: &Ex
                                    &format!("you seem to want to iterate on a map's {}s", kind),
                                    |db| {
                     let map = sugg::Sugg::hir(cx, arg, "map");
-                    multispan_sugg(db, "use the corresponding method".into(), &[
-                        (pat_span, &snippet(cx, new_pat_span, kind)),
-                        (arg_span, &format!("{}.{}s()", map.maybe_par(), kind)),
-                    ]);
+                    multispan_sugg(db,
+                                   "use the corresponding method".into(),
+                                   &[(pat_span, &snippet(cx, new_pat_span, kind)),
+                                     (arg_span, &format!("{}.{}s()", map.maybe_par(), kind))]);
                 });
             }
         }
@@ -871,7 +866,8 @@ fn extract_first_expr(block: &Block) -> Option<&Expr> {
         Some(ref expr) if block.stmts.is_empty() => Some(expr),
         None if !block.stmts.is_empty() => {
             match block.stmts[0].node {
-                StmtExpr(ref expr, _) | StmtSemi(ref expr, _) => Some(expr),
+                StmtExpr(ref expr, _) |
+                StmtSemi(ref expr, _) => Some(expr),
                 StmtDecl(..) => None,
             }
         }

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -1,8 +1,8 @@
 use rustc::lint::*;
 use rustc::hir::*;
 use syntax::ast;
-use utils::{is_adjusted, match_path, match_trait_method, match_type, paths, snippet,
-            span_help_and_lint, walk_ptrs_ty, walk_ptrs_ty_depth};
+use utils::{is_adjusted, match_path, match_trait_method, match_type, paths, snippet, span_help_and_lint, walk_ptrs_ty,
+            walk_ptrs_ty_depth};
 
 /// **What it does:** Checks for mapping `clone()` over an iterator.
 ///

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -291,7 +291,7 @@ fn check_match_bool(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr) {
                 }
             }
 
-       });
+        });
     }
 }
 
@@ -320,10 +320,10 @@ fn check_match_ref_pats(cx: &LateContext, ex: &Expr, arms: &[Arm], source: Match
                                expr.span,
                                "you don't need to add `&` to both the expression and the patterns",
                                |db| {
-                let inner = Sugg::hir(cx, inner, "..");
-                let template = match_template(expr.span, source, inner);
-                db.span_suggestion(expr.span, "try", template);
-            });
+                                   let inner = Sugg::hir(cx, inner, "..");
+                                   let template = match_template(expr.span, source, inner);
+                                   db.span_suggestion(expr.span, "try", template);
+                               });
         } else {
             span_lint_and_then(cx,
                                MATCH_REF_PATS,
@@ -346,11 +346,12 @@ fn all_ranges(cx: &LateContext, arms: &[Arm]) -> Vec<SpannedRange<ConstVal>> {
     arms.iter()
         .flat_map(|arm| {
             if let Arm { ref pats, guard: None, .. } = *arm {
-                pats.iter()
-            } else {
-                [].iter()
-            }.filter_map(|pat| {
-                if_let_chain! {[
+                    pats.iter()
+                } else {
+                    [].iter()
+                }
+                .filter_map(|pat| {
+                    if_let_chain! {[
                     let PatKind::Range(ref lhs, ref rhs) = pat.node,
                     let Ok(lhs) = eval_const_expr_partial(cx.tcx, lhs, ExprTypeChecked, None),
                     let Ok(rhs) = eval_const_expr_partial(cx.tcx, rhs, ExprTypeChecked, None)
@@ -358,15 +359,15 @@ fn all_ranges(cx: &LateContext, arms: &[Arm]) -> Vec<SpannedRange<ConstVal>> {
                     return Some(SpannedRange { span: pat.span, node: (lhs, rhs) });
                 }}
 
-                if_let_chain! {[
+                    if_let_chain! {[
                     let PatKind::Lit(ref value) = pat.node,
                     let Ok(value) = eval_const_expr_partial(cx.tcx, value, ExprTypeChecked, None)
                 ], {
                     return Some(SpannedRange { span: pat.span, node: (value.clone(), value) });
                 }}
 
-                None
-            })
+                    None
+                })
         })
         .collect()
 }
@@ -383,17 +384,17 @@ type TypedRanges = Vec<SpannedRange<ConstInt>>;
 /// `Uint` and `Int` probably don't make sense.
 fn type_ranges(ranges: &[SpannedRange<ConstVal>]) -> TypedRanges {
     ranges.iter()
-          .filter_map(|range| {
-              if let (ConstVal::Integral(start), ConstVal::Integral(end)) = range.node {
-                  Some(SpannedRange {
-                      span: range.span,
-                      node: (start, end),
-                  })
-              } else {
-                  None
-              }
-          })
-          .collect()
+        .filter_map(|range| {
+            if let (ConstVal::Integral(start), ConstVal::Integral(end)) = range.node {
+                Some(SpannedRange {
+                    span: range.span,
+                    node: (start, end),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn is_unit_expr(expr: &Expr) -> bool {
@@ -406,15 +407,15 @@ fn is_unit_expr(expr: &Expr) -> bool {
 
 fn has_only_ref_pats(arms: &[Arm]) -> bool {
     let mapped = arms.iter()
-                     .flat_map(|a| &a.pats)
-                     .map(|p| {
-                         match p.node {
-                             PatKind::Ref(..) => Some(true),  // &-patterns
-                             PatKind::Wild => Some(false),   // an "anything" wildcard is also fine
-                             _ => None,                    // any other pattern is not fine
-                         }
-                     })
-                     .collect::<Option<Vec<bool>>>();
+        .flat_map(|a| &a.pats)
+        .map(|p| {
+            match p.node {
+                PatKind::Ref(..) => Some(true),  // &-patterns
+                PatKind::Wild => Some(false),   // an "anything" wildcard is also fine
+                _ => None,                    // any other pattern is not fine
+            }
+        })
+        .collect::<Option<Vec<bool>>>();
     // look for Some(v) where there's at least one true element
     mapped.map_or(false, |v| v.iter().any(|el| *el))
 }

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -9,10 +9,8 @@ use rustc_const_eval::eval_const_expr_partial;
 use rustc_const_math::ConstFloat;
 use syntax::codemap::{Span, Spanned, ExpnFormat};
 use syntax::ptr::P;
-use utils::{
-    get_item_name, get_parent_expr, implements_trait, in_macro, is_integer_literal, match_path,
-    snippet, span_lint, span_lint_and_then, walk_ptrs_ty
-};
+use utils::{get_item_name, get_parent_expr, implements_trait, in_macro, is_integer_literal, match_path, snippet,
+            span_lint, span_lint_and_then, walk_ptrs_ty};
 use utils::sugg::Sugg;
 
 /// **What it does:** Checks for function arguments and let bindings denoted as `ref`.
@@ -237,23 +235,19 @@ impl LateLintPass for Pass {
                 if let Some(name) = get_item_name(cx, expr) {
                     let name = name.as_str();
                     if name == "eq" || name == "ne" || name == "is_nan" || name.starts_with("eq_") ||
-                        name.ends_with("_eq") {
+                       name.ends_with("_eq") {
                         return;
                     }
                 }
-                span_lint_and_then(cx,
-                                   FLOAT_CMP,
-                                   expr.span,
-                                   "strict comparison of f32 or f64",
-                                   |db| {
-                                       let lhs = Sugg::hir(cx, left, "..");
-                                       let rhs = Sugg::hir(cx, right, "..");
+                span_lint_and_then(cx, FLOAT_CMP, expr.span, "strict comparison of f32 or f64", |db| {
+                    let lhs = Sugg::hir(cx, left, "..");
+                    let rhs = Sugg::hir(cx, right, "..");
 
-                                       db.span_suggestion(expr.span,
-                                                          "consider comparing them within some error",
-                                                          format!("({}).abs() < error", lhs - rhs));
-                                       db.span_note(expr.span, "std::f32::EPSILON and std::f64::EPSILON are available.");
-                                   });
+                    db.span_suggestion(expr.span,
+                                       "consider comparing them within some error",
+                                       format!("({}).abs() < error", lhs - rhs));
+                    db.span_note(expr.span, "std::f32::EPSILON and std::f64::EPSILON are available.");
+                });
             } else if op == BiRem && is_integer_literal(right, 1) {
                 span_lint(cx, MODULO_ONE, expr.span, "any number modulo 1 will be 0");
             }
@@ -344,9 +338,8 @@ fn is_allowed(cx: &LateContext, expr: &Expr) -> bool {
             f64: ::std::f64::NEG_INFINITY,
         };
 
-        val.try_cmp(zero) == Ok(Ordering::Equal)
-            || val.try_cmp(infinity) == Ok(Ordering::Equal)
-            || val.try_cmp(neg_infinity) == Ok(Ordering::Equal)
+        val.try_cmp(zero) == Ok(Ordering::Equal) || val.try_cmp(infinity) == Ok(Ordering::Equal) ||
+        val.try_cmp(neg_infinity) == Ok(Ordering::Equal)
     } else {
         false
     }
@@ -412,8 +405,7 @@ fn check_to_owned(cx: &LateContext, expr: &Expr, other: &Expr, left: bool, op: S
 }
 
 fn is_str_arg(cx: &LateContext, args: &[P<Expr>]) -> bool {
-    args.len() == 1 &&
-        matches!(walk_ptrs_ty(cx.tcx.expr_ty(&args[0])).sty, ty::TyStr)
+    args.len() == 1 && matches!(walk_ptrs_ty(cx.tcx.expr_ty(&args[0])).sty, ty::TyStr)
 }
 
 /// Heuristic to see if an expression is used. Should be compatible with `unused_variables`'s idea
@@ -434,16 +426,15 @@ fn is_used(cx: &LateContext, expr: &Expr) -> bool {
 /// `#[derive(...)`] or the like).
 fn in_attributes_expansion(cx: &LateContext, expr: &Expr) -> bool {
     cx.sess().codemap().with_expn_info(expr.span.expn_id, |info_opt| {
-        info_opt.map_or(false, |info| {
-            matches!(info.callee.format, ExpnFormat::MacroAttribute(_))
-        })
+        info_opt.map_or(false, |info| matches!(info.callee.format, ExpnFormat::MacroAttribute(_)))
     })
 }
 
 /// Test whether `def` is a variable defined outside a macro.
 fn non_macro_local(cx: &LateContext, def: &def::Def) -> bool {
     match *def {
-        def::Def::Local(id) | def::Def::Upvar(id, _, _) => {
+        def::Def::Local(id) |
+        def::Def::Upvar(id, _, _) => {
             let id = cx.tcx.map.as_local_node_id(id).expect("That DefId should be valid");
 
             if let Some(span) = cx.tcx.map.opt_span(id) {

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -321,7 +321,7 @@ impl EarlyLintPass for MiscEarly {
                                       "inconsistent casing in hexadecimal literal");
                         }
                     } else if src.starts_with("0b") || src.starts_with("0o") {
-                        /* nothing to do */
+                // nothing to do
                     } else if value != 0 && src.starts_with('0') {
                         span_lint_and_then(cx,
                                            ZERO_PREFIXED_LITERAL,
@@ -352,7 +352,7 @@ impl EarlyLintPass for MiscEarly {
                     }
                 }}
             }
-            _ => ()
+            _ => (),
         }
     }
 

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -1,21 +1,21 @@
-/* This file incorporates work covered by the following copyright and
- * permission notice:
- *   Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
- *   file at the top-level directory of this distribution and at
- *   http://rust-lang.org/COPYRIGHT.
- *
- *   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
- *   http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
- *   <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
- *   option. This file may not be copied, modified, or distributed
- *   except according to those terms.
- */
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//   Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+//   file at the top-level directory of this distribution and at
+//   http://rust-lang.org/COPYRIGHT.
+//
+//   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+//   http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+//   <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+//   option. This file may not be copied, modified, or distributed
+//   except according to those terms.
+//
 
-/* Note: More specifically this lint is largely inspired (aka copied) from *rustc*'s
- * [`missing_doc`].
- *
- * [`missing_doc`]: https://github.com/rust-lang/rust/blob/d6d05904697d89099b55da3331155392f1db9c00/src/librustc_lint/builtin.rs#L246
- */
+// Note: More specifically this lint is largely inspired (aka copied) from *rustc*'s
+// [`missing_doc`].
+//
+// [`missing_doc`]: https://github.com/rust-lang/rust/blob/d6d05904697d89099b55da3331155392f1db9c00/src/librustc_lint/builtin.rs#L246
+//
 
 use rustc::hir;
 use rustc::lint::*;
@@ -51,20 +51,14 @@ impl ::std::default::Default for MissingDoc {
 
 impl MissingDoc {
     pub fn new() -> MissingDoc {
-        MissingDoc {
-            doc_hidden_stack: vec![false],
-        }
+        MissingDoc { doc_hidden_stack: vec![false] }
     }
 
     fn doc_hidden(&self) -> bool {
         *self.doc_hidden_stack.last().expect("empty doc_hidden_stack")
     }
 
-    fn check_missing_docs_attrs(&self,
-                               cx: &LateContext,
-                               attrs: &[ast::Attribute],
-                               sp: Span,
-                               desc: &'static str) {
+    fn check_missing_docs_attrs(&self, cx: &LateContext, attrs: &[ast::Attribute], sp: Span, desc: &'static str) {
         // If we're building a test harness, then warning about
         // documentation is probably not really relevant right now.
         if cx.sess().opts.test {
@@ -82,7 +76,8 @@ impl MissingDoc {
 
         let has_doc = attrs.iter().any(|a| a.is_value_str() && a.name() == "doc");
         if !has_doc {
-            cx.span_lint(MISSING_DOCS_IN_PRIVATE_ITEMS, sp,
+            cx.span_lint(MISSING_DOCS_IN_PRIVATE_ITEMS,
+                         sp,
                          &format!("missing documentation for {}", desc));
         }
     }
@@ -96,8 +91,10 @@ impl LintPass for MissingDoc {
 
 impl LateLintPass for MissingDoc {
     fn enter_lint_attrs(&mut self, _: &LateContext, attrs: &[ast::Attribute]) {
-        let doc_hidden = self.doc_hidden() || attrs.iter().any(|attr| {
-            attr.check_name("doc") && match attr.meta_item_list() {
+        let doc_hidden = self.doc_hidden() ||
+                         attrs.iter().any(|attr| {
+            attr.check_name("doc") &&
+            match attr.meta_item_list() {
                 None => false,
                 Some(l) => attr::list_contains_name(&l[..], "hidden"),
             }
@@ -147,14 +144,16 @@ impl LateLintPass for MissingDoc {
     fn check_impl_item(&mut self, cx: &LateContext, impl_item: &hir::ImplItem) {
         // If the method is an impl for a trait, don't doc.
         let def_id = cx.tcx.map.local_def_id(impl_item.id);
-        match cx.tcx.impl_or_trait_items.borrow()
-                                         .get(&def_id)
-                                         .expect("missing method descriptor?!")
-                                         .container() {
+        match cx.tcx
+            .impl_or_trait_items
+            .borrow()
+            .get(&def_id)
+            .expect("missing method descriptor?!")
+            .container() {
             ty::TraitContainer(_) => return,
             ty::ImplContainer(cid) => {
                 if cx.tcx.impl_trait_ref(cid).is_some() {
-                    return
+                    return;
                 }
             }
         }

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -64,7 +64,10 @@ impl<'a, 'tcx, 'v> intravisit::Visitor<'v> for MutVisitor<'a, 'tcx> {
             intravisit::walk_expr(self, body);
         } else if let hir::ExprAddrOf(hir::MutMutable, ref e) = expr.node {
             if let hir::ExprAddrOf(hir::MutMutable, _) = e.node {
-                span_lint(self.cx, MUT_MUT, expr.span, "generally you want to avoid `&mut &mut _` if possible");
+                span_lint(self.cx,
+                          MUT_MUT,
+                          expr.span,
+                          "generally you want to avoid `&mut &mut _` if possible");
             } else if let TyRef(_, TypeAndMut { mutbl: hir::MutMutable, .. }) = self.cx.tcx.expr_ty(e).sty {
                 span_lint(self.cx,
                           MUT_MUT,
@@ -77,7 +80,10 @@ impl<'a, 'tcx, 'v> intravisit::Visitor<'v> for MutVisitor<'a, 'tcx> {
     fn visit_ty(&mut self, ty: &hir::Ty) {
         if let hir::TyRptr(_, hir::MutTy { ty: ref pty, mutbl: hir::MutMutable }) = ty.node {
             if let hir::TyRptr(_, hir::MutTy { mutbl: hir::MutMutable, .. }) = pty.node {
-                span_lint(self.cx, MUT_MUT, ty.span, "generally you want to avoid `&mut &mut _` if possible");
+                span_lint(self.cx,
+                          MUT_MUT,
+                          ty.span,
+                          "generally you want to avoid `&mut &mut _` if possible");
             }
 
         }

--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -39,10 +39,9 @@ impl LateLintPass for UnnecessaryMutPassed {
         match e.node {
             ExprCall(ref fn_expr, ref arguments) => {
                 let function_type = borrowed_table.node_types
-                                                  .get(&fn_expr.id)
-                                                  .expect("A function with an unknown type is called. \
-                                                           If this happened, the compiler would have \
-                                                           aborted the compilation long ago");
+                    .get(&fn_expr.id)
+                    .expect("A function with an unknown type is called. If this happened, the compiler would have \
+                             aborted the compilation long ago");
                 if let ExprPath(_, ref path) = fn_expr.node {
                     check_arguments(cx, arguments, function_type, &path.to_string());
                 }

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -62,11 +62,7 @@ impl LateLintPass for NeedlessBool {
         if let ExprIf(ref pred, ref then_block, Some(ref else_expr)) = e.node {
             let reduce = |ret, not| {
                 let snip = Sugg::hir(cx, pred, "<predicate>");
-                let snip = if not {
-                    !snip
-                } else {
-                    snip
-                };
+                let snip = if not { !snip } else { snip };
 
                 let hint = if ret {
                     format!("return {}", snip)
@@ -148,7 +144,9 @@ impl LateLintPass for BoolComparison {
                                        e.span,
                                        "equality checks against false can be replaced by a negation",
                                        |db| {
-                                           db.span_suggestion(e.span, "try simplifying it as shown:", (!hint).to_string());
+                                           db.span_suggestion(e.span,
+                                                              "try simplifying it as shown:",
+                                                              (!hint).to_string());
                                        });
                 }
                 (Other, Bool(false)) => {
@@ -158,7 +156,9 @@ impl LateLintPass for BoolComparison {
                                        e.span,
                                        "equality checks against false can be replaced by a negation",
                                        |db| {
-                                           db.span_suggestion(e.span, "try simplifying it as shown:", (!hint).to_string());
+                                           db.span_suggestion(e.span,
+                                                              "try simplifying it as shown:",
+                                                              (!hint).to_string());
                                        });
                 }
                 _ => (),

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -62,10 +62,7 @@ impl LateLintPass for NeedlessBorrow {
             if let TyRef(_, ref tam) = cx.tcx.pat_ty(pat).sty {
                 if tam.mutbl == MutImmutable {
                     if let TyRef(..) = tam.ty.sty {
-                        span_lint(cx,
-                                  NEEDLESS_BORROW,
-                                  pat.span,
-                                  "this pattern creates a reference to a reference")
+                        span_lint(cx, NEEDLESS_BORROW, pat.span, "this pattern creates a reference to a reference")
                     }
                 }
             }

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -90,7 +90,8 @@ impl LintPass for NewWithoutDefault {
 }
 
 impl LateLintPass for NewWithoutDefault {
-    fn check_fn(&mut self, cx: &LateContext, kind: FnKind, decl: &hir::FnDecl, _: &hir::Block, span: Span, id: ast::NodeId) {
+    fn check_fn(&mut self, cx: &LateContext, kind: FnKind, decl: &hir::FnDecl, _: &hir::Block, span: Span,
+                id: ast::NodeId) {
         if in_external_macro(cx, span) {
             return;
         }

--- a/clippy_lints/src/ok_if_let.rs
+++ b/clippy_lints/src/ok_if_let.rs
@@ -1,0 +1,49 @@
+use rustc::lint::*;
+use rustc::hir::*;
+use utils::{method_chain_args, span_help_and_lint};
+/// **What it does:*** Checks for unnecessary ok() in if let.
+///
+/// **Why is this bad?** Calling ok() in if let is unnecessary, instead match on Ok()
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rustc
+/// for result in iter {
+///     if let Some(bench) = try!(result).parse().ok() {
+///         vec.push(bench)
+///     }
+/// }
+/// ```
+declare_lint! {
+    pub OK_IF_LET,
+    Warn,
+    "usage of ok() in if let statements is unnecessary, match on Ok(expr) instead"
+}
+
+#[derive(Copy, Clone)]
+pub struct OkIfLetPass;
+
+impl LintPass for OkIfLetPass {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(OK_IF_LET)
+    }
+}
+
+impl LateLintPass for OkIfLetPass {
+    fn check_expr(&mut self, cx: &LateContext, expr: &Expr) {
+        if_let_chain! {[
+            let ExprMatch(ref op, ref body, ref source) = expr.node, //test if expr is a match
+            let MatchSource::IfLetDesugar { contains_else_clause: _ } = *source, //test if it is an If Let
+            let PatKind::TupleStruct(ref x, _, _)  = body[0].pats[0].node, //get operation
+            let Some(_) = method_chain_args(op, &["ok"]) //test to see if using ok() method
+
+        ], { 
+            if print::path_to_string(x) == "Some" { //if using ok() on a Some, kick in lint
+                span_help_and_lint(cx, OK_IF_LET, expr.span,
+                "Matching on `Some` with `ok()` is redundant",
+                "Consider matching on `Ok()` instead");
+            }
+        }}
+    }
+}

--- a/clippy_lints/src/ok_if_let.rs
+++ b/clippy_lints/src/ok_if_let.rs
@@ -33,7 +33,7 @@ impl LintPass for OkIfLetPass {
 
 impl LateLintPass for OkIfLetPass {
     fn check_expr(&mut self, cx: &LateContext, expr: &Expr) {
-        if_let_chain! {[
+        if_let_chain! {[ //begin checking variables
             let ExprMatch(ref op, ref body, ref source) = expr.node, //test if expr is a match
             let MatchSource::IfLetDesugar { contains_else_clause: _ } = *source, //test if it is an If Let
             let ExprMethodCall(_, _, ref result_types) = op.node, //check is expr.ok() has type Result<T,E>.ok()

--- a/clippy_lints/src/open_options.rs
+++ b/clippy_lints/src/open_options.rs
@@ -71,11 +71,7 @@ fn get_open_options(cx: &LateContext, argument: &Expr, options: &mut Vec<(OpenOp
             let argument_option = match arguments[1].node {
                 ExprLit(ref span) => {
                     if let Spanned { node: LitKind::Bool(lit), .. } = **span {
-                        if lit {
-                            Argument::True
-                        } else {
-                            Argument::False
-                        }
+                        if lit { Argument::True } else { Argument::False }
                     } else {
                         return; // The function is called with a literal
                                 // which is not a boolean literal. This is theoretically
@@ -111,11 +107,8 @@ fn get_open_options(cx: &LateContext, argument: &Expr, options: &mut Vec<(OpenOp
 
 fn check_open_options(cx: &LateContext, options: &[(OpenOption, Argument)], span: Span) {
     let (mut create, mut append, mut truncate, mut read, mut write) = (false, false, false, false, false);
-    let (mut create_arg, mut append_arg, mut truncate_arg, mut read_arg, mut write_arg) = (false,
-                                                                                           false,
-                                                                                           false,
-                                                                                           false,
-                                                                                           false);
+    let (mut create_arg, mut append_arg, mut truncate_arg, mut read_arg, mut write_arg) =
+        (false, false, false, false, false);
     // This code is almost duplicated (oh, the irony), but I haven't found a way to unify it.
 
     for option in options {

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -77,7 +77,7 @@ impl LateLintPass for PointerPass {
             check_fn(cx, &sig.decl, item.id);
         }
     }
-    
+
     fn check_expr(&mut self, cx: &LateContext, expr: &Expr) {
         if let ExprBinary(ref op, ref l, ref r) = expr.node {
             if (op.node == BiEq || op.node == BiNe) && (is_null_path(l) || is_null_path(r)) {
@@ -116,7 +116,7 @@ fn is_null_path(expr: &Expr) -> bool {
     if let ExprCall(ref pathexp, ref args) = expr.node {
         if args.is_empty() {
             if let ExprPath(_, ref path) = pathexp.node {
-                return match_path(path, &paths::PTR_NULL) || match_path(path, &paths::PTR_NULL_MUT)
+                return match_path(path, &paths::PTR_NULL) || match_path(path, &paths::PTR_NULL_MUT);
             }
         }
     }

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -92,7 +92,6 @@ fn has_step_by(cx: &LateContext, expr: &Expr) -> bool {
     let ty = cx.tcx.expr_ty(expr);
 
     // Note: `RangeTo`, `RangeToInclusive` and `RangeFull` don't have step_by
-    match_type(cx, ty, &paths::RANGE)
-        || match_type(cx, ty, &paths::RANGE_FROM)
-        || match_type(cx, ty, &paths::RANGE_INCLUSIVE)
+    match_type(cx, ty, &paths::RANGE) || match_type(cx, ty, &paths::RANGE_FROM) ||
+    match_type(cx, ty, &paths::RANGE_INCLUSIVE)
 }

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -174,7 +174,9 @@ fn is_trivial_regex(s: &regex_syntax::Expr) -> Option<&'static str> {
                     }
                 }
                 3 => {
-                    if let (&Expr::StartText, &Expr::Literal {..}, &Expr::EndText) = (&exprs[0], &exprs[1], &exprs[2]) {
+                    if let (&Expr::StartText, &Expr::Literal { .. }, &Expr::EndText) = (&exprs[0],
+                                                                                        &exprs[1],
+                                                                                        &exprs[2]) {
                         Some("consider using `==` on `str`s")
                     } else {
                         None

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -48,7 +48,8 @@ impl ReturnPass {
     fn check_block_return(&mut self, cx: &EarlyContext, block: &Block) {
         if let Some(stmt) = block.stmts.last() {
             match stmt.node {
-                StmtKind::Expr(ref expr) | StmtKind::Semi(ref expr) => {
+                StmtKind::Expr(ref expr) |
+                StmtKind::Semi(ref expr) => {
                     self.check_final_expr(cx, expr, Some(stmt.span));
                 }
                 _ => (),

--- a/clippy_lints/src/serde.rs
+++ b/clippy_lints/src/serde.rs
@@ -38,7 +38,7 @@ impl LateLintPass for Serde {
                         match &*item.name.as_str() {
                             "visit_str" => seen_str = Some(item.span),
                             "visit_string" => seen_string = Some(item.span),
-                            _ => {},
+                            _ => {}
                         }
                     }
                     if let Some(span) = seen_string {
@@ -46,8 +46,7 @@ impl LateLintPass for Serde {
                             span_lint(cx,
                                       SERDE_API_MISUSE,
                                       span,
-                                      "you should not implement `visit_string` without also implementing `visit_str`",
-                            );
+                                      "you should not implement `visit_string` without also implementing `visit_str`");
                         }
                     }
                 }

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -172,8 +172,8 @@ fn check_pat(cx: &LateContext, pat: &Pat, init: &Option<&Expr>, span: Span, bind
                     for field in pfields {
                         let name = field.node.name;
                         let efield = efields.iter()
-                                            .find(|f| f.name.node == name)
-                                            .map(|f| &*f.expr);
+                            .find(|f| f.name.node == name)
+                            .map(|f| &*f.expr);
                         check_pat(cx, &field.node.pat, &efield, span, bindings);
                     }
                 } else {
@@ -232,8 +232,9 @@ fn lint_shadow<T>(cx: &LateContext, name: Name, span: Span, pattern_span: Span, 
                                &format!("`{}` is shadowed by itself in `{}`",
                                         snippet(cx, pattern_span, "_"),
                                         snippet(cx, expr.span, "..")),
-                               |db| { db.span_note(prev_span, "previous binding is here"); },
-            );
+                               |db| {
+                                   db.span_note(prev_span, "previous binding is here");
+                               });
         } else if contains_self(name, expr) {
             span_lint_and_then(cx,
                                SHADOW_REUSE,
@@ -263,7 +264,9 @@ fn lint_shadow<T>(cx: &LateContext, name: Name, span: Span, pattern_span: Span, 
                            SHADOW_UNRELATED,
                            span,
                            &format!("{} shadows a previous declaration", snippet(cx, pattern_span, "_")),
-                           |db| { db.span_note(prev_span, "previous binding is here"); });
+                           |db| {
+                               db.span_note(prev_span, "previous binding is here");
+                           });
     }
 }
 

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -61,17 +61,17 @@ impl LateLintPass for Swap {
 fn check_manual_swap(cx: &LateContext, block: &Block) {
     for w in block.stmts.windows(3) {
         if_let_chain!{[
-            // let t = foo();
+        // let t = foo();
             let StmtDecl(ref tmp, _) = w[0].node,
             let DeclLocal(ref tmp) = tmp.node,
             let Some(ref tmp_init) = tmp.init,
             let PatKind::Binding(_, ref tmp_name, None) = tmp.pat.node,
 
-            // foo() = bar();
+        // foo() = bar();
             let StmtSemi(ref first, _) = w[1].node,
             let ExprAssign(ref lhs1, ref rhs1) = first.node,
 
-            // bar() = t;
+        // bar() = t;
             let StmtSemi(ref second, _) = w[2].node,
             let ExprAssign(ref lhs2, ref rhs2) = second.node,
             let ExprPath(None, ref rhs2) = rhs2.node,

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -95,18 +95,18 @@ impl LateLintPass for Transmute {
                     let to_ty = cx.tcx.expr_ty(e);
 
                     match (&from_ty.sty, &to_ty.sty) {
-                        _ if from_ty == to_ty => span_lint(
-                            cx,
-                            USELESS_TRANSMUTE,
-                            e.span,
-                            &format!("transmute from a type (`{}`) to itself", from_ty),
-                        ),
-                        (&TyRef(_, rty), &TyRawPtr(ptr_ty)) => span_lint_and_then(
-                            cx,
-                            USELESS_TRANSMUTE,
-                            e.span,
-                            "transmute from a reference to a pointer",
-                            |db| {
+                        _ if from_ty == to_ty => {
+                            span_lint(cx,
+                                      USELESS_TRANSMUTE,
+                                      e.span,
+                                      &format!("transmute from a type (`{}`) to itself", from_ty))
+                        }
+                        (&TyRef(_, rty), &TyRawPtr(ptr_ty)) => {
+                            span_lint_and_then(cx,
+                                               USELESS_TRANSMUTE,
+                                               e.span,
+                                               "transmute from a reference to a pointer",
+                                               |db| {
                                 if let Some(arg) = sugg::Sugg::hir_opt(cx, &*args[0]) {
                                     let sugg = if ptr_ty == rty {
                                         arg.as_ty(to_ty)
@@ -116,45 +116,45 @@ impl LateLintPass for Transmute {
 
                                     db.span_suggestion(e.span, "try", sugg.to_string());
                                 }
-                            },
-                        ),
+                            })
+                        }
                         (&ty::TyInt(_), &TyRawPtr(_)) |
-                        (&ty::TyUint(_), &TyRawPtr(_)) => span_lint_and_then(
-                            cx,
-                            USELESS_TRANSMUTE,
-                            e.span,
-                            "transmute from an integer to a pointer",
-                            |db| {
+                        (&ty::TyUint(_), &TyRawPtr(_)) => {
+                            span_lint_and_then(cx,
+                                               USELESS_TRANSMUTE,
+                                               e.span,
+                                               "transmute from an integer to a pointer",
+                                               |db| {
                                 if let Some(arg) = sugg::Sugg::hir_opt(cx, &*args[0]) {
                                     db.span_suggestion(e.span, "try", arg.as_ty(&to_ty.to_string()).to_string());
                                 }
-                            },
-                        ),
+                            })
+                        }
                         (&ty::TyFloat(_), &TyRef(..)) |
                         (&ty::TyFloat(_), &TyRawPtr(_)) |
                         (&ty::TyChar, &TyRef(..)) |
-                        (&ty::TyChar, &TyRawPtr(_)) => span_lint(
-                            cx,
-                            WRONG_TRANSMUTE,
-                            e.span,
-                            &format!("transmute from a `{}` to a pointer", from_ty),
-                        ),
-                        (&TyRawPtr(from_ptr), _) if from_ptr.ty == to_ty => span_lint(
-                            cx,
-                            CROSSPOINTER_TRANSMUTE,
-                            e.span,
-                            &format!("transmute from a type (`{}`) to the type that it points to (`{}`)",
+                        (&ty::TyChar, &TyRawPtr(_)) => {
+                            span_lint(cx,
+                                      WRONG_TRANSMUTE,
+                                      e.span,
+                                      &format!("transmute from a `{}` to a pointer", from_ty))
+                        }
+                        (&TyRawPtr(from_ptr), _) if from_ptr.ty == to_ty => {
+                            span_lint(cx,
+                                      CROSSPOINTER_TRANSMUTE,
+                                      e.span,
+                                      &format!("transmute from a type (`{}`) to the type that it points to (`{}`)",
                                      from_ty,
-                                     to_ty),
-                        ),
-                        (_, &TyRawPtr(to_ptr)) if to_ptr.ty == from_ty => span_lint(
-                            cx,
-                            CROSSPOINTER_TRANSMUTE,
-                            e.span,
-                            &format!("transmute from a type (`{}`) to a pointer to that type (`{}`)",
+                                     to_ty))
+                        }
+                        (_, &TyRawPtr(to_ptr)) if to_ptr.ty == from_ty => {
+                            span_lint(cx,
+                                      CROSSPOINTER_TRANSMUTE,
+                                      e.span,
+                                      &format!("transmute from a type (`{}`) to a pointer to that type (`{}`)",
                                      from_ty,
-                                     to_ty),
-                        ),
+                                     to_ty))
+                        }
                         (&TyRawPtr(from_pty), &TyRef(_, to_rty)) => span_lint_and_then(
                             cx,
                             TRANSMUTE_PTR_TO_REF,

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -6,8 +6,7 @@ use rustc::ty;
 use std::cmp::Ordering;
 use syntax::ast::{IntTy, UintTy, FloatTy};
 use syntax::codemap::Span;
-use utils::{comparisons, higher, in_external_macro, in_macro, match_def_path, snippet,
-            span_help_and_lint, span_lint};
+use utils::{comparisons, higher, in_external_macro, in_macro, match_def_path, snippet, span_help_and_lint, span_lint};
 use utils::paths;
 
 /// Handles all the linting of funky types
@@ -211,7 +210,7 @@ impl LateLintPass for UnitCmp {
                                            op.as_str(),
                                            result));
                     }
-                    _ => ()
+                    _ => (),
                 }
             }
         }
@@ -335,11 +334,7 @@ fn is_isize_or_usize(typ: &ty::TyS) -> bool {
 }
 
 fn span_precision_loss_lint(cx: &LateContext, expr: &Expr, cast_from: &ty::TyS, cast_to_f64: bool) {
-    let mantissa_nbits = if cast_to_f64 {
-        52
-    } else {
-        23
-    };
+    let mantissa_nbits = if cast_to_f64 { 52 } else { 23 };
     let arch_dependent = is_isize_or_usize(cast_from) && cast_to_f64;
     let arch_dependent_str = "on targets with 64-bit wide pointers ";
     let from_nbits_str = if arch_dependent {

--- a/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/clippy_lints/src/unsafe_removed_from_name.rs
@@ -39,14 +39,13 @@ impl LateLintPass for UnsafeNameRemoval {
         if let ItemUse(ref item_use) = item.node {
             match item_use.node {
                 ViewPath_::ViewPathSimple(ref name, ref path) => {
-                    unsafe_to_safe_check(
-                        path.segments
-                            .last()
-                            .expect("use paths cannot be empty")
-                            .name,
-                        *name,
-                        cx, &item.span
-                        );
+                    unsafe_to_safe_check(path.segments
+                                             .last()
+                                             .expect("use paths cannot be empty")
+                                             .name,
+                                         *name,
+                                         cx,
+                                         &item.span);
                 }
                 ViewPath_::ViewPathList(_, ref path_list_items) => {
                     for path_list_item in path_list_items.iter() {

--- a/clippy_lints/src/unused_label.rs
+++ b/clippy_lints/src/unused_label.rs
@@ -47,7 +47,8 @@ impl LintPass for UnusedLabel {
 }
 
 impl LateLintPass for UnusedLabel {
-    fn check_fn(&mut self, cx: &LateContext, kind: FnKind, decl: &hir::FnDecl, body: &hir::Block, span: Span, fn_id: ast::NodeId) {
+    fn check_fn(&mut self, cx: &LateContext, kind: FnKind, decl: &hir::FnDecl, body: &hir::Block, span: Span,
+                fn_id: ast::NodeId) {
         if in_macro(cx, span) {
             return;
         }

--- a/clippy_lints/src/utils/comparisons.rs
+++ b/clippy_lints/src/utils/comparisons.rs
@@ -18,8 +18,7 @@ pub enum Rel {
 }
 
 /// Put the expression in the form  `lhs < rhs`, `lhs <= rhs`, `lhs == rhs` or `lhs != rhs`.
-pub fn normalize_comparison<'a>(op: BinOp_, lhs: &'a Expr, rhs: &'a Expr)
-                                -> Option<(Rel, &'a Expr, &'a Expr)> {
+pub fn normalize_comparison<'a>(op: BinOp_, lhs: &'a Expr, rhs: &'a Expr) -> Option<(Rel, &'a Expr, &'a Expr)> {
     match op {
         BinOp_::BiLt => Some((Rel::Lt, lhs, rhs)),
         BinOp_::BiLe => Some((Rel::Le, lhs, rhs)),

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -9,7 +9,8 @@ use syntax::parse::token;
 use toml;
 
 /// Get the configuration file from arguments.
-pub fn file(args: &[codemap::Spanned<ast::NestedMetaItemKind>]) -> Result<Option<token::InternedString>, (&'static str, codemap::Span)> {
+pub fn file(args: &[codemap::Spanned<ast::NestedMetaItemKind>])
+            -> Result<Option<token::InternedString>, (&'static str, codemap::Span)> {
     for arg in args.iter().filter_map(|a| a.meta_item()) {
         match arg.node {
             ast::MetaItemKind::Word(ref name) |
@@ -41,14 +42,12 @@ pub enum Error {
     /// The file is not valid TOML.
     Toml(Vec<toml::ParserError>),
     /// Type error.
-    Type(
-        /// The name of the key.
-        &'static str,
-        /// The expected type.
-        &'static str,
-        /// The type we got instead.
-        &'static str
-    ),
+    Type(/// The name of the key.
+         &'static str,
+         /// The expected type.
+         &'static str,
+         /// The type we got instead.
+         &'static str),
     /// There is an unknown key is the file.
     UnknownKey(String),
 }
@@ -86,7 +85,7 @@ impl From<io::Error> for Error {
 
 macro_rules! define_Conf {
     ($(#[$doc: meta] ($toml_name: tt, $rust_name: ident, $default: expr => $($ty: tt)+),)+) => {
-        /// Type used to store lint configuration.
+/// Type used to store lint configuration.
         pub struct Conf {
             $(#[$doc] pub $rust_name: define_Conf!(TY $($ty)+),)+
         }
@@ -100,7 +99,7 @@ macro_rules! define_Conf {
         }
 
         impl Conf {
-            /// Set the property `name` (which must be the `toml` name) to the given value
+/// Set the property `name` (which must be the `toml` name) to the given value
             #[allow(cast_sign_loss)]
             fn set(&mut self, name: String, value: toml::Value) -> Result<(), Error> {
                 match name.as_str() {
@@ -117,7 +116,7 @@ macro_rules! define_Conf {
                         },
                     )+
                     "third-party" => {
-                        // for external tools such as clippy-service
+// for external tools such as clippy-service
                         return Ok(());
                     }
                     _ => {
@@ -130,12 +129,12 @@ macro_rules! define_Conf {
         }
     };
 
-    // hack to convert tts
+// hack to convert tts
     (PAT $pat: pat) => { $pat };
     (EXPR $e: expr) => { $e };
     (TY $ty: ty) => { $ty };
 
-    // how to read the value?
+// how to read the value?
     (CONV i64, $value: expr) => { $value.as_integer() };
     (CONV u64, $value: expr) => { $value.as_integer().iter().filter_map(|&i| if i >= 0 { Some(i as u64) } else { None }).next() };
     (CONV String, $value: expr) => { $value.as_str().map(Into::into) };
@@ -155,27 +154,27 @@ macro_rules! define_Conf {
         }
     }};
 
-    // provide a nicer syntax to declare the default value of `Vec<String>` variables
+// provide a nicer syntax to declare the default value of `Vec<String>` variables
     (DEFAULT Vec<String>, $e: expr) => { $e.iter().map(|&e| e.to_owned()).collect() };
     (DEFAULT $ty: ty, $e: expr) => { $e };
 }
 
 define_Conf! {
-    /// Lint: BLACKLISTED_NAME. The list of blacklisted names to lint about
+/// Lint: BLACKLISTED_NAME. The list of blacklisted names to lint about
     ("blacklisted-names", blacklisted_names, ["foo", "bar", "baz"] => Vec<String>),
-    /// Lint: CYCLOMATIC_COMPLEXITY. The maximum cyclomatic complexity a function can have
+/// Lint: CYCLOMATIC_COMPLEXITY. The maximum cyclomatic complexity a function can have
     ("cyclomatic-complexity-threshold", cyclomatic_complexity_threshold, 25 => u64),
-    /// Lint: DOC_MARKDOWN. The list of words this lint should not consider as identifiers needing ticks
+/// Lint: DOC_MARKDOWN. The list of words this lint should not consider as identifiers needing ticks
     ("doc-valid-idents", doc_valid_idents, ["MiB", "GiB", "TiB", "PiB", "EiB", "DirectX", "GPLv2", "GPLv3", "GitHub", "IPv4", "IPv6", "JavaScript", "NaN", "OAuth", "OpenGL", "TrueType"] => Vec<String>),
-    /// Lint: TOO_MANY_ARGUMENTS. The maximum number of argument a function or method can have
+/// Lint: TOO_MANY_ARGUMENTS. The maximum number of argument a function or method can have
     ("too-many-arguments-threshold", too_many_arguments_threshold, 7 => u64),
-    /// Lint: TYPE_COMPLEXITY. The maximum complexity a type can have
+/// Lint: TYPE_COMPLEXITY. The maximum complexity a type can have
     ("type-complexity-threshold", type_complexity_threshold, 250 => u64),
-    /// Lint: MANY_SINGLE_CHAR_NAMES. The maximum number of single char bindings a scope may have
+/// Lint: MANY_SINGLE_CHAR_NAMES. The maximum number of single char bindings a scope may have
     ("single-char-binding-names-threshold", max_single_char_names, 5 => u64),
-    /// Lint: BOXED_LOCAL. The maximum size of objects (in bytes) that will be linted. Larger objects are ok on the heap
+/// Lint: BOXED_LOCAL. The maximum size of objects (in bytes) that will be linted. Larger objects are ok on the heap
     ("too-large-for-stack", too_large_for_stack, 200 => u64),
-    /// Lint: ENUM_VARIANT_NAMES. The minimum number of enum variants for the lints about variant names to trigger
+/// Lint: ENUM_VARIANT_NAMES. The minimum number of enum variants for the lints about variant names to trigger
     ("enum-variant-name-threshold", enum_variant_name_threshold, 3 => u64),
 }
 

--- a/clippy_lints/src/utils/constants.rs
+++ b/clippy_lints/src/utils/constants.rs
@@ -7,15 +7,5 @@
 /// See also [the reference][reference-types] for a list of such types.
 ///
 /// [reference-types]: https://doc.rust-lang.org/reference.html#types
-pub const BUILTIN_TYPES: &'static [&'static str] = &[
-    "i8", "u8",
-    "i16", "u16",
-    "i32", "u32",
-    "i64", "u64",
-    "isize", "usize",
-    "f32",
-    "f64",
-    "bool",
-    "str",
-    "char",
-];
+pub const BUILTIN_TYPES: &'static [&'static str] = &["i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64", "isize",
+                                                     "usize", "f32", "f64", "bool", "str", "char"];

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -48,7 +48,8 @@ pub fn range(expr: &hir::Expr) -> Option<Range> {
     /// Skip unstable blocks. To be removed when ranges get stable.
     fn unwrap_unstable(expr: &hir::Expr) -> &hir::Expr {
         if let hir::ExprBlock(ref block) = expr.node {
-            if block.rules == hir::BlockCheckMode::PushUnstableBlock || block.rules == hir::BlockCheckMode::PopUnstableBlock {
+            if block.rules == hir::BlockCheckMode::PushUnstableBlock ||
+               block.rules == hir::BlockCheckMode::PopUnstableBlock {
                 if let Some(ref expr) = block.expr {
                     return expr;
                 }
@@ -61,9 +62,9 @@ pub fn range(expr: &hir::Expr) -> Option<Range> {
     /// Find the field named `name` in the field. Always return `Some` for convenience.
     fn get_field<'a>(name: &str, fields: &'a [hir::Field]) -> Option<&'a hir::Expr> {
         let expr = &fields.iter()
-                          .find(|field| field.name.node.as_str() == name)
-                          .unwrap_or_else(|| panic!("missing {} field for range", name))
-                          .expr;
+            .find(|field| field.name.node.as_str() == name)
+            .unwrap_or_else(|| panic!("missing {} field for range", name))
+            .expr;
 
         Some(unwrap_unstable(expr))
     }
@@ -91,7 +92,7 @@ pub fn range(expr: &hir::Expr) -> Option<Range> {
                     limits: ast::RangeLimits::HalfOpen,
                 })
             } else if match_path(path, &paths::RANGE_INCLUSIVE_NON_EMPTY_STD) ||
-               match_path(path, &paths::RANGE_INCLUSIVE_NON_EMPTY) {
+                      match_path(path, &paths::RANGE_INCLUSIVE_NON_EMPTY) {
                 Some(Range {
                     start: get_field("start", fields),
                     end: get_field("end", fields),

--- a/clippy_lints/src/utils/hir.rs
+++ b/clippy_lints/src/utils/hir.rs
@@ -203,13 +203,7 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
 
 fn swap_binop<'a>(binop: BinOp_, lhs: &'a Expr, rhs: &'a Expr) -> Option<(BinOp_, &'a Expr, &'a Expr)> {
     match binop {
-        BiAdd |
-        BiMul |
-        BiBitXor |
-        BiBitAnd |
-        BiEq |
-        BiNe |
-        BiBitOr => Some((binop, rhs, lhs)),
+        BiAdd | BiMul | BiBitXor | BiBitAnd | BiEq | BiNe | BiBitOr => Some((binop, rhs, lhs)),
         BiLt => Some((BiGt, rhs, lhs)),
         BiLe => Some((BiGe, rhs, lhs)),
         BiGe => Some((BiLe, rhs, lhs)),

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -75,8 +75,8 @@ impl EarlyLintPass for Clippy {
                                     span_lint(cx,
                                               CLIPPY_LINTS_INTERNAL,
                                               item.span,
-                                              "this constant should be before the previous constant due to lexical ordering",
-                                    );
+                                              "this constant should be before the previous constant due to lexical \
+                                               ordering");
                                 }
                             }
                             last_name = Some(name);

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -164,11 +164,11 @@ pub fn match_impl_method(cx: &LateContext, expr: &Expr, path: &[&str]) -> bool {
     let method_call = ty::MethodCall::expr(expr.id);
 
     let trt_id = cx.tcx
-                   .tables
-                   .borrow()
-                   .method_map
-                   .get(&method_call)
-                   .and_then(|callee| cx.tcx.impl_of_method(callee.def_id));
+        .tables
+        .borrow()
+        .method_map
+        .get(&method_call)
+        .and_then(|callee| cx.tcx.impl_of_method(callee.def_id));
     if let Some(trt_id) = trt_id {
         match_def_path(cx, trt_id, path)
     } else {
@@ -181,11 +181,11 @@ pub fn match_trait_method(cx: &LateContext, expr: &Expr, path: &[&str]) -> bool 
     let method_call = ty::MethodCall::expr(expr.id);
 
     let trt_id = cx.tcx
-                   .tables
-                   .borrow()
-                   .method_map
-                   .get(&method_call)
-                   .and_then(|callee| cx.tcx.trait_of_item(callee.def_id));
+        .tables
+        .borrow()
+        .method_map
+        .get(&method_call)
+        .and_then(|callee| cx.tcx.trait_of_item(callee.def_id));
     if let Some(trt_id) = trt_id {
         match_def_path(cx, trt_id, path)
     } else {
@@ -221,7 +221,10 @@ pub fn path_to_def(cx: &LateContext, path: &[&str]) -> Option<def::Def> {
     let crates = cstore.crates();
     let krate = crates.iter().find(|&&krate| cstore.crate_name(krate) == path[0]);
     if let Some(krate) = krate {
-        let krate = DefId { krate: *krate, index: CRATE_DEF_INDEX };
+        let krate = DefId {
+            krate: *krate,
+            index: CRATE_DEF_INDEX,
+        };
         let mut items = cstore.item_children(krate);
         let mut path_it = path.iter().skip(1).peekable();
 
@@ -269,11 +272,7 @@ pub fn implements_trait<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: ty::Ty<'tcx>, 
 
     let ty = cx.tcx.erase_regions(&ty);
     cx.tcx.infer_ctxt(None, None, Reveal::All).enter(|infcx| {
-        let obligation = cx.tcx.predicate_for_trait_def(traits::ObligationCause::dummy(),
-                                                        trait_id,
-                                                        0,
-                                                        ty,
-                                                        &ty_params);
+        let obligation = cx.tcx.predicate_for_trait_def(traits::ObligationCause::dummy(), trait_id, 0, ty, &ty_params);
 
         traits::SelectionContext::new(&infcx).evaluate_obligation_conservatively(&obligation)
     })
@@ -367,32 +366,32 @@ pub fn trim_multiline(s: Cow<str>, ignore_first: bool) -> Cow<str> {
 
 fn trim_multiline_inner(s: Cow<str>, ignore_first: bool, ch: char) -> Cow<str> {
     let x = s.lines()
-             .skip(ignore_first as usize)
-             .filter_map(|l| {
-                 if l.is_empty() {
-                     None
-                 } else {
-                     // ignore empty lines
-                     Some(l.char_indices()
-                           .find(|&(_, x)| x != ch)
-                           .unwrap_or((l.len(), ch))
-                           .0)
-                 }
-             })
-             .min()
-             .unwrap_or(0);
+        .skip(ignore_first as usize)
+        .filter_map(|l| {
+            if l.is_empty() {
+                None
+            } else {
+                // ignore empty lines
+                Some(l.char_indices()
+                    .find(|&(_, x)| x != ch)
+                    .unwrap_or((l.len(), ch))
+                    .0)
+            }
+        })
+        .min()
+        .unwrap_or(0);
     if x > 0 {
         Cow::Owned(s.lines()
-                    .enumerate()
-                    .map(|(i, l)| {
-                        if (ignore_first && i == 0) || l.is_empty() {
-                            l
-                        } else {
-                            l.split_at(x).1
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n"))
+            .enumerate()
+            .map(|(i, l)| {
+                if (ignore_first && i == 0) || l.is_empty() {
+                    l
+                } else {
+                    l.split_at(x).1
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n"))
     } else {
         s
     }
@@ -418,7 +417,7 @@ pub fn get_parent_expr<'c>(cx: &'c LateContext, e: &Expr) -> Option<&'c Expr> {
 pub fn get_enclosing_block<'c>(cx: &'c LateContext, node: NodeId) -> Option<&'c Block> {
     let map = &cx.tcx.map;
     let enclosing_node = map.get_enclosing_scope(node)
-                            .and_then(|enclosing_id| map.find(enclosing_id));
+        .and_then(|enclosing_id| map.find(enclosing_id));
     if let Some(node) = enclosing_node {
         match node {
             Node::NodeBlock(block) => Some(block),
@@ -593,9 +592,9 @@ fn parse_attrs<F: FnMut(u64)>(sess: &Session, attrs: &[ast::Attribute], name: &'
 pub fn is_expn_of(cx: &LateContext, mut span: Span, name: &str) -> Option<Span> {
     loop {
         let span_name_span = cx.tcx
-                               .sess
-                               .codemap()
-                               .with_expn_info(span.expn_id, |expn| expn.map(|ei| (ei.callee.name(), ei.call_site)));
+            .sess
+            .codemap()
+            .with_expn_info(span.expn_id, |expn| expn.map(|ei| (ei.callee.name(), ei.call_site)));
 
         match span_name_span {
             Some((mac_name, new_span)) if mac_name.as_str() == name => return Some(new_span),
@@ -614,9 +613,9 @@ pub fn is_expn_of(cx: &LateContext, mut span: Span, name: &str) -> Option<Span> 
 /// `is_direct_expn_of`.
 pub fn is_direct_expn_of(cx: &LateContext, span: Span, name: &str) -> Option<Span> {
     let span_name_span = cx.tcx
-                           .sess
-                           .codemap()
-                           .with_expn_info(span.expn_id, |expn| expn.map(|ei| (ei.callee.name(), ei.call_site)));
+        .sess
+        .codemap()
+        .with_expn_info(span.expn_id, |expn| expn.map(|ei| (ei.callee.name(), ei.call_site)));
 
     match span_name_span {
         Some((mac_name, new_span)) if mac_name.as_str() == name => Some(new_span),
@@ -650,11 +649,7 @@ pub fn camel_case_until(s: &str) -> usize {
             return i;
         }
     }
-    if up {
-        last_i
-    } else {
-        s.len()
-    }
+    if up { last_i } else { s.len() }
 }
 
 /// Return index of the last camel-case component of `s`.
@@ -697,7 +692,8 @@ pub fn return_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, fn_item: NodeId) -> ty::T
 /// Check if two types are the same.
 // FIXME: this works correctly for lifetimes bounds (`for <'a> Foo<'a>` == `for <'b> Foo<'b>` but
 // not for type parameters.
-pub fn same_tys<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, a: ty::Ty<'tcx>, b: ty::Ty<'tcx>, parameter_item: NodeId) -> bool {
+pub fn same_tys<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, a: ty::Ty<'tcx>, b: ty::Ty<'tcx>, parameter_item: NodeId)
+                          -> bool {
     let parameter_env = ty::ParameterEnvironment::for_item(cx.tcx, parameter_item);
     cx.tcx.infer_ctxt(None, Some(parameter_env), Reveal::All).enter(|infcx| {
         let new_a = a.subst(infcx.tcx, infcx.parameter_environment.free_substs);
@@ -726,14 +722,17 @@ pub fn is_refutable(cx: &LateContext, pat: &Pat) -> bool {
         matches!(cx.tcx.def_map.borrow().get(&did).map(|d| d.full_def()), Some(def::Def::Variant(..)))
     }
 
-    fn are_refutable<'a, I: Iterator<Item=&'a Pat>>(cx: &LateContext, mut i: I) -> bool {
+    fn are_refutable<'a, I: Iterator<Item = &'a Pat>>(cx: &LateContext, mut i: I) -> bool {
         i.any(|pat| is_refutable(cx, pat))
     }
 
     match pat.node {
-        PatKind::Binding(..) | PatKind::Wild => false,
-        PatKind::Box(ref pat) | PatKind::Ref(ref pat, _) => is_refutable(cx, pat),
-        PatKind::Lit(..) | PatKind::Range(..) => true,
+        PatKind::Binding(..) |
+        PatKind::Wild => false,
+        PatKind::Box(ref pat) |
+        PatKind::Ref(ref pat, _) => is_refutable(cx, pat),
+        PatKind::Lit(..) |
+        PatKind::Range(..) => true,
         PatKind::Path(..) => is_enum_variant(cx, pat.id),
         PatKind::Tuple(ref pats, _) => are_refutable(cx, pats.iter().map(|pat| &**pat)),
         PatKind::Struct(_, ref fields, _) => {

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -29,9 +29,9 @@ pub const ONE: Sugg<'static> = Sugg::NonParen(Cow::Borrowed("1"));
 impl<'a> Display for Sugg<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match *self {
-            Sugg::NonParen(ref s) | Sugg::MaybeParen(ref s) | Sugg::BinOp(_, ref s) => {
-                s.fmt(f)
-            }
+            Sugg::NonParen(ref s) |
+            Sugg::MaybeParen(ref s) |
+            Sugg::BinOp(_, ref s) => s.fmt(f),
         }
     }
 }
@@ -168,11 +168,13 @@ impl<'a> Sugg<'a> {
         match self {
             Sugg::NonParen(..) => self,
             // (x) and (x).y() both don't need additional parens
-            Sugg::MaybeParen(sugg) => if sugg.starts_with('(') && sugg.ends_with(')') {
-                Sugg::MaybeParen(sugg)
-            } else {
-                Sugg::NonParen(format!("({})", sugg).into())
-            },
+            Sugg::MaybeParen(sugg) => {
+                if sugg.starts_with('(') && sugg.ends_with(')') {
+                    Sugg::MaybeParen(sugg)
+                } else {
+                    Sugg::NonParen(format!("({})", sugg).into())
+                }
+            }
             Sugg::BinOp(_, sugg) => Sugg::NonParen(format!("({})", sugg).into()),
         }
     }
@@ -254,11 +256,9 @@ pub fn make_assoc(op: AssocOp, lhs: &Sugg, rhs: &Sugg) -> Sugg<'static> {
     /// `dir`.
     fn needs_paren(op: &AssocOp, other: &AssocOp, dir: Associativity) -> bool {
         other.precedence() < op.precedence() ||
-            (other.precedence() == op.precedence() &&
-                ((op != other && associativity(op) != dir) ||
-                 (op == other && associativity(op) != Associativity::Both))) ||
-             is_shift(op) && is_arith(other) ||
-             is_shift(other) && is_arith(op)
+        (other.precedence() == op.precedence() &&
+         ((op != other && associativity(op) != dir) || (op == other && associativity(op) != Associativity::Both))) ||
+        is_shift(op) && is_arith(other) || is_shift(other) && is_arith(op)
     }
 
     let lhs_paren = if let Sugg::BinOp(ref lop, _) = *lhs {
@@ -276,24 +276,12 @@ pub fn make_assoc(op: AssocOp, lhs: &Sugg, rhs: &Sugg) -> Sugg<'static> {
     let lhs = ParenHelper::new(lhs_paren, lhs);
     let rhs = ParenHelper::new(rhs_paren, rhs);
     let sugg = match op {
-        AssocOp::Add |
-        AssocOp::BitAnd |
-        AssocOp::BitOr |
-        AssocOp::BitXor |
-        AssocOp::Divide |
-        AssocOp::Equal |
-        AssocOp::Greater |
-        AssocOp::GreaterEqual |
-        AssocOp::LAnd |
-        AssocOp::LOr |
-        AssocOp::Less |
-        AssocOp::LessEqual |
-        AssocOp::Modulus |
-        AssocOp::Multiply |
-        AssocOp::NotEqual |
-        AssocOp::ShiftLeft |
-        AssocOp::ShiftRight |
-        AssocOp::Subtract => format!("{} {} {}", lhs, op.to_ast_binop().expect("Those are AST ops").to_string(), rhs),
+        AssocOp::Add | AssocOp::BitAnd | AssocOp::BitOr | AssocOp::BitXor | AssocOp::Divide | AssocOp::Equal |
+        AssocOp::Greater | AssocOp::GreaterEqual | AssocOp::LAnd | AssocOp::LOr | AssocOp::Less |
+        AssocOp::LessEqual | AssocOp::Modulus | AssocOp::Multiply | AssocOp::NotEqual | AssocOp::ShiftLeft |
+        AssocOp::ShiftRight | AssocOp::Subtract => {
+            format!("{} {} {}", lhs, op.to_ast_binop().expect("Those are AST ops").to_string(), rhs)
+        }
         AssocOp::Inplace => format!("in ({}) {}", lhs, rhs),
         AssocOp::Assign => format!("{} = {}", lhs, rhs),
         AssocOp::AssignOp(op) => format!("{} {}= {}", lhs, binop_to_string(op), rhs),
@@ -335,11 +323,10 @@ fn associativity(op: &AssocOp) -> Associativity {
 
     match *op {
         Inplace | Assign | AssignOp(_) => Associativity::Right,
-        Add | BitAnd | BitOr | BitXor | LAnd | LOr | Multiply |
-        As | Colon => Associativity::Both,
-    Divide | Equal | Greater | GreaterEqual | Less | LessEqual | Modulus | NotEqual | ShiftLeft |
-        ShiftRight | Subtract => Associativity::Left,
-        DotDot | DotDotDot => Associativity::None
+        Add | BitAnd | BitOr | BitXor | LAnd | LOr | Multiply | As | Colon => Associativity::Both,
+        Divide | Equal | Greater | GreaterEqual | Less | LessEqual | Modulus | NotEqual | ShiftLeft | ShiftRight |
+        Subtract => Associativity::Left,
+        DotDot | DotDotDot => Associativity::None,
     }
 }
 
@@ -413,7 +400,7 @@ pub trait DiagnosticBuilderExt<T: LintContext> {
     /// ```rust
     /// db.suggest_item_with_attr(cx, item, "#[derive(Default)]");
     /// ```
-    fn suggest_item_with_attr<D: Display+?Sized>(&mut self, cx: &T, item: Span, msg: &str, attr: &D);
+    fn suggest_item_with_attr<D: Display + ?Sized>(&mut self, cx: &T, item: Span, msg: &str, attr: &D);
 
     /// Suggest to add an item before another.
     ///
@@ -431,12 +418,9 @@ pub trait DiagnosticBuilderExt<T: LintContext> {
 }
 
 impl<'a, 'b, T: LintContext> DiagnosticBuilderExt<T> for rustc_errors::DiagnosticBuilder<'b> {
-    fn suggest_item_with_attr<D: Display+?Sized>(&mut self, cx: &T, item: Span, msg: &str, attr: &D) {
+    fn suggest_item_with_attr<D: Display + ?Sized>(&mut self, cx: &T, item: Span, msg: &str, attr: &D) {
         if let Some(indent) = indentation(cx, item) {
-            let span = Span {
-                hi: item.lo,
-                ..item
-            };
+            let span = Span { hi: item.lo, ..item };
 
             self.span_suggestion(span, msg, format!("{}\n{}", attr, indent));
         }
@@ -444,20 +428,19 @@ impl<'a, 'b, T: LintContext> DiagnosticBuilderExt<T> for rustc_errors::Diagnosti
 
     fn suggest_prepend_item(&mut self, cx: &T, item: Span, msg: &str, new_item: &str) {
         if let Some(indent) = indentation(cx, item) {
-            let span = Span {
-                hi: item.lo,
-                ..item
-            };
+            let span = Span { hi: item.lo, ..item };
 
             let mut first = true;
-            let new_item = new_item.lines().map(|l| {
-                if first {
-                    first = false;
-                    format!("{}\n", l)
-                } else {
-                    format!("{}{}\n", indent, l)
-                }
-            }).collect::<String>();
+            let new_item = new_item.lines()
+                .map(|l| {
+                    if first {
+                        first = false;
+                        format!("{}\n", l)
+                    } else {
+                        format!("{}{}\n", indent, l)
+                    }
+                })
+                .collect::<String>();
 
             self.span_suggestion(span, msg, format!("{}\n{}", new_item, indent));
         }

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -38,8 +38,8 @@ impl LateLintPass for Pass {
             // do something like 0.0/(2.0 - 2.0), but it would be nice to warn on that case too.
             let Some(Constant::Float(ref lhs_value, lhs_width)) = constant_simple(left),
             let Some(Constant::Float(ref rhs_value, rhs_width)) = constant_simple(right),
-            let Some(0.0) = lhs_value.parse().ok(),
-            let Some(0.0) = rhs_value.parse().ok()
+            let Ok(0.0) = lhs_value.parse(),
+            let Ok(0.0) = rhs_value.parse()
         ], {
             // since we're about to suggest a use of std::f32::NaN or std::f64::NaN,
             // match the precision of the literals that are given.

--- a/tests/compile-fail/ok_if_let.rs
+++ b/tests/compile-fail/ok_if_let.rs
@@ -1,0 +1,17 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+#![deny(ok_if_let)]
+
+fn str_to_int(x: &str) -> i32 {
+    if let Some(y) = x.parse().ok() { 
+    //~^ERROR Matching on `Some` with `ok()` is redundant
+        y
+    } else {
+        0
+    }
+}
+fn main() {
+    let y = str_to_int("1");
+    println!("{}", y);
+}

--- a/tests/compile-fail/ok_if_let.rs
+++ b/tests/compile-fail/ok_if_let.rs
@@ -1,7 +1,7 @@
 #![feature(plugin)]
 #![plugin(clippy)]
 
-#![deny(ok_if_let)]
+#![deny(if_let_some_result)]
 
 fn str_to_int(x: &str) -> i32 {
     if let Some(y) = x.parse().ok() { 
@@ -11,7 +11,17 @@ fn str_to_int(x: &str) -> i32 {
         0
     }
 }
+
+fn str_to_int_ok(x: &str) -> i32 {
+    if let Ok(y) = x.parse() {
+        y
+    } else {
+        0
+    }
+}
+
 fn main() {
     let y = str_to_int("1");
-    println!("{}", y);
+    let z = str_to_int_ok("2");
+    println!("{}{}", y, z);
 }


### PR DESCRIPTION
Hey all,

I added a lint that checks for expressions like:

```rust
if let Some(y) = x.parse().ok()
```
And suggests changing to:

```rust
if let Ok(y) = x.parse()
```

This is my first clippy lint, please let me know if I can refactor anything or make it more idiomatic!

Fix #1185.