### PR TITLE
Rustup to rustc 1.16.0-nightly (c07a6ae77 2017-01-17)

### DIFF
--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -326,7 +326,8 @@ fn has_where_lifetimes<'a, 'tcx: 'a>(cx: &LateContext<'a, 'tcx>, where_clause: &
             },
             WherePredicate::EqPredicate(ref pred) => {
                 let mut visitor = RefVisitor::new(cx);
-                walk_ty(&mut visitor, &pred.ty);
+                walk_ty(&mut visitor, &pred.lhs_ty);
+                walk_ty(&mut visitor, &pred.rhs_ty);
                 if !visitor.lts.is_empty() {
                     return true;
                 }

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -335,7 +335,6 @@ fn check_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, bindings: 
 
 fn check_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: &'tcx Ty, bindings: &mut Vec<(Name, Span)>) {
     match ty.node {
-        TyObjectSum(ref sty, _) |
         TySlice(ref sty) => check_ty(cx, sty, bindings),
         TyArray(ref fty, body_id) => {
             check_ty(cx, fty, bindings);

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -116,7 +116,7 @@ impl<'a> Sugg<'a> {
             ast::ExprKind::Try(..) |
             ast::ExprKind::Tup(..) |
             ast::ExprKind::TupField(..) |
-            ast::ExprKind::Vec(..) |
+            ast::ExprKind::Array(..) |
             ast::ExprKind::While(..) |
             ast::ExprKind::WhileLet(..) => Sugg::NonParen(snippet),
             ast::ExprKind::Range(.., RangeLimits::HalfOpen) => Sugg::BinOp(AssocOp::DotDot, snippet),


### PR DESCRIPTION
Relevant rustc commits:
- [Rename ExprKind::Vec to Array in HIR and HAIR.
](https://github.com/rust-lang/rust/commit/a9f8f98caabbe388b576f1c277cff51253db6b44)
- [AST/HIR: Replace Path with Type in WhereEqPredicate
](https://github.com/rust-lang/rust/commit/828404684b486a2b741858970a150530228258bb)
- [AST/HIR: Merge ObjectSum and PolyTraitRef](https://github.com/rust-lang/rust/commit/2efe865d22eb85871562b2497ac819efc0174a3d) + [Rename ObjectSum into TraitObject in AST/HIR
](https://github.com/rust-lang/rust/commit/66ef5f2bb55f3204d50b5011e3d15385065834c1)