### PR TITLE
Avoid redundant multiple pattern suggested when one pattern is _

### DIFF
--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -201,7 +201,14 @@ fn lint_match_arms(cx: &LateContext, expr: &Expr) {
                 if i.pats.len() == 1 && j.pats.len() == 1 {
                     let lhs = snippet(cx, i.pats[0].span, "<pat1>");
                     let rhs = snippet(cx, j.pats[0].span, "<pat2>");
-                    db.span_note(i.body.span, &format!("consider refactoring into `{} | {}`", lhs, rhs));
+
+                    if let PatKind::Wild = j.pats[0].node {
+                        // if the last arm is _, then i could be integrated into _
+                        // note that i.pats[0] cannot be _, because that would mean that we're hiding all the subsequent arms, and rust won't compile
+                        db.span_note(i.body.span, &format!("`{}` has the same arm body as the `_` wildcard, consider removing it`", lhs));
+                    } else {
+                        db.span_note(i.body.span, &format!("consider refactoring into `{} | {}`", lhs, rhs));
+                    }
                 }
             });
         }

--- a/tests/compile-fail/copies.rs
+++ b/tests/compile-fail/copies.rs
@@ -18,6 +18,12 @@ struct Foo {
     bar: u8,
 }
 
+pub enum Abc {
+    A,
+    B,
+    C,
+}
+
 #[deny(if_same_then_else)]
 #[deny(match_same_arms)]
 fn if_same_then_else() -> Result<&'static str, ()> {
@@ -73,7 +79,7 @@ fn if_same_then_else() -> Result<&'static str, ()> {
     let _ = match 42 {
         42 => {
             //~^ NOTE same as this
-            //~| NOTE refactoring
+            //~| NOTE removing
             foo();
             let mut a = 42 + [23].len() as i32;
             if true {
@@ -91,6 +97,14 @@ fn if_same_then_else() -> Result<&'static str, ()> {
             a = -31-a;
             a
         }
+    };
+
+    let _ = match Abc::A {
+        Abc::A => 0,
+        //~^ NOTE same as this
+        //~| NOTE removing
+        Abc::B => 1,
+        _ => 0, //~ERROR this `match` has identical arm bodies
     };
 
     if true {


### PR DESCRIPTION
This PR fixes #1272.

However I'm not sure the warning message is clear enough, but after all it should work fine.