### PR TITLE
Don't assume the first package in the result of `cargo metadata` is the current crate.

### DIFF
--- a/clippy_lints/src/utils/cargo.rs
+++ b/clippy_lints/src/utils/cargo.rs
@@ -20,7 +20,7 @@ pub struct Package {
     pub dependencies: Vec<Dependency>,
     pub targets: Vec<Target>,
     features: HashMap<String, Vec<String>>,
-    manifest_path: String,
+    pub manifest_path: String,
 }
 
 #[derive(RustcDecodable, Debug)]
@@ -65,10 +65,10 @@ impl From<json::DecoderError> for Error {
     }
 }
 
-pub fn metadata(manifest_path: Option<String>) -> Result<Metadata, Error> {
+pub fn metadata(manifest_path_arg: &Option<String>) -> Result<Metadata, Error> {
     let mut cmd = Command::new("cargo");
     cmd.arg("metadata").arg("--no-deps");
-    if let Some(ref mani) = manifest_path {
+    if let Some(ref mani) = *manifest_path_arg {
         cmd.arg(mani);
     }
     let output = cmd.output()?;

--- a/clippy_lints/src/utils/cargo.rs
+++ b/clippy_lints/src/utils/cargo.rs
@@ -65,10 +65,10 @@ impl From<json::DecoderError> for Error {
     }
 }
 
-pub fn metadata(manifest_path_arg: &Option<String>) -> Result<Metadata, Error> {
+pub fn metadata(manifest_path_arg: Option<&str>) -> Result<Metadata, Error> {
     let mut cmd = Command::new("cargo");
     cmd.arg("metadata").arg("--no-deps");
-    if let Some(ref mani) = *manifest_path_arg {
+    if let Some(mani) = manifest_path_arg {
         cmd.arg(mani);
     }
     let output = cmd.output()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ pub fn main() {
         // this arm is executed on the initial call to `cargo clippy`
         let manifest_path_arg = std::env::args().skip(2).find(|val| val.starts_with("--manifest-path="));
 
-        let mut metadata = cargo::metadata(&manifest_path_arg).expect("could not obtain cargo metadata");
+        let mut metadata = cargo::metadata(manifest_path_arg.as_ref().map(AsRef::as_ref)).expect("could not obtain cargo metadata");
         assert_eq!(metadata.version, 1);
 
         let manifest_path = manifest_path_arg.map(|arg| PathBuf::from(Path::new(&arg["--manifest-path=".len()..])));

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,11 +152,10 @@ pub fn main() {
                 let package_manifest_path = Path::new(&package.manifest_path);
                 if let Some(ref manifest_path) = manifest_path {
                     package_manifest_path == manifest_path
-                } else if let Ok(ref current_dir) = current_dir {
+                } else {
+                    let current_dir = current_dir.as_ref().expect("could not read current directory");
                     let package_manifest_directory = package_manifest_path.parent().expect("could not find parent directory of package manifest");
                     package_manifest_directory == current_dir
-                } else {
-                    panic!("could not read current directory")
                 }
             })
             .expect("could not find matching package");

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,10 +138,30 @@ pub fn main() {
 
     if let Some("clippy") = std::env::args().nth(1).as_ref().map(AsRef::as_ref) {
         // this arm is executed on the initial call to `cargo clippy`
-        let manifest_path = std::env::args().skip(2).find(|val| val.starts_with("--manifest-path="));
-        let mut metadata = cargo::metadata(manifest_path).expect("could not obtain cargo metadata");
+        let manifest_path_arg = std::env::args().skip(2).find(|val| val.starts_with("--manifest-path="));
+
+        let mut metadata = cargo::metadata(&manifest_path_arg).expect("could not obtain cargo metadata");
         assert_eq!(metadata.version, 1);
-        for target in metadata.packages.remove(0).targets {
+
+        let manifest_path = manifest_path_arg.map(|arg| PathBuf::from(Path::new(&arg["--manifest-path=".len()..])));
+
+        let current_dir = std::env::current_dir();
+
+        let package_index = metadata.packages.iter()
+            .position(|package| {
+                let package_manifest_path = Path::new(&package.manifest_path);
+                if let Some(ref manifest_path) = manifest_path {
+                    package_manifest_path == manifest_path
+                } else if let Ok(ref current_dir) = current_dir {
+                    let package_manifest_directory = package_manifest_path.parent().expect("could not find parent directory of package manifest");
+                    package_manifest_directory == current_dir
+                } else {
+                    panic!("could not read current directory")
+                }
+            })
+            .expect("could not find matching package");
+        let package = metadata.packages.remove(package_index);
+        for target in package.targets {
             let args = std::env::args().skip(2);
             if let Some(first) = target.kind.get(0) {
                 if target.kind.len() > 1 || first.ends_with("lib") {

--- a/tests/versioncheck.rs
+++ b/tests/versioncheck.rs
@@ -3,9 +3,9 @@ use clippy_lints::utils::cargo;
 
 #[test]
 fn check_that_clippy_lints_has_the_same_version_as_clippy() {
-    let clippy_meta = cargo::metadata(None).expect("could not obtain cargo metadata");
+    let clippy_meta = cargo::metadata(&None).expect("could not obtain cargo metadata");
     std::env::set_current_dir(std::env::current_dir().unwrap().join("clippy_lints")).unwrap();
-    let clippy_lints_meta = cargo::metadata(None).expect("could not obtain cargo metadata");
+    let clippy_lints_meta = cargo::metadata(&None).expect("could not obtain cargo metadata");
     assert_eq!(clippy_lints_meta.packages[0].version, clippy_meta.packages[0].version);
     for package in &clippy_meta.packages[0].dependencies {
         if package.name == "clippy_lints" {

--- a/tests/versioncheck.rs
+++ b/tests/versioncheck.rs
@@ -3,9 +3,9 @@ use clippy_lints::utils::cargo;
 
 #[test]
 fn check_that_clippy_lints_has_the_same_version_as_clippy() {
-    let clippy_meta = cargo::metadata(&None).expect("could not obtain cargo metadata");
+    let clippy_meta = cargo::metadata(None).expect("could not obtain cargo metadata");
     std::env::set_current_dir(std::env::current_dir().unwrap().join("clippy_lints")).unwrap();
-    let clippy_lints_meta = cargo::metadata(&None).expect("could not obtain cargo metadata");
+    let clippy_lints_meta = cargo::metadata(None).expect("could not obtain cargo metadata");
     assert_eq!(clippy_lints_meta.packages[0].version, clippy_meta.packages[0].version);
     for package in &clippy_meta.packages[0].dependencies {
         if package.name == "clippy_lints" {


### PR DESCRIPTION
Instead find the one with the manifest path that matches the --manifest-path argument or the current directory.

Fixes #1247

---

This contains one breaking API change in the signature of `clippy_lints::utils::cargo::metadata()`. I could revert it and `clone()` the option in `clippy` if you don't want the breaking change.

---

I can't just define `Package::manifest_path` as a `PathBuf` instead of a `String` because [this](https://github.com/rust-lang-nursery/rustc-serialize/blob/740f705/src/serialize.rs#L1356) leads to `Json(ExpectedError("Array", "\"C:\\\\foo\\\\bar\\\\Cargo.toml\""))`