### PR TITLE
Run rustfmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Cargo.lock
 
 # gh pages docs
 util/gh-pages/lints.json
+
+# rustfmt backups
+*.rs.bk

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ install:
   - nvm install stable
   - nvm use stable
   - npm install remark-cli remark-lint
-  - cargo install rustfmt
+  # || true, because we cache rustfmt and don't want to crash on the next travis run
+  # due to rustfmt already being installed
+  - (cargo install rustfmt || true)
 
 script:
  - remark -f README.md > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 script:
  - remark -f README.md > /dev/null
  - python util/update_lints.py -c
- - cargo fmt -- --write-mode=diff
+ - PATH=$PATH:~/.cargo/bin cargo fmt -- --write-mode=diff
  - set -e
  - cargo build --features debugging
  - cargo test --features debugging

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,12 @@ install:
   - nvm install stable
   - nvm use stable
   - npm install remark-cli remark-lint
+  - cargo install rustfmt
 
 script:
  - remark -f README.md > /dev/null
  - python util/update_lints.py -c
+ - cargo fmt -- --write-mode=diff
  - set -e
  - cargo build --features debugging
  - cargo test --features debugging

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,3 +3,5 @@ ideal_width = 100
 fn_args_density = "Compressed"
 fn_call_width = 80
 fn_args_paren_newline = false
+closure_block_indent_threshold = -1
+match_block_trailing_comma = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,5 +3,4 @@ ideal_width = 100
 fn_args_density = "Compressed"
 fn_call_width = 80
 fn_args_paren_newline = false
-closure_block_indent_threshold = -1
 match_block_trailing_comma = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,30 +38,17 @@ impl ClippyCompilerCalls {
 }
 
 impl<'a> CompilerCalls<'a> for ClippyCompilerCalls {
-    fn early_callback(&mut self,
-                      matches: &getopts::Matches,
-                      sopts: &config::Options,
-                      cfg: &ast::CrateConfig,
-                      descriptions: &rustc_errors::registry::Registry,
-                      output: ErrorOutputType)
+    fn early_callback(&mut self, matches: &getopts::Matches, sopts: &config::Options, cfg: &ast::CrateConfig,
+                      descriptions: &rustc_errors::registry::Registry, output: ErrorOutputType)
                       -> Compilation {
         self.default.early_callback(matches, sopts, cfg, descriptions, output)
     }
-    fn no_input(&mut self,
-                matches: &getopts::Matches,
-                sopts: &config::Options,
-                cfg: &ast::CrateConfig,
-                odir: &Option<PathBuf>,
-                ofile: &Option<PathBuf>,
-                descriptions: &rustc_errors::registry::Registry)
+    fn no_input(&mut self, matches: &getopts::Matches, sopts: &config::Options, cfg: &ast::CrateConfig,
+                odir: &Option<PathBuf>, ofile: &Option<PathBuf>, descriptions: &rustc_errors::registry::Registry)
                 -> Option<(Input, Option<PathBuf>)> {
         self.default.no_input(matches, sopts, cfg, odir, ofile, descriptions)
     }
-    fn late_callback(&mut self,
-                     matches: &getopts::Matches,
-                     sess: &Session,
-                     input: &Input,
-                     odir: &Option<PathBuf>,
+    fn late_callback(&mut self, matches: &getopts::Matches, sess: &Session, input: &Input, odir: &Option<PathBuf>,
                      ofile: &Option<PathBuf>)
                      -> Compilation {
         self.default.late_callback(matches, sess, input, odir, ofile)
@@ -73,7 +60,12 @@ impl<'a> CompilerCalls<'a> for ClippyCompilerCalls {
             let old = std::mem::replace(&mut control.after_parse.callback, box |_| {});
             control.after_parse.callback = Box::new(move |state| {
                 {
-                    let mut registry = rustc_plugin::registry::Registry::new(state.session, state.krate.as_ref().expect("at this compilation stage the krate must be parsed").span);
+                    let mut registry = rustc_plugin::registry::Registry::new(state.session,
+                                                                             state.krate
+                                                                                 .as_ref()
+                                                                                 .expect("at this compilation stage \
+                                                                                          the krate must be parsed")
+                                                                                 .span);
                     registry.args_hidden = Some(Vec::new());
                     clippy_lints::register_plugins(&mut registry);
 
@@ -153,7 +145,7 @@ pub fn main() {
     if env::var("CLIPPY_DOGFOOD").map(|_| true).unwrap_or(false) {
         panic!("yummy");
     }
-    
+
     // Check for version and help flags even when invoked as 'cargo-clippy'
     if std::env::args().any(|a| a == "--help" || a == "-h") {
         show_help();
@@ -184,14 +176,16 @@ pub fn main() {
 
         let current_dir = std::env::current_dir();
 
-        let package_index = metadata.packages.iter()
+        let package_index = metadata.packages
+            .iter()
             .position(|package| {
                 let package_manifest_path = Path::new(&package.manifest_path);
                 if let Some(ref manifest_path) = manifest_path {
                     package_manifest_path == manifest_path
                 } else {
                     let current_dir = current_dir.as_ref().expect("could not read current directory");
-                    let package_manifest_directory = package_manifest_path.parent().expect("could not find parent directory of package manifest");
+                    let package_manifest_directory = package_manifest_path.parent()
+                        .expect("could not find parent directory of package manifest");
                     package_manifest_directory == current_dir
                 }
             })
@@ -205,7 +199,8 @@ pub fn main() {
                         std::process::exit(code);
                     }
                 } else if ["bin", "example", "test", "bench"].contains(&&**first) {
-                    if let Err(code) = process(vec![format!("--{}", first), target.name].into_iter().chain(args), &dep_path) {
+                    if let Err(code) = process(vec![format!("--{}", first), target.name].into_iter().chain(args),
+                                               &dep_path) {
                         std::process::exit(code);
                     }
                 }
@@ -285,8 +280,10 @@ fn process<P, I>(old_args: I, dep_path: P) -> Result<(), i32>
     let exit_status = std::process::Command::new("cargo")
         .args(&args)
         .env("RUSTC", path)
-        .spawn().expect("could not run cargo")
-        .wait().expect("failed to wait for cargo?");
+        .spawn()
+        .expect("could not run cargo")
+        .wait()
+        .expect("failed to wait for cargo?");
 
     if exit_status.success() {
         Ok(())

--- a/tests/ice_exacte_size.rs
+++ b/tests/ice_exacte_size.rs
@@ -14,4 +14,4 @@ impl Iterator for Foo {
     }
 }
 
-impl ExactSizeIterator for Foo { }
+impl ExactSizeIterator for Foo {}

--- a/tests/issue-825.rs
+++ b/tests/issue-825.rs
@@ -5,19 +5,10 @@
 
 // this should compile in a reasonable amount of time
 fn rust_type_id(name: String) {
-    if "bool" == &name[..] ||
-        "uint" == &name[..] ||
-        "u8" == &name[..] ||
-        "u16" == &name[..] ||
-        "u32" == &name[..] ||
-        "f32" == &name[..] ||
-        "f64" == &name[..] ||
-        "i8" == &name[..] ||
-        "i16" == &name[..] ||
-        "i32" == &name[..] ||
-        "i64" == &name[..] ||
-        "Self" == &name[..] ||
-        "str" == &name[..] {
+    if "bool" == &name[..] || "uint" == &name[..] || "u8" == &name[..] || "u16" == &name[..] ||
+       "u32" == &name[..] || "f32" == &name[..] || "f64" == &name[..] || "i8" == &name[..] ||
+       "i16" == &name[..] || "i32" == &name[..] || "i64" == &name[..] ||
+       "Self" == &name[..] || "str" == &name[..] {
         unreachable!();
     }
 }

--- a/tests/trim_multiline.rs
+++ b/tests/trim_multiline.rs
@@ -13,6 +13,7 @@ fn test_single_line() {
 }
 
 #[test]
+#[cfg_attr(rustfmt, rustfmt_skip)]
 fn test_block() {
     assert_eq!("\
 if x {
@@ -37,6 +38,7 @@ if x {
 }
 
 #[test]
+#[cfg_attr(rustfmt, rustfmt_skip)]
 fn test_empty_line() {
     assert_eq!("\
 if x {


### PR DESCRIPTION
So I was going to integrate coverage tests in Travis, but [@Manishearth was to fast](https://github.com/Manishearth/rust-clippy/pull/1255#issuecomment-251158625).
So I though “Hey, what other tool could I fight against? Oh I know, [it's been a long time since we haven't run `rustfmt`](https://github.com/Manishearth/rust-clippy/pull/1249#issuecomment-250905291)!”.

:warning: I offer one Internet point to anyone who can explain to me how `rustfmt` decides what to do with `match` arms and another one for all our `|db| {}` lambdas.
