### PR TITLE
doc-markdown: Allow LaTeX-related words

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -175,6 +175,7 @@ define_Conf! {
         "OpenGL",
         "TrueType",
         "iOS", "macOS",
+        "TeX", "LaTeX", "BibTex", "BibLaTex",
     ] => Vec<String>),
     /// Lint: TOO_MANY_ARGUMENTS. The maximum number of argument a function or method can have
     ("too-many-arguments-threshold", too_many_arguments_threshold, 7 => u64),


### PR DESCRIPTION
Add "TeX", "LaTeX", "BibTeX" and "BibLaTeX" to the default list of allowed
words.