### PR TITLE
Implement 'Re-implementing `PartialEq::ne`' lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,6 +319,7 @@ All notable changes to this project will be documented in this file.
 [`out_of_bounds_indexing`]: https://github.com/Manishearth/rust-clippy/wiki#out_of_bounds_indexing
 [`overflow_check_conditional`]: https://github.com/Manishearth/rust-clippy/wiki#overflow_check_conditional
 [`panic_params`]: https://github.com/Manishearth/rust-clippy/wiki#panic_params
+[`partialeq_ne_impl`]: https://github.com/Manishearth/rust-clippy/wiki#partialeq_ne_impl
 [`precedence`]: https://github.com/Manishearth/rust-clippy/wiki#precedence
 [`print_stdout`]: https://github.com/Manishearth/rust-clippy/wiki#print_stdout
 [`print_with_newline`]: https://github.com/Manishearth/rust-clippy/wiki#print_with_newline

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ You can check out this great service at [clippy.bashy.io](https://clippy.bashy.i
 
 ## Lints
 
-There are 175 lints included in this crate:
+There are 176 lints included in this crate:
 
 name                                                                                                                   | default | triggers on
 -----------------------------------------------------------------------------------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------
@@ -293,6 +293,7 @@ name                                                                            
 [out_of_bounds_indexing](https://github.com/Manishearth/rust-clippy/wiki#out_of_bounds_indexing)                       | deny    | out of bounds constant indexing
 [overflow_check_conditional](https://github.com/Manishearth/rust-clippy/wiki#overflow_check_conditional)               | warn    | overflow checks inspired by C which are likely to panic
 [panic_params](https://github.com/Manishearth/rust-clippy/wiki#panic_params)                                           | warn    | missing parameters in `panic!` calls
+[partialeq_ne_impl](https://github.com/Manishearth/rust-clippy/wiki#partialeq_ne_impl)                                 | warn    | re-implementing `PartialEq::ne`
 [precedence](https://github.com/Manishearth/rust-clippy/wiki#precedence)                                               | warn    | operations where precedence may be unclear
 [print_stdout](https://github.com/Manishearth/rust-clippy/wiki#print_stdout)                                           | allow   | printing on stdout
 [print_with_newline](https://github.com/Manishearth/rust-clippy/wiki#print_with_newline)                               | warn    | using `print!()` with a format string that ends in a newline

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -111,6 +111,7 @@ pub mod ok_if_let;
 pub mod open_options;
 pub mod overflow_check_conditional;
 pub mod panic;
+pub mod partialeq_ne_impl;
 pub mod precedence;
 pub mod print;
 pub mod ptr;
@@ -259,6 +260,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box missing_doc::MissingDoc::new());
     reg.register_late_lint_pass(box ok_if_let::Pass);
     reg.register_late_lint_pass(box if_let_redundant_pattern_matching::Pass);
+    reg.register_late_lint_pass(box partialeq_ne_impl::Pass);
 
     reg.register_lint_group("clippy_restrictions", vec![
         arithmetic::FLOAT_ARITHMETIC,
@@ -415,6 +417,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         open_options::NONSENSICAL_OPEN_OPTIONS,
         overflow_check_conditional::OVERFLOW_CHECK_CONDITIONAL,
         panic::PANIC_PARAMS,
+        partialeq_ne_impl::PARTIALEQ_NE_IMPL,
         precedence::PRECEDENCE,
         print::PRINT_WITH_NEWLINE,
         ptr::CMP_NULL,

--- a/clippy_lints/src/partialeq_ne_impl.rs
+++ b/clippy_lints/src/partialeq_ne_impl.rs
@@ -1,0 +1,55 @@
+use rustc::lint::*;
+use rustc::hir::*;
+use utils::{is_automatically_derived, span_lint};
+
+/// **What it does:** Checks for manual re-implementations of `PartialEq::ne`.
+///
+/// **Why is this bad?** `PartialEq::ne` is required to always return the
+/// negated result of `PartialEq::eq`, which is exactly what the default
+/// implementation does. Therefore, there should never be any need to
+/// re-implement it.
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rust
+/// struct Foo;
+///
+/// impl PartialEq for Foo {
+///    fn eq(&self, other: &Foo) -> bool { ... }
+///    fn ne(&self, other: &Foo) -> bool { !(self == other) }
+/// }
+/// ```
+declare_lint! {
+    pub PARTIALEQ_NE_IMPL,
+    Warn,
+    "re-implementing `PartialEq::ne`"
+}
+
+#[derive(Clone, Copy)]
+pub struct Pass;
+
+impl LintPass for Pass {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(PARTIALEQ_NE_IMPL)
+    }
+}
+
+impl LateLintPass for Pass {
+    fn check_item(&mut self, cx: &LateContext, item: &Item) {
+        if_let_chain! {[
+            let ItemImpl(_, _, _, Some(ref trait_ref), _, ref impl_items) = item.node,
+            !is_automatically_derived(&*item.attrs),
+            cx.tcx.expect_def(trait_ref.ref_id).def_id() == cx.tcx.lang_items.eq_trait().unwrap(),
+        ], {
+            for impl_item in impl_items {
+                if &*impl_item.name.as_str() == "ne" {
+                    span_lint(cx,
+                              PARTIALEQ_NE_IMPL,
+                              impl_item.span,
+                              "re-implementing `PartialEq::ne` is unnecessary")
+                }
+            }
+        }};
+    }
+}

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -4,7 +4,8 @@
 
 use rustc::lint::*;
 use rustc::hir;
-use syntax::ast::{Attribute, MetaItemKind};
+use syntax::ast::Attribute;
+use syntax::attr;
 
 /// **What it does:** Dumps every ast/hir node which has the `#[clippy_dump]` attribute
 ///
@@ -128,10 +129,7 @@ impl LateLintPass for Pass {
 }
 
 fn has_attr(attrs: &[Attribute]) -> bool {
-    attrs.iter().any(|attr| match attr.node.value.node {
-        MetaItemKind::Word(ref word) => word == "clippy_dump",
-        _ => false,
-    })
+    attr::contains_name(attrs, "clippy_dump")
 }
 
 fn print_decl(cx: &LateContext, decl: &hir::Decl) {

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -379,12 +379,12 @@ fn print_item(cx: &LateContext, item: &hir::Item) {
             }
         },
         hir::ItemDefaultImpl(_, ref trait_ref) => {
-            let trait_did = cx.tcx.map.local_def_id(trait_ref.ref_id);
-            println!("default impl for `{:?}`", cx.tcx.item_path_str(trait_did));
+            let trait_did = cx.tcx.expect_def(trait_ref.ref_id).def_id();
+            println!("default impl for `{}`", cx.tcx.item_path_str(trait_did));
         },
         hir::ItemImpl(_, _, _, Some(ref trait_ref), _, _) => {
-            let trait_did = cx.tcx.map.local_def_id(trait_ref.ref_id);
-            println!("impl of trait `{:?}`", cx.tcx.item_path_str(trait_did));
+            let trait_did = cx.tcx.expect_def(trait_ref.ref_id).def_id();
+            println!("impl of trait `{}`", cx.tcx.item_path_str(trait_did));
         },
         hir::ItemImpl(_, _, _, None, _, _) => {
             println!("impl");

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -14,6 +14,7 @@ use std::env;
 use std::mem;
 use std::str::FromStr;
 use syntax::ast::{self, LitKind};
+use syntax::attr;
 use syntax::codemap::{ExpnFormat, ExpnInfo, MultiSpan, Span, DUMMY_SP};
 use syntax::errors::DiagnosticBuilder;
 use syntax::ptr::P;
@@ -760,4 +761,9 @@ pub fn is_refutable(cx: &LateContext, pat: &Pat) -> bool {
             are_refutable(cx, head.iter().chain(middle).chain(tail.iter()).map(|pat| &**pat))
         }
     }
+}
+
+/// Checks for the `#[automatically_derived]` attribute all `#[derive]`d implementations have.
+pub fn is_automatically_derived(attrs: &[ast::Attribute]) -> bool {
+    attr::contains_name(attrs, "automatically_derived")
 }

--- a/tests/compile-fail/partialeq_ne_impl.rs
+++ b/tests/compile-fail/partialeq_ne_impl.rs
@@ -1,0 +1,15 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+#![deny(warnings)]
+#![allow(dead_code)]
+
+struct Foo;
+
+impl PartialEq for Foo {
+    fn eq(&self, _: &Foo) -> bool { true }
+    fn ne(&self, _: &Foo) -> bool { false }
+    //~^ ERROR re-implementing `PartialEq::ne` is unnecessary
+}
+
+fn main() {}

--- a/util/dogfood.sh
+++ b/util/dogfood.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 rm -rf target*/*so
-cargo build --lib && cp -R target target_recur && cargo rustc -- -Zextra-plugins=clippy -Ltarget_recur/debug -Dclippy_pedantic -Dclippy || exit 1
+cargo build --lib && cp -R target target_recur && cargo rustc --lib -- -Zextra-plugins=clippy -Ltarget_recur/debug -Dclippy_pedantic -Dclippy || exit 1
 rm -rf target_recur
 


### PR DESCRIPTION
Closes #86

@oli-obk I didn't track the time for implementing this, but most of it was probably spent on figuring out why `compiletest` kept saying `0 unexpected errors found, 1 expected errors not found`. In the end, I copied and ran the `rustc` cmdline for that file separately, which showed that there was indeed an unexpected and very simple error: `main function not found` :| . Apparently `compiletest` [may swallow unexpected errors](https://github.com/laumann/compiletest-rs/issues/48).

So perhaps `CONTRIBUTING.md` should include some hints for debugging lints, including mentioning the `TESTNAME` env var and `#[clippy_dump]`.
