### PR TITLE
Rustup to *rustc 1.14.0-nightly (f09420685 2016-10-20)* and bump to 0.0.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.96 — 2016-10-22
+* Rustup to *rustc 1.14.0-nightly (f09420685 2016-10-20)*
+* New lint: [`iter_skip_next`]
+
 ## 0.0.95 — 2016-10-06
 * Rustup to *rustc 1.14.0-nightly (3210fd5c2 2016-10-05)*
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.95"
+version = "0.0.96"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -25,7 +25,7 @@ test = false
 
 [dependencies]
 # begin automatic update
-clippy_lints = { version = "0.0.95", path = "clippy_lints" }
+clippy_lints = { version = "0.0.96", path = "clippy_lints" }
 # end automatic update
 
 [dev-dependencies]

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.95"
+version = "0.0.96"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",

--- a/clippy_lints/src/print.rs
+++ b/clippy_lints/src/print.rs
@@ -2,7 +2,7 @@ use rustc::hir::*;
 use rustc::hir::map::Node::{NodeItem, NodeImplItem};
 use rustc::lint::*;
 use utils::paths;
-use utils::{is_expn_of, match_path, span_lint};
+use utils::{is_expn_of, match_path, match_def_path, resolve_node, span_lint};
 use format::get_argument_fmtstr_parts;
 
 /// **What it does:** This lint warns when you using `print!()` with a format string that
@@ -67,63 +67,69 @@ impl LintPass for Pass {
 
 impl LateLintPass for Pass {
     fn check_expr(&mut self, cx: &LateContext, expr: &Expr) {
-        if let ExprCall(ref fun, ref args) = expr.node {
-            if let ExprPath(_, ref path) = fun.node {
-                // Search for `std::io::_print(..)` which is unique in a
-                // `print!` expansion.
-                if match_path(path, &paths::IO_PRINT) {
-                    if let Some(span) = is_expn_of(cx, expr.span, "print") {
-                        // `println!` uses `print!`.
-                        let (span, name) = match is_expn_of(cx, span, "println") {
-                            Some(span) => (span, "println"),
-                            None => (span, "print"),
-                        };
+        if_let_chain! {[
+            let ExprCall(ref fun, ref args) = expr.node,
+            let ExprPath(..) = fun.node,
+            let Some(fun) = resolve_node(cx, fun.id),
+        ], {
+            let fun_id = fun.def_id();
 
-                        span_lint(cx, PRINT_STDOUT, span, &format!("use of `{}!`", name));
+            // Search for `std::io::_print(..)` which is unique in a
+            // `print!` expansion.
+            if match_def_path(cx, fun_id, &paths::IO_PRINT) {
+                if let Some(span) = is_expn_of(cx, expr.span, "print") {
+                    // `println!` uses `print!`.
+                    let (span, name) = match is_expn_of(cx, span, "println") {
+                        Some(span) => (span, "println"),
+                        None => (span, "print"),
+                    };
 
-                        // Check print! with format string ending in "\n".
-                        if_let_chain!{[
-                            name == "print",
+                    span_lint(cx, PRINT_STDOUT, span, &format!("use of `{}!`", name));
 
-                            // ensure we're calling Arguments::new_v1
-                            args.len() == 1,
-                            let ExprCall(ref args_fun, ref args_args) = args[0].node,
-                            let ExprPath(_, ref args_path) = args_fun.node,
-                            match_path(args_path, &paths::FMT_ARGUMENTS_NEWV1),
-                            args_args.len() == 2,
-                            let ExprAddrOf(_, ref match_expr) = args_args[1].node,
-                            let ExprMatch(ref args, _, _) = match_expr.node,
-                            let ExprTup(ref args) = args.node,
+                    // Check print! with format string ending in "\n".
+                    if_let_chain!{[
+                        name == "print",
 
-                            // collect the format string parts and check the last one
-                            let Some(fmtstrs) = get_argument_fmtstr_parts(cx, &args_args[0]),
-                            let Some(last_str) = fmtstrs.last(),
-                            let Some('\n') = last_str.chars().last(),
+                        // ensure we're calling Arguments::new_v1
+                        args.len() == 1,
+                        let ExprCall(ref args_fun, ref args_args) = args[0].node,
+                        let ExprPath(..) = args_fun.node,
+                        let Some(def) = resolve_node(cx, args_fun.id),
+                        match_def_path(cx, def.def_id(), &paths::FMT_ARGUMENTS_NEWV1),
+                        args_args.len() == 2,
+                        let ExprAddrOf(_, ref match_expr) = args_args[1].node,
+                        let ExprMatch(ref args, _, _) = match_expr.node,
+                        let ExprTup(ref args) = args.node,
 
-                            // "foo{}bar" is made into two strings + one argument,
-                            // if the format string starts with `{}` (eg. "{}foo"),
-                            // the string array is prepended an empty string "".
-                            // We only want to check the last string after any `{}`:
-                            args.len() < fmtstrs.len(),
-                        ], {
-                            span_lint(cx, PRINT_WITH_NEWLINE, span,
-                                      "using `print!()` with a format string that ends in a \
-                                       newline, consider using `println!()` instead");
-                        }}
-                    }
+                        // collect the format string parts and check the last one
+                        let Some(fmtstrs) = get_argument_fmtstr_parts(cx, &args_args[0]),
+                        let Some(last_str) = fmtstrs.last(),
+                        let Some('\n') = last_str.chars().last(),
+
+                        // "foo{}bar" is made into two strings + one argument,
+                        // if the format string starts with `{}` (eg. "{}foo"),
+                        // the string array is prepended an empty string "".
+                        // We only want to check the last string after any `{}`:
+                        args.len() < fmtstrs.len(),
+                    ], {
+                        span_lint(cx, PRINT_WITH_NEWLINE, span,
+                                  "using `print!()` with a format string that ends in a \
+                                   newline, consider using `println!()` instead");
+                    }}
                 }
-                // Search for something like
-                // `::std::fmt::ArgumentV1::new(__arg0, ::std::fmt::Debug::fmt)`
-                else if args.len() == 2 && match_path(path, &paths::FMT_ARGUMENTV1_NEW) {
-                    if let ExprPath(None, ref path) = args[1].node {
-                        if match_path(path, &paths::DEBUG_FMT_METHOD) && !is_in_debug_impl(cx, expr) &&
-                           is_expn_of(cx, expr.span, "panic").is_none() {
-                            span_lint(cx, USE_DEBUG, args[0].span, "use of `Debug`-based formatting");
-                        }
+            }
+            // Search for something like
+            // `::std::fmt::ArgumentV1::new(__arg0, ::std::fmt::Debug::fmt)`
+            else if args.len() == 2 && match_def_path(cx, fun_id, &paths::FMT_ARGUMENTV1_NEW) {
+                if let ExprPath(None, _) = args[1].node {
+                    let def_id = resolve_node(cx, args[1].id).unwrap().def_id();
+                    if match_def_path(cx, def_id, &paths::DEBUG_FMT_METHOD) && !is_in_debug_impl(cx, expr) &&
+                       is_expn_of(cx, expr.span, "panic").is_none() {
+                        span_lint(cx, USE_DEBUG, args[0].span, "use of `Debug`-based formatting");
                     }
                 }
             }
-        }
+        }}
     }
 }
 

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -279,6 +279,11 @@ pub fn implements_trait<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: ty::Ty<'tcx>, 
     })
 }
 
+/// Resolve the definition of a node from its `NodeId`.
+pub fn resolve_node(cx: &LateContext, id: NodeId) -> Option<def::Def> {
+    cx.tcx.def_map.borrow().get(&id).map(|d| d.full_def())
+}
+
 /// Match an `Expr` against a chain of methods, and return the matched `Expr`s.
 ///
 /// For example, if `expr` represents the `.baz()` in `foo.bar().baz()`,

--- a/clippy_lints/src/utils/paths.rs
+++ b/clippy_lints/src/utils/paths.rs
@@ -1,6 +1,6 @@
 //! This module contains paths to types and functions Clippy needs to know about.
 
-pub const BEGIN_PANIC: [&'static str; 3] = ["std", "rt", "begin_panic"];
+pub const BEGIN_PANIC: [&'static str; 3] = ["std", "panicking", "begin_panic"];
 pub const BINARY_HEAP: [&'static str; 3] = ["collections", "binary_heap", "BinaryHeap"];
 pub const BOX: [&'static str; 3] = ["std", "boxed", "Box"];
 pub const BOX_NEW: [&'static str; 4] = ["std", "boxed", "Box", "new"];
@@ -13,18 +13,18 @@ pub const CMP_MAX: [&'static str; 3] = ["core", "cmp", "max"];
 pub const CMP_MIN: [&'static str; 3] = ["core", "cmp", "min"];
 pub const COW: [&'static str; 3] = ["collections", "borrow", "Cow"];
 pub const CSTRING_NEW: [&'static str; 4] = ["std", "ffi", "CString", "new"];
-pub const DEBUG_FMT_METHOD: [&'static str; 4] = ["std", "fmt", "Debug", "fmt"];
+pub const DEBUG_FMT_METHOD: [&'static str; 4] = ["core", "fmt", "Debug", "fmt"];
 pub const DEFAULT_TRAIT: [&'static str; 3] = ["core", "default", "Default"];
-pub const DISPLAY_FMT_METHOD: [&'static str; 4] = ["std", "fmt", "Display", "fmt"];
+pub const DISPLAY_FMT_METHOD: [&'static str; 4] = ["core", "fmt", "Display", "fmt"];
 pub const DROP: [&'static str; 3] = ["core", "mem", "drop"];
-pub const FMT_ARGUMENTS_NEWV1: [&'static str; 4] = ["std", "fmt", "Arguments", "new_v1"];
-pub const FMT_ARGUMENTV1_NEW: [&'static str; 4] = ["std", "fmt", "ArgumentV1", "new"];
+pub const FMT_ARGUMENTS_NEWV1: [&'static str; 4] = ["core", "fmt", "Arguments", "new_v1"];
+pub const FMT_ARGUMENTV1_NEW: [&'static str; 4] = ["core", "fmt", "ArgumentV1", "new"];
 pub const HASH: [&'static str; 2] = ["hash", "Hash"];
 pub const HASHMAP: [&'static str; 5] = ["std", "collections", "hash", "map", "HashMap"];
 pub const HASHMAP_ENTRY: [&'static str; 5] = ["std", "collections", "hash", "map", "Entry"];
 pub const HASHSET: [&'static str; 5] = ["std", "collections", "hash", "set", "HashSet"];
 pub const INTO_ITERATOR: [&'static str; 4] = ["core", "iter", "traits", "IntoIterator"];
-pub const IO_PRINT: [&'static str; 3] = ["std", "io", "_print"];
+pub const IO_PRINT: [&'static str; 4] = ["std", "io", "stdio", "_print"];
 pub const ITERATOR: [&'static str; 4] = ["core", "iter", "iterator", "Iterator"];
 pub const LINKED_LIST: [&'static str; 3] = ["collections", "linked_list", "LinkedList"];
 pub const LINT: [&'static str; 3] = ["rustc", "lint", "Lint"];
@@ -64,4 +64,4 @@ pub const STRING: [&'static str; 3] = ["collections", "string", "String"];
 pub const TRANSMUTE: [&'static str; 4] = ["core", "intrinsics", "", "transmute"];
 pub const VEC: [&'static str; 3] = ["collections", "vec", "Vec"];
 pub const VEC_DEQUE: [&'static str; 3] = ["collections", "vec_deque", "VecDeque"];
-pub const VEC_FROM_ELEM: [&'static str; 3] = ["std", "vec", "from_elem"];
+pub const VEC_FROM_ELEM: [&'static str; 3] = ["collections", "vec", "from_elem"];


### PR DESCRIPTION
0.0.95 compiles on the latest nightly, but is buggy with macros (see [Travis](https://travis-ci.org/Manishearth/rust-clippy/builds/168036054)).
See https://github.com/rust-lang/rust/pull/37213.