### PR TITLE
Ignore exclusive patterns when checking for overlapping.

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -361,11 +361,15 @@ fn all_ranges(cx: &LateContext, arms: &[Arm]) -> Vec<SpannedRange<ConstVal>> {
                 }
                 .filter_map(|pat| {
                     if_let_chain! {[
-                    let PatKind::Range(ref lhs, ref rhs, _) = pat.node,
+                    let PatKind::Range(ref lhs, ref rhs, ref range_end) = pat.node,
                     let Ok(lhs) = constcx.eval(lhs, ExprTypeChecked),
                     let Ok(rhs) = constcx.eval(rhs, ExprTypeChecked)
                 ], {
-                    return Some(SpannedRange { span: pat.span, node: (lhs, rhs) });
+                    match *range_end {
+                        // FIXME: Doesn't handle excluded range patterns yet.
+                        RangeEnd::Excluded => return None,
+                        RangeEnd::Included => return Some(SpannedRange { span: pat.span, node: (lhs, rhs) }),
+                    }
                 }}
 
                     if_let_chain! {[

--- a/tests/compile-fail/matches.rs
+++ b/tests/compile-fail/matches.rs
@@ -1,4 +1,5 @@
 #![feature(plugin)]
+#![feature(exclusive_range_pattern)]
 
 #![plugin(clippy)]
 #![deny(clippy)]
@@ -248,6 +249,12 @@ fn overlapping() {
     match 42 {
         0 ... 10 => println!("0 ... 10"),
         11 ... 50 => println!("0 ... 10"),
+        _ => (),
+    }
+
+    match 42 {
+        2 => println!("2"),
+        0 .. 2 => println!("0 .. 2"),
         _ => (),
     }
 


### PR DESCRIPTION
This is sub-optimal, but avoids false positives from them. (False positives introduced in #1477)