### PR TITLE
Add to docs for if_let_some_result

### DIFF
--- a/clippy_lints/src/ok_if_let.rs
+++ b/clippy_lints/src/ok_if_let.rs
@@ -9,9 +9,18 @@ use utils::{paths, method_chain_args, span_help_and_lint, match_type, snippet};
 /// **Known problems:** None.
 ///
 /// **Example:**
-/// ```rustc
+/// ```rust
 /// for result in iter {
 ///     if let Some(bench) = try!(result).parse().ok() {
+///         vec.push(bench)
+///     }
+/// }
+///```
+/// Could be written:
+///
+/// ```rust
+/// for result in iter {
+///     if let Ok(bench) = try!(result).parse() {
 ///         vec.push(bench)
 ///     }
 /// }


### PR DESCRIPTION
Add the changed output for if_let_some_result

This lint doesn't appear in the wiki, I was wondering if this is because the file is called `ok_if_let` rather than `if_let_some_result` (or if it's just because the wiki hasn't been updated yet 😄 ). Is it worth changing the file names?