### PR TITLE
Allow explicit returns with cfg attributes

### DIFF
--- a/tests/run-pass/needless_return.rs
+++ b/tests/run-pass/needless_return.rs
@@ -1,0 +1,9 @@
+#[deny(warnings)]
+fn cfg_return() -> i32 {
+    #[cfg(msvc)] return 1;
+    #[cfg(not(msvc))] return 2;
+}
+
+fn main() {
+    cfg_return();
+}

--- a/tests/run-pass/needless_return.rs
+++ b/tests/run-pass/needless_return.rs
@@ -1,9 +1,0 @@
-#[deny(warnings)]
-fn cfg_return() -> i32 {
-    #[cfg(msvc)] return 1;
-    #[cfg(not(msvc))] return 2;
-}
-
-fn main() {
-    cfg_return();
-}

--- a/tests/run-pass/returns.rs
+++ b/tests/run-pass/returns.rs
@@ -1,0 +1,19 @@
+#[deny(warnings)]
+fn cfg_return() -> i32 {
+    #[cfg(unix)] return 1;
+    #[cfg(not(unix))] return 2;
+}
+
+#[deny(warnings)]
+fn cfg_let_and_return() -> i32 {
+    #[cfg(unix)]
+    let x = 1;
+    #[cfg(not(unix))]
+    let x = 2;
+    x
+}
+
+fn main() {
+    cfg_return();
+    cfg_let_and_return();
+}


### PR DESCRIPTION
Clippy warns for this code ("remove return as shown: `#[cfg(b)] b`"), but the original may look better.

```rust
#[cfg(a)] return a;
#[cfg(b)] return b;
```