### PR TITLE
fix travis config for clippy.bashy.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ after_success:
             -H "Travis-API-Version: 3" \
             -H "Authorization: token $TRAVIS_TOKEN_CLIPPY_SERVICE" \
             -d "{ \"request\": { \"branch\":\"master\" }}" \
-            https://api.travis-ci.org/repo/ligthyear%2Fclippy-service/requests
+            https://api.travis-ci.org/repo/gnunicorn%2Fclippy-service/requests
 
     else
       echo "Ignored"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Table of contents:
 *   [Lint list](#lints)
 *   [Usage instructions](#usage)
 *   [Configuration](#configuration)
-*   [*clippy-service*](#link-with-clippy-service)
 *   [License](#license)
 
 ## Usage
@@ -170,15 +169,6 @@ transparently:
 ```rust
 #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
 ```
-
-## Link with clippy service
-
-`clippy-service` is a rust web initiative providing `rust-clippy` as a web service.
-
-Both projects are independent and maintained by different people
-(even if some `clippy-service`'s contributions are authored by some `rust-clippy` members).
-
-You can check out this great service at [clippy.bashy.io](https://clippy.bashy.io/).
 
 ## Lints
 


### PR DESCRIPTION
The repository got moved from ligthyear/clippy-service to gnunicorn/clippy-service.

However, their build appears to be broken so I also removed the text from README.md -- we can add it back when the service is working again.