### PR TITLE
 Add '--version' flag and allow version and help flags when called as 'cargo-clippy'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,7 @@ Usage:
 Common options:
     -h, --help               Print this message
     --features               Features to compile for the package
+    -V, --version            Print version info and exit
 
 Other options are the same as `cargo rustc`.
 
@@ -146,16 +147,21 @@ pub fn main() {
     if env::var("CLIPPY_DOGFOOD").map(|_| true).unwrap_or(false) {
         panic!("yummy");
     }
+    
+    // Check for version and help flags even when invoked as 'cargo-clippy'
+    if std::env::args().any(|a| a == "--help" || a == "-h") {
+        show_help();
+        return;
+    }
+    if std::env::args().any(|a| a == "--version" || a == "-V") {
+        println!("{}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
 
     let dep_path = env::current_dir().expect("current dir is not readable").join("target").join("debug").join("deps");
 
     if let Some("clippy") = std::env::args().nth(1).as_ref().map(AsRef::as_ref) {
         // this arm is executed on the initial call to `cargo clippy`
-
-        if std::env::args().any(|a| a == "--help" || a == "-h") {
-            show_help();
-            return;
-        }
 
         let manifest_path_arg = std::env::args().skip(2).find(|val| val.starts_with("--manifest-path="));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,6 @@ fn show_version() {
     println!("{}", env!("CARGO_PKG_VERSION"));
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(print_stdout))]
 pub fn main() {
     use std::env;
 


### PR DESCRIPTION
This makes it easier to integrate 'cargo clippy' into other tools. 
(Or at least makes it possible to reason about the capabilities of the tool based on its version).