### PR TITLE
Remove warning in the latest nightly

### DIFF
--- a/clippy_lints/src/utils/hir.rs
+++ b/clippy_lints/src/utils/hir.rs
@@ -1,7 +1,8 @@
 use consts::constant;
 use rustc::lint::*;
 use rustc::hir::*;
-use std::hash::{Hash, Hasher, SipHasher};
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
 use syntax::ast::Name;
 use syntax::ptr::P;
 use utils::differing_macro_contexts;
@@ -272,14 +273,14 @@ fn over<X, F>(left: &[X], right: &[X], mut eq_fn: F) -> bool
 pub struct SpanlessHash<'a, 'tcx: 'a> {
     /// Context used to evaluate constant expressions.
     cx: &'a LateContext<'a, 'tcx>,
-    s: SipHasher,
+    s: DefaultHasher,
 }
 
 impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
     pub fn new(cx: &'a LateContext<'a, 'tcx>) -> Self {
         SpanlessHash {
             cx: cx,
-            s: SipHasher::new(),
+            s: DefaultHasher::new(),
         }
     }
 


### PR DESCRIPTION
We have a warning with the latest nightly:

```rust
warning: use of deprecated item: use `DefaultHasher` instead, #[warn(deprecated)] on by default
 --> clippy_lints/src/utils/hir.rs:4:31
  |
4 | use std::hash::{Hash, Hasher, SipHasher};
  |                               ^^^^^^^^^

warning: use of deprecated item: use `DefaultHasher` instead, #[warn(deprecated)] on by default
   --> clippy_lints/src/utils/hir.rs:275:8
    |
275 |     s: SipHasher,
    |        ^^^^^^^^^

warning: use of deprecated item: use `DefaultHasher` instead, #[warn(deprecated)] on by default
   --> clippy_lints/src/utils/hir.rs:282:16
    |
282 |             s: SipHasher::new(),
    |                ^^^^^^^^^^^^^^
```

See https://github.com/rust-lang/rust/pull/36815.

It's probably not worth bumping the version for just that but it's kind of paradoxical to have warnings in a linter :blush: