### PR TITLE
Add categories to Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.110 — 2017-01-20
+* Add badges and categories to `Cargo.toml`
+
 ## 0.0.109 — 2017-01-19
 * Update to *1.16.0-nightly (c07a6ae77 2017-01-17)*
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ license = "MPL-2.0"
 keywords = ["clippy", "lint", "plugin"]
 categories = ["development-tools"]
 
+[badges]
+travis-ci = { repository = "Manishearth/rust-clippy" }
+appveyor = { repository = "Manishearth/rust-clippy" }
+
 [lib]
 name = "clippy"
 plugin = true
@@ -36,7 +40,6 @@ regex = "0.2"
 rustc-serialize = "0.3"
 clippy-mini-macro-test = { version = "0.1", path = "mini-macro" }
 serde = "0.7"
-
 
 [features]
 debugging = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/Manishearth/rust-clippy"
 readme = "README.md"
 license = "MPL-2.0"
 keywords = ["clippy", "lint", "plugin"]
+categories = ["development-tools"]
 
 [lib]
 name = "clippy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.109"
+version = "0.0.110"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -30,7 +30,7 @@ test = false
 
 [dependencies]
 # begin automatic update
-clippy_lints = { version = "0.0.109", path = "clippy_lints" }
+clippy_lints = { version = "0.0.110", path = "clippy_lints" }
 # end automatic update
 
 [dev-dependencies]

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.109"
+version = "0.0.110"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",

--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -97,8 +97,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssignOps {
                                                |db| if let (Some(snip_a), Some(snip_r)) =
                                                    (snippet_opt(cx, assignee.span), snippet_opt(cx, rhs.span)) {
                                                    db.span_suggestion(expr.span,
-                                                       "replace it with",
-                                                       format!("{} {}= {}", snip_a, op.node.as_str(), snip_r));
+                                                                      "replace it with",
+                                                                      format!("{} {}= {}",
+                                                                              snip_a,
+                                                                              op.node.as_str(),
+                                                                              snip_r));
                                                });
                         };
                         // lhs op= l op r
@@ -178,8 +181,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssignOps {
                                                |db| if let (Some(snip_a), Some(snip_r)) =
                                                    (snippet_opt(cx, assignee.span), snippet_opt(cx, rhs.span)) {
                                                    db.span_suggestion(expr.span,
-                                                       "replace it with",
-                                                       format!("{} {}= {}", snip_a, op.node.as_str(), snip_r));
+                                                                      "replace it with",
+                                                                      format!("{} {}= {}",
+                                                                              snip_a,
+                                                                              op.node.as_str(),
+                                                                              snip_r));
                                                });
                         }
                     };


### PR DESCRIPTION

Hi! [crates.io now supports categories][categories], which are a curated list
of topics aimed at helping an end-user coming to crates.io looking for
"a crate to do ______".

We're sending pull requests to selected crates to add categories in order to help 
populate the categories and seed their usefulness. We've made a guess at the best
category/categories for this crate; if it doesn't fit, please feel free to take
a look at [all the available categories and their descriptions][categories] and
[the slug values that should be specified in your Cargo.toml][slugs] and pick
different ones. If you have a category in mind that isn't available, you can
[send a PR to this file on crates.io][categories.toml] to propose additional
categories.

Crates can have up to 5 categories, and uploading categories to crates.io
currently requires publishing a new version with a cargo nightly from 2017-01-18
or later (it needs to contain [this PR][cargo-pr]).

We've [published a blog post][blog-post] with further details about categories.
The blog post also talks about the new crates.io support for CI badges, which
you may be interested in adding as well.

Please let me know if you have any questions!

[categories]: https://crates.io/categories
[slugs]: https://crates.io/category_slugs
[categories.toml]: https://github.com/rust-lang/crates.io/blob/master/src/categories.toml
[cargo-pr]: https://github.com/rust-lang/cargo/pull/3301
[blog-post]: http://integer32.com/2017/01/20/categories-and-ci-badges.html