### PR TITLE
Rustup to rustc 1.16.0-nightly (24055d0f2 2017-01-31)

### DIFF
--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -143,12 +143,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssignOps {
                                             return; // useless if the trait doesn't exist
                                         };
                                         // check that we are not inside an `impl AssignOp` of this exact operation
-                                        let parent_fn = cx.tcx.map.get_parent(e.id);
-                                        let parent_impl = cx.tcx.map.get_parent(parent_fn);
+                                        let parent_fn = cx.tcx.hir.get_parent(e.id);
+                                        let parent_impl = cx.tcx.hir.get_parent(parent_fn);
                                         // the crate node is the only one that is not in the map
                                         if_let_chain!{[
                                             parent_impl != ast::CRATE_NODE_ID,
-                                            let hir::map::Node::NodeItem(item) = cx.tcx.map.get(parent_impl),
+                                            let hir::map::Node::NodeItem(item) = cx.tcx.hir.get(parent_impl),
                                             let hir::Item_::ItemImpl(_, _, _, Some(ref trait_ref), _, _) = item.node,
                                             trait_ref.path.def.def_id() == trait_id
                                         ], { return; }}

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -181,7 +181,7 @@ fn is_relevant_trait(tcx: ty::TyCtxt, item: &TraitItem) -> bool {
     }
 }
 
-fn is_relevant_block(tcx: ty::TyCtxt, tables: &ty::Tables, block: &Block) -> bool {
+fn is_relevant_block(tcx: ty::TyCtxt, tables: &ty::TypeckTables, block: &Block) -> bool {
     for stmt in &block.stmts {
         match stmt.node {
             StmtDecl(_, _) => return true,
@@ -194,7 +194,7 @@ fn is_relevant_block(tcx: ty::TyCtxt, tables: &ty::Tables, block: &Block) -> boo
     block.expr.as_ref().map_or(false, |e| is_relevant_expr(tcx, tables, e))
 }
 
-fn is_relevant_expr(tcx: ty::TyCtxt, tables: &ty::Tables, expr: &Expr) -> bool {
+fn is_relevant_expr(tcx: ty::TyCtxt, tables: &ty::TypeckTables, expr: &Expr) -> bool {
     match expr.node {
         ExprBlock(ref block) => is_relevant_block(tcx, tables, block),
         ExprRet(Some(ref e)) => is_relevant_expr(tcx, tables, e),

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -158,7 +158,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AttrPass {
 
 fn is_relevant_item(tcx: ty::TyCtxt, item: &Item) -> bool {
     if let ItemFn(_, _, _, _, _, eid) = item.node {
-        is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.map.body(eid).value)
+        is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.hir.body(eid).value)
     } else {
         false
     }
@@ -166,7 +166,7 @@ fn is_relevant_item(tcx: ty::TyCtxt, item: &Item) -> bool {
 
 fn is_relevant_impl(tcx: ty::TyCtxt, item: &ImplItem) -> bool {
     match item.node {
-        ImplItemKind::Method(_, eid) => is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.map.body(eid).value),
+        ImplItemKind::Method(_, eid) => is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.hir.body(eid).value),
         _ => false,
     }
 }
@@ -175,7 +175,7 @@ fn is_relevant_trait(tcx: ty::TyCtxt, item: &TraitItem) -> bool {
     match item.node {
         TraitItemKind::Method(_, TraitMethod::Required(_)) => true,
         TraitItemKind::Method(_, TraitMethod::Provided(eid)) => {
-            is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.map.body(eid).value)
+            is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.hir.body(eid).value)
         },
         _ => false,
     }

--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -57,7 +57,7 @@ struct ExVisitor<'a, 'tcx: 'a> {
 impl<'a, 'tcx: 'a> Visitor<'tcx> for ExVisitor<'a, 'tcx> {
     fn visit_expr(&mut self, expr: &'tcx Expr) {
         if let ExprClosure(_, _, eid, _) = expr.node {
-            let body = self.cx.tcx.map.body(eid);
+            let body = self.cx.tcx.hir.body(eid);
             let ex = &body.value;
             if matches!(ex.node, ExprBlock(_)) {
                 self.found_block = Some(ex);
@@ -67,7 +67,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for ExVisitor<'a, 'tcx> {
         walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -263,7 +263,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
             ExprRepeat(ref value, number_id) => {
                 if let Some(lcx) = self.lcx {
                     self.binop_apply(value,
-                                     &lcx.tcx.map.body(number_id).value,
+                                     &lcx.tcx.hir.body(number_id).value,
                                      |v, n| Some(Constant::Repeat(Box::new(v), n.as_u64() as usize)))
                 } else {
                     None

--- a/clippy_lints/src/cyclomatic_complexity.rs
+++ b/clippy_lints/src/cyclomatic_complexity.rs
@@ -99,7 +99,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CyclomaticComplexity {
         span: Span,
         node_id: NodeId
     ) {
-        let def_id = cx.tcx.map.local_def_id(node_id);
+        let def_id = cx.tcx.hir.local_def_id(node_id);
         if !cx.tcx.has_attr(def_id, "test") {
             self.check(cx, &body.value, span);
         }

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -73,7 +73,7 @@ impl LintPass for Derive {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Derive {
     fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx Item) {
         if let ItemImpl(_, _, _, Some(ref trait_ref), _, _) = item.node {
-            let ty = cx.tcx.item_type(cx.tcx.map.local_def_id(item.id));
+            let ty = cx.tcx.item_type(cx.tcx.hir.local_def_id(item.id));
             let is_automatically_derived = is_automatically_derived(&*item.attrs);
 
             check_hash_peq(cx, item.span, trait_ref, ty, is_automatically_derived);
@@ -122,9 +122,9 @@ fn check_hash_peq<'a, 'tcx>(
                     cx, DERIVE_HASH_XOR_EQ, span,
                     mess,
                     |db| {
-                    if let Some(node_id) = cx.tcx.map.as_local_node_id(impl_id) {
+                    if let Some(node_id) = cx.tcx.hir.as_local_node_id(impl_id) {
                         db.span_note(
-                            cx.tcx.map.span(node_id),
+                            cx.tcx.hir.span(node_id),
                             "`PartialEq` implemented here"
                         );
                     }

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -148,6 +148,6 @@ impl<'a, 'tcx, 'b> Visitor<'tcx> for InsertVisitor<'a, 'tcx, 'b> {
         }
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }

--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -45,7 +45,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnportableVariant {
                 if let Some(body_id) = variant.disr_expr {
                     use rustc_const_eval::*;
                     let constcx = ConstContext::new(cx.tcx, body_id);
-                    let bad = match constcx.eval(&cx.tcx.map.body(body_id).value, EvalHint::ExprTypeChecked) {
+                    let bad = match constcx.eval(&cx.tcx.hir.body(body_id).value, EvalHint::ExprTypeChecked) {
                         Ok(ConstVal::Integral(Usize(Us64(i)))) => i as u32 as u64 != i,
                         Ok(ConstVal::Integral(Isize(Is64(i)))) => i as i32 as i64 != i,
                         _ => false,

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -89,7 +89,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
         for node in v.set {
             span_lint(cx,
                       BOXED_LOCAL,
-                      cx.tcx.map.span(node),
+                      cx.tcx.hir.span(node),
                       "local variable doesn't need to be boxed here");
         }
     }
@@ -108,7 +108,7 @@ impl<'a, 'tcx: 'a> Delegate<'tcx> for EscapeDelegate<'a, 'tcx> {
     }
     fn matched_pat(&mut self, _: &Pat, _: cmt<'tcx>, _: MatchMode) {}
     fn consume_pat(&mut self, consume_pat: &Pat, cmt: cmt<'tcx>, _: ConsumeMode) {
-        let map = &self.tcx.map;
+        let map = &self.tcx.hir;
         if map.is_argument(consume_pat.id) {
             // Skip closure arguments
             if let Some(NodeExpr(..)) = map.find(map.get_parent_node(consume_pat.id)) {
@@ -180,7 +180,7 @@ impl<'a, 'tcx: 'a> Delegate<'tcx> for EscapeDelegate<'a, 'tcx> {
                         self.tables
                             .adjustments
                             .get(&self.tcx
-                                .map
+                                .hir
                                 .get_parent_node(borrow_id))
                             .map(|a| &a.kind) {
                         if autoderefs <= 1 {

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -49,7 +49,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EtaPass {
 
 fn check_closure(cx: &LateContext, expr: &Expr) {
     if let ExprClosure(_, ref decl, eid, _) = expr.node {
-        let body = cx.tcx.map.body(eid);
+        let body = cx.tcx.hir.body(eid);
         let ex = &body.value;
         if let ExprCall(ref caller, ref args) = ex.node {
             if args.len() != decl.inputs.len() {

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -156,7 +156,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DivergenceVisitor<'a, 'tcx> {
         // don't continue over blocks, LateLintPass already does that
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 
@@ -176,7 +176,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DivergenceVisitor<'a, 'tcx> {
 ///
 /// When such a read is found, the lint is triggered.
 fn check_for_unsequenced_reads(vis: &mut ReadVisitor) {
-    let map = &vis.cx.tcx.map;
+    let map = &vis.cx.tcx.hir;
     let mut cur_id = vis.write_expr.id;
     loop {
         let parent_id = map.get_parent_node(cur_id);
@@ -342,7 +342,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ReadVisitor<'a, 'tcx> {
         walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -78,10 +78,10 @@ pub fn get_argument_fmtstr_parts<'a, 'b>(cx: &LateContext<'a, 'b>, expr: &'a Exp
         block.stmts.len() == 1,
         let StmtDecl(ref decl, _) = block.stmts[0].node,
         let DeclItem(ref decl) = decl.node,
-        let Some(NodeItem(decl)) = cx.tcx.map.find(decl.id),
+        let Some(NodeItem(decl)) = cx.tcx.hir.find(decl.id),
         &*decl.name.as_str() == "__STATIC_FMTSTR",
         let ItemStatic(_, _, ref expr) = decl.node,
-        let ExprAddrOf(_, ref expr) = cx.tcx.map.body(*expr).value.node, // &["…", "…", …]
+        let ExprAddrOf(_, ref expr) = cx.tcx.hir.body(*expr).value.node, // &["…", "…", …]
         let ExprArray(ref exprs) = expr.node,
     ], {
         let mut result = Vec::new();

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -80,7 +80,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Functions {
     ) {
         use rustc::hir::map::Node::*;
 
-        let is_impl = if let Some(NodeItem(item)) = cx.tcx.map.find(cx.tcx.map.get_parent_node(nodeid)) {
+        let is_impl = if let Some(NodeItem(item)) = cx.tcx.hir.find(cx.tcx.hir.get_parent_node(nodeid)) {
             matches!(item.node, hir::ItemImpl(_, _, _, Some(_), _, _) | hir::ItemDefaultImpl(..))
         } else {
             false
@@ -113,7 +113,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Functions {
             }
 
             if let hir::TraitMethod::Provided(eid) = *eid {
-                let body = cx.tcx.map.body(eid);
+                let body = cx.tcx.hir.body(eid);
                 self.check_raw_ptr(cx, sig.unsafety, &sig.decl, body, item.id);
             }
         }
@@ -200,7 +200,7 @@ impl<'a, 'tcx> hir::intravisit::Visitor<'tcx> for DerefVisitor<'a, 'tcx> {
         hir::intravisit::walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> intravisit::NestedVisitorMap<'this, 'tcx> {
-        intravisit::NestedVisitorMap::All(&self.cx.tcx.map)
+        intravisit::NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -46,7 +46,7 @@ impl LintPass for LargeEnumVariant {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeEnumVariant {
     fn check_item(&mut self, cx: &LateContext, item: &Item) {
-        let did = cx.tcx.map.local_def_id(item.id);
+        let did = cx.tcx.hir.local_def_id(item.id);
         if let ItemEnum(ref def, _) = item.node {
             let ty = cx.tcx.item_type(did);
             let adt = ty.ty_adt_def().expect("already checked whether this is an enum");

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -93,7 +93,7 @@ fn check_trait_items(cx: &LateContext, item: &Item, trait_items: &[TraitItemRef]
         if let AssociatedItemKind::Method { has_self } = item.kind {
             has_self &&
             {
-                let did = cx.tcx.map.local_def_id(item.id.node_id);
+                let did = cx.tcx.hir.local_def_id(item.id.node_id);
                 let impl_ty = cx.tcx.item_type(did);
                 impl_ty.fn_args().skip_binder().len() == 1
             }
@@ -120,7 +120,7 @@ fn check_impl_items(cx: &LateContext, item: &Item, impl_items: &[ImplItemRef]) {
         if let AssociatedItemKind::Method { has_self } = item.kind {
             has_self &&
             {
-                let did = cx.tcx.map.local_def_id(item.id.node_id);
+                let did = cx.tcx.hir.local_def_id(item.id.node_id);
                 let impl_ty = cx.tcx.item_type(did);
                 impl_ty.fn_args().skip_binder().len() == 1
             }
@@ -141,7 +141,7 @@ fn check_impl_items(cx: &LateContext, item: &Item, impl_items: &[ImplItemRef]) {
 
     if let Some(i) = impl_items.iter().find(|i| is_named_self(cx, i, "len")) {
         if cx.access_levels.is_exported(i.id.node_id) {
-            let def_id = cx.tcx.map.local_def_id(item.id);
+            let def_id = cx.tcx.hir.local_def_id(item.id);
             let ty = cx.tcx.item_type(def_id);
 
             span_lint(cx,

--- a/clippy_lints/src/let_if_seq.rs
+++ b/clippy_lints/src/let_if_seq.rs
@@ -145,7 +145,7 @@ impl<'a, 'tcx> hir::intravisit::Visitor<'tcx> for UsedVisitor<'a, 'tcx> {
         hir::intravisit::walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> hir::intravisit::NestedVisitorMap<'this, 'tcx> {
-        hir::intravisit::NestedVisitorMap::All(&self.cx.tcx.map)
+        hir::intravisit::NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -8,7 +8,6 @@
 #![feature(rustc_private)]
 #![feature(slice_patterns)]
 #![feature(stmt_expr_attributes)]
-#![feature(repeat_str)]
 #![feature(conservative_impl_trait)]
 #![feature(collections_bound)]
 

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -230,6 +230,9 @@ impl<'v, 't> RefVisitor<'v, 't> {
         if let Some(ref lt) = *lifetime {
             if &*lt.name.as_str() == "'static" {
                 self.lts.push(RefLt::Static);
+            } else if lt.is_elided() {
+                // TODO: investigate
+                self.lts.push(RefLt::Unnamed);
             } else {
                 self.lts.push(RefLt::Named(lt.name));
             }
@@ -275,7 +278,7 @@ impl<'a, 'tcx> Visitor<'tcx> for RefVisitor<'a, 'tcx> {
 
     fn visit_ty(&mut self, ty: &'tcx Ty) {
         match ty.node {
-            TyRptr(None, _) => {
+            TyRptr(ref lt, _) if lt.is_elided() => {
                 self.record(&None);
             },
             TyPath(ref path) => {

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -231,7 +231,6 @@ impl<'v, 't> RefVisitor<'v, 't> {
             if &*lt.name.as_str() == "'static" {
                 self.lts.push(RefLt::Static);
             } else if lt.is_elided() {
-                // TODO: investigate
                 self.lts.push(RefLt::Unnamed);
             } else {
                 self.lts.push(RefLt::Named(lt.name));
@@ -290,6 +289,15 @@ impl<'a, 'tcx> Visitor<'tcx> for RefVisitor<'a, 'tcx> {
                         self.record(&None);
                     }
                 }
+            },
+            TyTraitObject(ref bounds, ref lt) => {
+                if !lt.is_elided() {
+                    self.record(&Some(*lt));
+                }
+                for bound in bounds {
+                    self.visit_poly_trait_ref(bound, TraitBoundModifier::None);
+                }
+                return;
             },
             _ => (),
         }

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -677,7 +677,7 @@ fn check_for_loop_explicit_counter<'a, 'tcx>(
 
     // For each candidate, check the parent block to see if
     // it's initialized to zero at the start of the loop.
-    let map = &cx.tcx.map;
+    let map = &cx.tcx.hir;
     let parent_scope = map.get_enclosing_scope(expr.id).and_then(|id| map.get_enclosing_scope(id));
     if let Some(parent_id) = parent_scope {
         if let NodeBlock(block) = map.get(parent_id) {
@@ -794,7 +794,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for UsedVisitor<'a, 'tcx> {
         walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 
@@ -822,7 +822,7 @@ impl<'a, 'tcx> Visitor<'tcx> for VarVisitor<'a, 'tcx> {
                         match def {
                             Def::Local(..) | Def::Upvar(..) => {
                                 let def_id = def.def_id();
-                                let node_id = self.cx.tcx.map.as_local_node_id(def_id).unwrap();
+                                let node_id = self.cx.tcx.hir.as_local_node_id(def_id).unwrap();
 
                                 let extent = self.cx.tcx.region_maps.var_scope(node_id);
                                 self.indexed.insert(seqvar.segments[0].name, Some(extent));
@@ -844,7 +844,7 @@ impl<'a, 'tcx> Visitor<'tcx> for VarVisitor<'a, 'tcx> {
         walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 
@@ -886,7 +886,7 @@ impl<'a, 'tcx> Visitor<'tcx> for VarUsedAfterLoopVisitor<'a, 'tcx> {
         walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 
@@ -1029,7 +1029,7 @@ impl<'a, 'tcx> Visitor<'tcx> for IncrementVisitor<'a, 'tcx> {
         walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 
@@ -1116,7 +1116,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InitializeVisitor<'a, 'tcx> {
         walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 
@@ -1124,7 +1124,7 @@ fn var_def_id(cx: &LateContext, expr: &Expr) -> Option<NodeId> {
     if let ExprPath(ref qpath) = expr.node {
         let path_res = cx.tables.qpath_def(qpath, expr.id);
         if let Def::Local(def_id) = path_res {
-            let node_id = cx.tcx.map.as_local_node_id(def_id).expect("That DefId should be valid");
+            let node_id = cx.tcx.hir.as_local_node_id(def_id).expect("That DefId should be valid");
             return Some(node_id);
         }
     }

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -31,7 +31,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if &*name.node.as_str() == "map" && args.len() == 2 {
                 match args[1].node {
                     ExprClosure(_, ref decl, closure_eid, _) => {
-                        let body = cx.tcx.map.body(closure_eid);
+                        let body = cx.tcx.hir.body(closure_eid);
                         let closure_expr = remove_blocks(&body.value);
                         if_let_chain! {[
                             // nothing special in the argument, besides reference bindings

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -951,8 +951,7 @@ fn derefs_to_slice(cx: &LateContext, expr: &hir::Expr, ty: ty::Ty) -> Option<sug
             ty::TySlice(_) => true,
             ty::TyAdt(..) => match_type(cx, ty, &paths::VEC),
             ty::TyArray(_, size) => size < 32,
-            ty::TyRef(_, ty::TypeAndMut { ty: inner, .. }) |
-            ty::TyBox(inner) => may_slice(cx, inner),
+            ty::TyRef(_, ty::TypeAndMut { ty: inner, .. }) => may_slice(cx, inner),
             _ => false,
         }
     }
@@ -966,8 +965,7 @@ fn derefs_to_slice(cx: &LateContext, expr: &hir::Expr, ty: ty::Ty) -> Option<sug
     } else {
         match ty.sty {
             ty::TySlice(_) => sugg::Sugg::hir_opt(cx, expr),
-            ty::TyRef(_, ty::TypeAndMut { ty: inner, .. }) |
-            ty::TyBox(inner) => {
+            ty::TyRef(_, ty::TypeAndMut { ty: inner, .. }) => {
                 if may_slice(cx, inner) {
                     sugg::Sugg::hir_opt(cx, expr)
                 } else {

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -477,7 +477,7 @@ fn non_macro_local(cx: &LateContext, def: &def::Def) -> bool {
     match *def {
         def::Def::Local(id) |
         def::Def::Upvar(id, _, _) => {
-            if let Some(span) = cx.tcx.map.span_if_local(id) {
+            if let Some(span) = cx.tcx.hir.span_if_local(id) {
                 !in_macro(cx, span)
             } else {
                 true

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -146,7 +146,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDoc {
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, impl_item: &'tcx hir::ImplItem) {
         // If the method is an impl for a trait, don't doc.
-        let def_id = cx.tcx.map.local_def_id(impl_item.id);
+        let def_id = cx.tcx.hir.local_def_id(impl_item.id);
         match cx.tcx.associated_item(def_id).container {
             ty::TraitContainer(_) => return,
             ty::ImplContainer(cid) => {

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -91,6 +91,6 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for MutVisitor<'a, 'tcx> {
         intravisit::walk_ty(self, ty);
     }
     fn nested_visit_map<'this>(&'this mut self) -> intravisit::NestedVisitorMap<'this, 'tcx> {
-        intravisit::NestedVisitorMap::All(&self.cx.tcx.map)
+        intravisit::NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -110,7 +110,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
             }
             if decl.inputs.is_empty() && &*name.as_str() == "new" && cx.access_levels.is_reachable(id) {
                 let self_ty = cx.tcx
-                    .item_type(cx.tcx.map.local_def_id(cx.tcx.map.get_parent(id)));
+                    .item_type(cx.tcx.hir.local_def_id(cx.tcx.hir.get_parent(id)));
                 if_let_chain!{[
                     self_ty.walk_shallow().next().is_none(), // implements_trait does not work with generics
                     same_tys(cx, self_ty, return_ty(cx, id), id),
@@ -160,7 +160,7 @@ fn can_derive_default<'t, 'c>(ty: ty::Ty<'t>, cx: &LateContext<'c, 't>, default_
                     return None;
                 }
             }
-            cx.tcx.map.span_if_local(adt_def.did)
+            cx.tcx.hir.span_if_local(adt_def.did)
         },
         _ => None,
     }

--- a/clippy_lints/src/print.rs
+++ b/clippy_lints/src/print.rs
@@ -135,7 +135,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 }
 
 fn is_in_debug_impl(cx: &LateContext, expr: &Expr) -> bool {
-    let map = &cx.tcx.map;
+    let map = &cx.tcx.hir;
 
     // `fmt` method
     if let Some(NodeImplItem(item)) = map.find(map.get_parent(expr.id)) {

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -63,7 +63,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PointerPass {
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx ImplItem) {
         if let ImplItemKind::Method(ref sig, _) = item.node {
-            if let Some(NodeItem(it)) = cx.tcx.map.find(cx.tcx.map.get_parent(item.id)) {
+            if let Some(NodeItem(it)) = cx.tcx.hir.find(cx.tcx.hir.get_parent(item.id)) {
                 if let ItemImpl(_, _, _, Some(_), _, _) = it.node {
                     return; // ignore trait impls
                 }
@@ -91,7 +91,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PointerPass {
 }
 
 fn check_fn(cx: &LateContext, decl: &FnDecl, fn_id: NodeId) {
-    let fn_def_id = cx.tcx.map.local_def_id(fn_id);
+    let fn_def_id = cx.tcx.hir.local_def_id(fn_id);
     let fn_ty = cx.tcx.item_type(fn_def_id).fn_sig().skip_binder();
 
     for (arg, ty) in decl.inputs.iter().zip(fn_ty.inputs()) {

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -338,7 +338,7 @@ fn check_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: &'tcx Ty, bindings: &mut V
         TySlice(ref sty) => check_ty(cx, sty, bindings),
         TyArray(ref fty, body_id) => {
             check_ty(cx, fty, bindings);
-            check_expr(cx, &cx.tcx.map.body(body_id).value, bindings);
+            check_expr(cx, &cx.tcx.hir.body(body_id).value, bindings);
         },
         TyPtr(MutTy { ty: ref mty, .. }) |
         TyRptr(_, MutTy { ty: ref mty, .. }) => check_ty(cx, mty, bindings),
@@ -347,7 +347,7 @@ fn check_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: &'tcx Ty, bindings: &mut V
                 check_ty(cx, t, bindings)
             }
         },
-        TyTypeof(body_id) => check_expr(cx, &cx.tcx.map.body(body_id).value, bindings),
+        TyTypeof(body_id) => check_expr(cx, &cx.tcx.hir.body(body_id).value, bindings),
         _ => (),
     }
 }
@@ -382,7 +382,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for ContainsSelf<'a, 'tcx> {
         }
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -72,7 +72,7 @@ impl LintPass for TypePass {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypePass {
     fn check_fn(&mut self, cx: &LateContext, _: FnKind, decl: &FnDecl, _: &Body, _: Span, id: NodeId) {
         // skip trait implementations, see #605
-        if let Some(map::NodeItem(item)) = cx.tcx.map.find(cx.tcx.map.get_parent(id)) {
+        if let Some(map::NodeItem(item)) = cx.tcx.hir.find(cx.tcx.hir.get_parent(id)) {
             if let ItemImpl(_, _, _, Some(..), _, _) = item.node {
                 return;
             }
@@ -725,7 +725,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for TypeComplexityVisitor<'a, 'tcx> {
         self.nest -= sub_nest;
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }
 

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -702,13 +702,10 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for TypeComplexityVisitor<'a, 'tcx> {
             // function types bring a lot of overhead
             TyBareFn(..) => (50 * self.nest, 1),
 
-            TyTraitObject(ref bounds) => {
-                let has_lifetimes = bounds.iter()
-                    .any(|bound| match *bound {
-                        TraitTyParamBound(ref poly_trait, ..) => !poly_trait.bound_lifetimes.is_empty(),
-                        RegionTyParamBound(..) => true,
-                    });
-                if has_lifetimes {
+            TyTraitObject(ref param_bounds, _) => {
+                let has_lifetime_parameters = param_bounds.iter()
+                    .any(|bound| !bound.bound_lifetimes.is_empty());
+                if has_lifetime_parameters {
                     // complex trait bounds like A<'a, 'b>
                     (50 * self.nest, 1)
                 } else {

--- a/clippy_lints/src/unused_label.rs
+++ b/clippy_lints/src/unused_label.rs
@@ -83,6 +83,6 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for UnusedLabelVisitor<'a, 'tcx> {
         walk_expr(self, expr);
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }

--- a/clippy_lints/src/utils/hir.rs
+++ b/clippy_lints/src/utils/hir.rs
@@ -114,7 +114,7 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
             },
             (&ExprRepeat(ref le, ll_id), &ExprRepeat(ref re, rl_id)) => {
                 self.eq_expr(le, re) &&
-                self.eq_expr(&self.cx.tcx.map.body(ll_id).value, &self.cx.tcx.map.body(rl_id).value)
+                self.eq_expr(&self.cx.tcx.hir.body(ll_id).value, &self.cx.tcx.hir.body(rl_id).value)
             },
             (&ExprRet(ref l), &ExprRet(ref r)) => both(l, r, |l, r| self.eq_expr(l, r)),
             (&ExprPath(ref l), &ExprPath(ref r)) => self.eq_qpath(l, r),
@@ -217,7 +217,7 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
             (&TySlice(ref l_vec), &TySlice(ref r_vec)) => self.eq_ty(l_vec, r_vec),
             (&TyArray(ref lt, ll_id), &TyArray(ref rt, rl_id)) => {
                 self.eq_ty(lt, rt) &&
-                self.eq_expr(&self.cx.tcx.map.body(ll_id).value, &self.cx.tcx.map.body(rl_id).value)
+                self.eq_expr(&self.cx.tcx.hir.body(ll_id).value, &self.cx.tcx.hir.body(rl_id).value)
             },
             (&TyPtr(ref l_mut), &TyPtr(ref r_mut)) => l_mut.mutbl == r_mut.mutbl && self.eq_ty(&*l_mut.ty, &*r_mut.ty),
             (&TyRptr(_, ref l_rmut), &TyRptr(_, ref r_rmut)) => {
@@ -370,7 +370,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 let c: fn(_, _, _, _) -> _ = ExprClosure;
                 c.hash(&mut self.s);
                 cap.hash(&mut self.s);
-                self.hash_expr(&self.cx.tcx.map.body(eid).value);
+                self.hash_expr(&self.cx.tcx.hir.body(eid).value);
             },
             ExprField(ref e, ref f) => {
                 let c: fn(_, _) -> _ = ExprField;
@@ -435,7 +435,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 let c: fn(_, _) -> _ = ExprRepeat;
                 c.hash(&mut self.s);
                 self.hash_expr(e);
-                self.hash_expr(&self.cx.tcx.map.body(l_id).value);
+                self.hash_expr(&self.cx.tcx.hir.body(l_id).value);
             },
             ExprRet(ref e) => {
                 let c: fn(_) -> _ = ExprRet;

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -65,7 +65,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
         match item.node {
             hir::ImplItemKind::Const(_, body_id) => {
                 println!("associated constant");
-                print_expr(cx, &cx.tcx.map.body(body_id).value, 1);
+                print_expr(cx, &cx.tcx.hir.body(body_id).value, 1);
             },
             hir::ImplItemKind::Method(..) => println!("method"),
             hir::ImplItemKind::Type(_) => println!("associated type"),
@@ -332,13 +332,13 @@ fn print_expr(cx: &LateContext, expr: &hir::Expr, indent: usize) {
             println!("{}value:", ind);
             print_expr(cx, val, indent + 1);
             println!("{}repeat count:", ind);
-            print_expr(cx, &cx.tcx.map.body(body_id).value, indent + 1);
+            print_expr(cx, &cx.tcx.hir.body(body_id).value, indent + 1);
         },
     }
 }
 
 fn print_item(cx: &LateContext, item: &hir::Item) {
-    let did = cx.tcx.map.local_def_id(item.id);
+    let did = cx.tcx.hir.local_def_id(item.id);
     println!("item `{}`", item.name);
     match item.vis {
         hir::Visibility::Public => println!("public"),

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -142,7 +142,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LintWithoutLintPass {
 
 
 fn is_lint_ref_type(ty: &Ty) -> bool {
-    if let TyRptr(_, MutTy { ty: ref inner, mutbl: MutImmutable }) = ty.node {
+    if let TyRptr(ref lt, MutTy { ty: ref inner, mutbl: MutImmutable }) = ty.node {
+        if lt.is_elided() {
+            return false;
+        }
         if let TyPath(ref path) = inner.node {
             return match_path(path, &paths::LINT);
         }

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -114,7 +114,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LintWithoutLintPass {
                     output: &mut self.registered_lints,
                     cx: cx,
                 };
-                collector.visit_expr(&cx.tcx.map.body(body_id).value);
+                collector.visit_expr(&cx.tcx.hir.body(body_id).value);
             }
         }
     }
@@ -142,7 +142,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LintWithoutLintPass {
 
 
 fn is_lint_ref_type(ty: &Ty) -> bool {
-    if let TyRptr(Some(_), MutTy { ty: ref inner, mutbl: MutImmutable }) = ty.node {
+    if let TyRptr(_, MutTy { ty: ref inner, mutbl: MutImmutable }) = ty.node {
         if let TyPath(ref path) = inner.node {
             return match_path(path, &paths::LINT);
         }
@@ -175,6 +175,6 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for LintCollector<'a, 'tcx> {
         }
     }
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::All(&self.cx.tcx.map)
+        NestedVisitorMap::All(&self.cx.tcx.hir)
     }
 }

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -48,7 +48,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
         if_let_chain!{[
             let Some((_, arg, _)) = higher::for_loop(expr),
             let Some(vec_args) = higher::vec_macro(cx, arg),
-            is_copy(cx, vec_type(cx.tables.expr_ty_adjusted(arg)), cx.tcx.map.get_parent(expr.id)),
+            is_copy(cx, vec_type(cx.tables.expr_ty_adjusted(arg)), cx.tcx.hir.get_parent(expr.id)),
         ], {
             // report the error around the `vec!` not inside `<std macros>:`
             let span = cx.sess().codemap().source_callsite(arg.span);


### PR DESCRIPTION
Relevant rustc changes:
- [rename `tcx.map` to `tcx.hir`](https://github.com/rust-lang/rust/pull/39309)
- [rename `Tables` to `TypeckTables`](https://github.com/rust-lang/rust/commit/282f7a3c44a428c26155b4686ad95e802fcd4158)
- [Merge ty::TyBox into ty::TyAdt](https://github.com/rust-lang/rust/commit/ffba0cea621c2609582b4e201b76b3b19860ec4f)
- [rustc: move most of lifetime elision to resolve_lifetimes.](https://github.com/rust-lang/rust/commit/ba1849daecf0ae8fee54cc32f378809a9531e5ed)

fixes #1475 and #1485 