### PR TITLE
Use closure body span for needless_return lint (fixes #1405)

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -138,7 +138,7 @@ impl EarlyLintPass for ReturnPass {
         match kind {
             FnKind::ItemFn(.., block) |
             FnKind::Method(.., block) => self.check_block_return(cx, block),
-            FnKind::Closure(body) => self.check_final_expr(cx, body, None),
+            FnKind::Closure(body) => self.check_final_expr(cx, body, Some(body.span)),
         }
     }
 

--- a/tests/compile-fail/needless_return.rs
+++ b/tests/compile-fail/needless_return.rs
@@ -58,6 +58,10 @@ fn test_closure() {
         //~| HELP remove `return` as shown
         //~| SUGGESTION true
     };
+    let _ = || return true;
+    //~^ ERROR unneeded return statement
+    //~| HELP remove `return` as shown
+    //~| SUGGESTION true
 }
 
 fn main() {


### PR DESCRIPTION
This code used to cause panic (#1405).

```rust
let _ = || return();
```

```
warning: unneeded return statement, #[warn(needless_return)] on by default
 --> src/main.rs:2:16
  |
2 |     let _ = || return ();
  |                ^^^^^^^^^
  |
help: remove `return` as shown:
  |     let _ = || ();
```