### PR TITLE
Be more helping, less helpful and bring convenience back for the dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.97 — 2016-10-24
+* For convenience, `cargo clippy` defines a `cargo-clippy` feature. This was
+  previously added for a short time under the name `clippy` but removed for
+  compatibility.
+* `cargo clippy --help` is more helping (and less helpful :smile:)
+
 ## 0.0.96 — 2016-10-22
 * Rustup to *rustc 1.14.0-nightly (f09420685 2016-10-20)*
 * New lint: [`iter_skip_next`]

--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ You can add options  to `allow`/`warn`/`deny`:
 
 Note: `deny` produces errors instead of warnings.
 
+For convenience, `cargo clippy` automatically defines a `cargo-clippy`
+features. This lets you set lints level and compile with or without clippy
+transparently:
+
+```rust
+#[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
+```
+
 ## Link with clippy service
 
 `clippy-service` is a rust web initiative providing `rust-clippy` as a web service.

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,11 @@ it to allow or deny lints, eg.:
     #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
 "#;
 
+#[allow(print_stdout)]
+fn show_help() {
+    println!("{}", CARGO_CLIPPY_HELP);
+}
+
 pub fn main() {
     use std::env;
 
@@ -165,12 +170,9 @@ pub fn main() {
     if let Some("clippy") = std::env::args().nth(1).as_ref().map(AsRef::as_ref) {
         // this arm is executed on the initial call to `cargo clippy`
 
-        match std::env::args().nth(2).as_ref().map(AsRef::as_ref) {
-            Some("--help") | Some("-h") => {
-                println!("{}", CARGO_CLIPPY_HELP);
-                return;
-            }
-            _ => (),
+        if std::env::args().any(|a| a == "--help" || a == "-h") {
+            show_help();
+            return;
         }
 
         let manifest_path_arg = std::env::args().skip(2).find(|val| val.starts_with("--manifest-path="));

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,8 +111,7 @@ impl<'a> CompilerCalls<'a> for ClippyCompilerCalls {
 
 use std::path::Path;
 
-const CARGO_CLIPPY_HELP: &str = "\
-Checks a package to catch common mistakes and improve your Rust code.
+const CARGO_CLIPPY_HELP: &str = r#"Checks a package to catch common mistakes and improve your Rust code.
 
 Usage:
     cargo clippy [options] [--] [<opts>...]
@@ -129,8 +128,13 @@ one of:
     -W --warn OPT       Set lint warnings
     -A --allow OPT      Set lint allowed
     -D --deny OPT       Set lint denied
-    -F --forbid OPT     Set lint forbidden\
-";
+    -F --forbid OPT     Set lint forbidden
+
+The feature `cargo-clippy` is automatically defined for convinence. You can use
+it to allow or deny lints, eg.:
+
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
+"#;
 
 pub fn main() {
     use std::env;
@@ -213,13 +217,16 @@ pub fn main() {
 
         // this conditional check for the --sysroot flag is there so users can call `cargo-clippy` directly
         // without having to pass --sysroot or anything
-        let args: Vec<String> = if env::args().any(|s| s == "--sysroot") {
+        let mut args: Vec<String> = if env::args().any(|s| s == "--sysroot") {
             env::args().collect()
         } else {
             env::args().chain(Some("--sysroot".to_owned())).chain(Some(sys_root)).collect()
         };
+
         // this check ensures that dependencies are built but not linted and the final crate is
         // linted but not built
+        args.extend_from_slice(&["--cfg".to_owned(), r#"feature="cargo-clippy""#.to_owned()]);
+
         let mut ccc = ClippyCompilerCalls::new(env::args().any(|s| s == "-Zno-trans"));
         let (result, _) = rustc_driver::run_compiler(&args, &mut ccc, None, None);
 
@@ -251,6 +258,8 @@ fn process<P, I>(old_args: I, dep_path: P, sysroot: &str) -> Result<(), i32>
     args.push(String::from("--sysroot"));
     args.push(sysroot.to_owned());
     args.push("-Zno-trans".to_owned());
+    args.push("--cfg".to_owned());
+    args.push(r#"feature="cargo-clippy""#.to_owned());
 
     let path = std::env::current_exe().expect("current executable path invalid");
     let exit_status = std::process::Command::new("cargo")

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,16 +122,16 @@ Common options:
 
 Other options are the same as `cargo rustc`.
 
-To allow or deny a lint from the command line you can use `cargo clippy --` with
-one of:
+To allow or deny a lint from the command line you can use `cargo clippy --`
+with:
 
     -W --warn OPT       Set lint warnings
     -A --allow OPT      Set lint allowed
     -D --deny OPT       Set lint denied
     -F --forbid OPT     Set lint forbidden
 
-The feature `cargo-clippy` is automatically defined for convinence. You can use
-it to allow or deny lints, eg.:
+The feature `cargo-clippy` is automatically defined for convenience. You can use
+it to allow or deny lints from the code, eg.:
 
     #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
 "#;


### PR DESCRIPTION
Close #1283. `cargo clippy --help` and `cargo help clippy` work as they should, not delegating to `cargo rustc --help` and showing help only once. Is the help message ok? What more should it contain?
Close #1286. Brings back the automatic feature under the name `cargo-clippy`. I haven't found any crate using that, so it should not cause compatibility problems as before.