### PR TITLE
Change large_enum_variant to lint against difference in sizes between variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ name                                                                            
 [iter_next_loop](https://github.com/Manishearth/rust-clippy/wiki#iter_next_loop)                                       | warn    | for-looping over `_.next()` which is probably not intended
 [iter_nth](https://github.com/Manishearth/rust-clippy/wiki#iter_nth)                                                   | warn    | using `.iter().nth()` on a standard library type with O(1) element access
 [iter_skip_next](https://github.com/Manishearth/rust-clippy/wiki#iter_skip_next)                                       | warn    | using `.skip(x).next()` on an iterator
-[large_enum_variant](https://github.com/Manishearth/rust-clippy/wiki#large_enum_variant)                               | warn    | large variants on an enum
+[large_enum_variant](https://github.com/Manishearth/rust-clippy/wiki#large_enum_variant)                               | warn    | large size difference between variants on an enum
 [len_without_is_empty](https://github.com/Manishearth/rust-clippy/wiki#len_without_is_empty)                           | warn    | traits or impls with a public `len` method but no corresponding `is_empty` method
 [len_zero](https://github.com/Manishearth/rust-clippy/wiki#len_zero)                                                   | warn    | checking `.len() == 0` or `.len() > 0` (or similar) when `.is_empty()` could be used instead
 [let_and_return](https://github.com/Manishearth/rust-clippy/wiki#let_and_return)                                       | warn    | creating a let-binding and then immediately returning it like `let x = expr; x` at the end of a block

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -114,7 +114,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeEnumVariant {
     }
 }
 
-fn update_if<T, F>(old: &mut Option<T>, new: T, f: F) where F: Fn(&T, &T) -> bool {
+fn update_if<T, F>(old: &mut Option<T>, new: T, f: F)
+    where F: Fn(&T, &T) -> bool
+{
     if let Some(ref mut val) = *old {
         if f(val, &new) {
             *val = new;

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -67,7 +67,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeEnumVariant {
                             }
                         })
                         .sum();
+
+                    use std::io::Write;
+                    let mut f = ::std::fs::File::create("log").unwrap();
+
+                    writeln!(f, "size, max size: {}, {}", size, self.maximum_variant_size_allowed).unwrap();
                     if size > self.maximum_variant_size_allowed {
+                        writeln!(f, "size > max").unwrap();
+                        // panic!("foo");
+
                         span_lint_and_then(cx,
                                            LARGE_ENUM_VARIANT,
                                            def.variants[i].span,

--- a/log
+++ b/log
@@ -1,0 +1,1 @@
+size, max size: 0, 200

--- a/log
+++ b/log
@@ -1,1 +1,0 @@
-size, max size: 0, 200

--- a/tests/ui/large_enum_variant.rs
+++ b/tests/ui/large_enum_variant.rs
@@ -7,9 +7,7 @@
 
 enum LargeEnum {
     A(i32),
-    B([i32; 8000]), //~ ERROR large size difference between variants
-    //~^ HELP consider boxing the large fields to reduce the total size of the enum
-    //~| SUGGESTION Box<[i32; 8000]>
+    B([i32; 8000]),
 }
 
 enum GenericEnumOk<T> {
@@ -20,8 +18,7 @@ enum GenericEnumOk<T> {
 enum GenericEnum2<T> {
     A(i32),
     B([i32; 8000]),
-    C(T, [i32; 8000]), //~ ERROR large size difference between variants
-    //~^ HELP consider boxing the large fields to reduce the total size of the enum
+    C(T, [i32; 8000]),
 }
 
 trait SomeTrait {
@@ -29,35 +26,27 @@ trait SomeTrait {
 }
 
 enum LargeEnumGeneric<A: SomeTrait> {
-    Var(A::Item), // regression test, this used to ICE
+    Var(A::Item),
 }
 
 enum LargeEnum2 {
     VariantOk(i32, u32),
-    ContainingLargeEnum(LargeEnum), //~ ERROR large size difference between variants
-    //~^ HELP consider boxing the large fields to reduce the total size of the enum
-    //~| SUGGESTION Box<LargeEnum>
+    ContainingLargeEnum(LargeEnum),
 }
 enum LargeEnum3 {
-    ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]), //~ ERROR large size difference between variants
-    //~^ HELP consider boxing the large fields to reduce the total size of the enum
+    ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]),
     VoidVariant,
     StructLikeLittle { x: i32, y: i32 },
 }
 
 enum LargeEnum4 {
     VariantOk(i32, u32),
-    StructLikeLarge { x: [i32; 8000], y: i32 }, //~ ERROR large size difference between variants
-    //~^ HELP consider boxing the large fields to reduce the total size of the enum
+    StructLikeLarge { x: [i32; 8000], y: i32 },
 }
 
 enum LargeEnum5 {
     VariantOk(i32, u32),
-    StructLikeLarge2 { //~ ERROR large size difference between variants
-        x:
-        [i32; 8000] //~ SUGGESTION Box<[i32; 8000]>
-        //~^ HELP consider boxing the large fields to reduce the total size of the enum
-    },
+    StructLikeLarge2 { x: [i32; 8000] },
 }
 
 enum LargeEnumOk {
@@ -65,6 +54,4 @@ enum LargeEnumOk {
     LargeB([i32; 8001]),
 }
 
-fn main() {
-
-}
+fn main() {}

--- a/tests/ui/large_enum_variant.rs
+++ b/tests/ui/large_enum_variant.rs
@@ -7,19 +7,21 @@
 
 enum LargeEnum {
     A(i32),
-    B([i32; 8000]),
-
-
+    B([i32; 8000]), //~ ERROR large size difference between variants
+    //~^ HELP consider boxing the large fields to reduce the total size of the enum
+    //~| SUGGESTION Box<[i32; 8000]>
 }
 
-enum GenericEnum<T> {
+enum GenericEnumOk<T> {
+    A(i32),
+    B([T; 8000]),
+}
+
+enum GenericEnum2<T> {
     A(i32),
     B([i32; 8000]),
-
-
-    C([T; 8000]),
-    D(T, [i32; 8000]),
-
+    C(T, [i32; 8000]), //~ ERROR large size difference between variants
+    //~^ HELP consider boxing the large fields to reduce the total size of the enum
 }
 
 trait SomeTrait {
@@ -30,22 +32,37 @@ enum LargeEnumGeneric<A: SomeTrait> {
     Var(A::Item), // regression test, this used to ICE
 }
 
-enum AnotherLargeEnum {
+enum LargeEnum2 {
     VariantOk(i32, u32),
-    ContainingLargeEnum(LargeEnum),
-
-
-    ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]),
-
+    ContainingLargeEnum(LargeEnum), //~ ERROR large size difference between variants
+    //~^ HELP consider boxing the large fields to reduce the total size of the enum
+    //~| SUGGESTION Box<LargeEnum>
+}
+enum LargeEnum3 {
+    ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]), //~ ERROR large size difference between variants
+    //~^ HELP consider boxing the large fields to reduce the total size of the enum
     VoidVariant,
     StructLikeLittle { x: i32, y: i32 },
-    StructLikeLarge { x: [i32; 8000], y: i32 },
+}
 
-    StructLikeLarge2 {
+enum LargeEnum4 {
+    VariantOk(i32, u32),
+    StructLikeLarge { x: [i32; 8000], y: i32 }, //~ ERROR large size difference between variants
+    //~^ HELP consider boxing the large fields to reduce the total size of the enum
+}
+
+enum LargeEnum5 {
+    VariantOk(i32, u32),
+    StructLikeLarge2 { //~ ERROR large size difference between variants
         x:
-        [i32; 8000]
-
+        [i32; 8000] //~ SUGGESTION Box<[i32; 8000]>
+        //~^ HELP consider boxing the large fields to reduce the total size of the enum
     },
+}
+
+enum LargeEnumOk {
+    LargeA([i32; 8000]),
+    LargeB([i32; 8001]),
 }
 
 fn main() {

--- a/tests/ui/large_enum_variant.stderr
+++ b/tests/ui/large_enum_variant.stderr
@@ -1,4 +1,4 @@
-error: large enum variant found
+error: large size difference between variants
   --> $DIR/large_enum_variant.rs:10:5
    |
 10 |     B([i32; 8000]),
@@ -12,73 +12,59 @@ note: lint level defined here
 help: consider boxing the large fields to reduce the total size of the enum
    |     B(Box<[i32; 8000]>),
 
-error: large enum variant found
-  --> $DIR/large_enum_variant.rs:17:5
-   |
-17 |     B([i32; 8000]),
-   |     ^^^^^^^^^^^^^^
-   |
-help: consider boxing the large fields to reduce the total size of the enum
-   |     B(Box<[i32; 8000]>),
-
-error: large enum variant found
+error: large size difference between variants
   --> $DIR/large_enum_variant.rs:21:5
    |
-21 |     D(T, [i32; 8000]),
+21 |     C(T, [i32; 8000]),
    |     ^^^^^^^^^^^^^^^^^
    |
 help: consider boxing the large fields to reduce the total size of the enum
   --> $DIR/large_enum_variant.rs:21:5
    |
-21 |     D(T, [i32; 8000]),
+21 |     C(T, [i32; 8000]),
    |     ^^^^^^^^^^^^^^^^^
 
-error: large enum variant found
-  --> $DIR/large_enum_variant.rs:35:5
+error: large size difference between variants
+  --> $DIR/large_enum_variant.rs:34:5
    |
-35 |     ContainingLargeEnum(LargeEnum),
+34 |     ContainingLargeEnum(LargeEnum),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider boxing the large fields to reduce the total size of the enum
    |     ContainingLargeEnum(Box<LargeEnum>),
 
-error: large enum variant found
-  --> $DIR/large_enum_variant.rs:38:5
+error: large size difference between variants
+  --> $DIR/large_enum_variant.rs:37:5
    |
-38 |     ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]),
+37 |     ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider boxing the large fields to reduce the total size of the enum
-  --> $DIR/large_enum_variant.rs:38:5
+  --> $DIR/large_enum_variant.rs:37:5
    |
-38 |     ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]),
+37 |     ContainingMoreThanOneField(i32, [i32; 8000], [i32; 9500]),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: large enum variant found
-  --> $DIR/large_enum_variant.rs:42:5
-   |
-42 |     StructLikeLarge { x: [i32; 8000], y: i32 },
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider boxing the large fields to reduce the total size of the enum
-  --> $DIR/large_enum_variant.rs:42:5
-   |
-42 |     StructLikeLarge { x: [i32; 8000], y: i32 },
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: large enum variant found
+error: large size difference between variants
   --> $DIR/large_enum_variant.rs:44:5
    |
-44 |       StructLikeLarge2 {
-   |  _____^ starting here...
-45 | |         x:
-46 | |         [i32; 8000]
-47 | |
-48 | |     },
-   | |_____^ ...ending here
+44 |     StructLikeLarge { x: [i32; 8000], y: i32 },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider boxing the large fields to reduce the total size of the enum
-   |         Box<[i32; 8000]>
+  --> $DIR/large_enum_variant.rs:44:5
+   |
+44 |     StructLikeLarge { x: [i32; 8000], y: i32 },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: large size difference between variants
+  --> $DIR/large_enum_variant.rs:49:5
+   |
+49 |     StructLikeLarge2 { x: [i32; 8000] },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider boxing the large fields to reduce the total size of the enum
+   |     StructLikeLarge2 { x: Box<[i32; 8000]> },
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Instead of detecting large variants, the lint will compare the sizes of the largest and smallest variants. This change will mean that code like

```
enum Foo {
    A([i32; 8000]),
}
```

or

```
enum Foo {
    A([i32; 8000]),
    B([i32; 8000]),
}
```

will no longer produce a warning. I think this makes more sense because having a large enum is no
worse than having a large struct. The problem is when one variant is small, such as `i32`, and
another variant is very large, such as `[i32; 8000]`.

The tests for this lint have been updated to reflect these changes.