### PR TITLE
methods: fix the option_unwrap_used message

### DIFF
--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -996,7 +996,7 @@ fn lint_unwrap(cx: &LateContext, expr: &hir::Expr, unwrap_args: &[hir::Expr]) {
                   lint,
                   expr.span,
                   &format!("used unwrap() on {} value. If you don't want to handle the {} case gracefully, consider \
-                            using expect() to provide a better panic
+                            using expect() to provide a better panic \
                             message",
                            kind,
                            none_value));


### PR DESCRIPTION
It had a hard linewrap in it rather than flowing naturally. This
confused the Vim error matching.