### PR TITLE
Add a lint for `slice.iter().cloned().collect()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,7 @@ All notable changes to this project will be documented in this file.
 [`invalid_regex`]: https://github.com/Manishearth/rust-clippy/wiki#invalid_regex
 [`invalid_upcast_comparisons`]: https://github.com/Manishearth/rust-clippy/wiki#invalid_upcast_comparisons
 [`items_after_statements`]: https://github.com/Manishearth/rust-clippy/wiki#items_after_statements
+[`iter_cloned_collect`]: https://github.com/Manishearth/rust-clippy/wiki#iter_cloned_collect
 [`iter_next_loop`]: https://github.com/Manishearth/rust-clippy/wiki#iter_next_loop
 [`iter_nth`]: https://github.com/Manishearth/rust-clippy/wiki#iter_nth
 [`iter_skip_next`]: https://github.com/Manishearth/rust-clippy/wiki#iter_skip_next

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ transparently:
 
 ## Lints
 
-There are 188 lints included in this crate:
+There are 189 lints included in this crate:
 
 name                                                                                                                   | default | triggers on
 -----------------------------------------------------------------------------------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------
@@ -253,6 +253,7 @@ name                                                                            
 [invalid_regex](https://github.com/Manishearth/rust-clippy/wiki#invalid_regex)                                         | deny    | invalid regular expressions
 [invalid_upcast_comparisons](https://github.com/Manishearth/rust-clippy/wiki#invalid_upcast_comparisons)               | allow   | a comparison involving an upcast which is always true or false
 [items_after_statements](https://github.com/Manishearth/rust-clippy/wiki#items_after_statements)                       | allow   | blocks where an item comes after a statement
+[iter_cloned_collect](https://github.com/Manishearth/rust-clippy/wiki#iter_cloned_collect)                             | warn    | using `.cloned().collect()` on slice to create a `Vec`
 [iter_next_loop](https://github.com/Manishearth/rust-clippy/wiki#iter_next_loop)                                       | warn    | for-looping over `_.next()` which is probably not intended
 [iter_nth](https://github.com/Manishearth/rust-clippy/wiki#iter_nth)                                                   | warn    | using `.iter().nth()` on a standard library type with O(1) element access
 [iter_skip_next](https://github.com/Manishearth/rust-clippy/wiki#iter_skip_next)                                       | warn    | using `.skip(x).next()` on an iterator

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -420,6 +420,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         methods::CLONE_ON_COPY,
         methods::FILTER_NEXT,
         methods::GET_UNWRAP,
+        methods::ITER_CLONED_COLLECT,
         methods::ITER_NTH,
         methods::ITER_SKIP_NEXT,
         methods::NEW_RET_NO_SELF,

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -904,11 +904,12 @@ fn lint_cstring_as_ptr(cx: &LateContext, expr: &hir::Expr, new: &hir::Expr, unwr
 
 fn lint_iter_cloned_collect(cx: &LateContext, expr: &hir::Expr, iter_args: &[hir::Expr]) {
     if match_type(cx, cx.tables.expr_ty(expr), &paths::VEC) &&
-        derefs_to_slice(cx, &iter_args[0], cx.tables.expr_ty(&iter_args[0])).is_some() {
+       derefs_to_slice(cx, &iter_args[0], cx.tables.expr_ty(&iter_args[0])).is_some() {
         span_lint(cx,
                   ITER_CLONED_COLLECT,
                   expr.span,
-                  "called `cloned().collect()` on a slice to create a `Vec`. This is more succinctly expressed by calling `to_owned(x)`");
+                  "called `cloned().collect()` on a slice to create a `Vec`. This is more succinctly expressed by \
+                  calling `to_owned(x)`");
     }
 }
 

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -494,13 +494,33 @@ declare_lint! {
 /// s.push_str(abc);
 /// s.push_str(&def));
 /// ```
-
 declare_lint! {
     pub STRING_EXTEND_CHARS,
     Warn,
     "using `x.extend(s.chars())` where s is a `&str` or `String`"
 }
 
+/// **What it does:** Checks for the use of `.cloned().collect()` on slice to create a Vec.
+///
+/// **Why is this bad?** `.to_owned()` is clearer
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rust
+/// let s = [1,2,3,4,5];
+/// let s2 : Vec<isize> = s.iter().cloned().collect();
+/// ```
+/// The correct use would be:
+/// ```rust
+/// let s = [1,2,3,4,5];
+/// let s2 : Vec<isize> = s.to_owned();
+/// ```
+declare_lint! {
+    pub ITER_CLONED_COLLECT,
+    Warn,
+    "using `.cloned().collect()` on slice to create a `Vec`"
+}
 
 impl LintPass for Pass {
     fn get_lints(&self) -> LintArray {
@@ -525,7 +545,8 @@ impl LintPass for Pass {
                     ITER_NTH,
                     ITER_SKIP_NEXT,
                     GET_UNWRAP,
-                    STRING_EXTEND_CHARS)
+                    STRING_EXTEND_CHARS,
+                    ITER_CLONED_COLLECT)
     }
 }
 
@@ -580,6 +601,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                     lint_iter_nth(cx, expr, arglists[0], true);
                 } else if method_chain_args(expr, &["skip", "next"]).is_some() {
                     lint_iter_skip_next(cx, expr);
+                } else if let Some(arglists) = method_chain_args(expr, &["cloned", "collect"]) {
+                    lint_iter_cloned_collect(cx, expr, arglists[0]);
                 }
 
                 lint_or_fun_call(cx, expr, &name.node.as_str(), args);
@@ -877,6 +900,16 @@ fn lint_cstring_as_ptr(cx: &LateContext, expr: &hir::Expr, new: &hir::Expr, unwr
                                db.span_help(unwrap.span, "assign the `CString` to a variable to extend its lifetime");
                            });
     }}
+}
+
+fn lint_iter_cloned_collect(cx: &LateContext, expr: &hir::Expr, iter_args: &[hir::Expr]) {
+    if match_type(cx, cx.tables.expr_ty(expr), &paths::VEC) &&
+        derefs_to_slice(cx, &iter_args[0], cx.tables.expr_ty(&iter_args[0])).is_some() {
+        span_lint(cx,
+                  ITER_CLONED_COLLECT,
+                  expr.span,
+                  "called `cloned().collect()` on a slice to create a `Vec`. This is more succinctly expressed by calling `to_owned(x)`");
+    }
 }
 
 fn lint_iter_nth(cx: &LateContext, expr: &hir::Expr, iter_args: &[hir::Expr], is_mut: bool) {

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -500,21 +500,21 @@ declare_lint! {
     "using `x.extend(s.chars())` where s is a `&str` or `String`"
 }
 
-/// **What it does:** Checks for the use of `.cloned().collect()` on slice to create a Vec.
+/// **What it does:** Checks for the use of `.cloned().collect()` on slice to create a `Vec`.
 ///
-/// **Why is this bad?** `.to_owned()` is clearer
+/// **Why is this bad?** `.to_vec()` is clearer
 ///
 /// **Known problems:** None.
 ///
 /// **Example:**
 /// ```rust
 /// let s = [1,2,3,4,5];
-/// let s2 : Vec<isize> = s.iter().cloned().collect();
+/// let s2 : Vec<isize> = s[..].iter().cloned().collect();
 /// ```
-/// The correct use would be:
+/// The better use would be:
 /// ```rust
 /// let s = [1,2,3,4,5];
-/// let s2 : Vec<isize> = s.to_owned();
+/// let s2 : Vec<isize> = s.to_vec();
 /// ```
 declare_lint! {
     pub ITER_CLONED_COLLECT,
@@ -908,8 +908,7 @@ fn lint_iter_cloned_collect(cx: &LateContext, expr: &hir::Expr, iter_args: &[hir
         span_lint(cx,
                   ITER_CLONED_COLLECT,
                   expr.span,
-                  "called `cloned().collect()` on a slice to create a `Vec`. This is more succinctly expressed by \
-                  calling `to_owned(x)`");
+                  "called `cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable");
     }
 }
 

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -908,7 +908,8 @@ fn lint_iter_cloned_collect(cx: &LateContext, expr: &hir::Expr, iter_args: &[hir
         span_lint(cx,
                   ITER_CLONED_COLLECT,
                   expr.span,
-                  "called `cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable");
+                  "called `cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and \
+                   more readable");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 // error-pattern:yummy
 #![feature(box_syntax)]
 #![feature(rustc_private)]
-#![feature(static_in_const)]
 
 #![allow(unknown_lints, missing_docs_in_private_items)]
 

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -693,4 +693,7 @@ fn temporary_cstring() {
 fn iter_clone_collect() {
     let v = [1,2,3,4,5];
     let v2 : Vec<isize> = v.iter().cloned().collect();
+
+    let v3 : HashSet<isize> = v.iter().cloned().collect();
+    let v4 : VecDeque<isize> = v.iter().cloned().collect();
 }

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -689,3 +689,8 @@ fn temporary_cstring() {
 
 
 }
+
+fn iter_clone_collect() {
+    let v = [1,2,3,4,5];
+    let v2 : Vec<isize> = v.iter().cloned().collect();
+}

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -950,7 +950,7 @@ help: assign the `CString` to a variable to extend its lifetime
 687 |     CString::new("foo").unwrap().as_ptr();
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: called `cloned().collect()` on a slice to create a `Vec`. This is more succinctly expressed by calling `to_owned(x)`
+warning: called `cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
    --> $DIR/methods.rs:695:27
     |
 695 |     let v2 : Vec<isize> = v.iter().cloned().collect();

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -950,5 +950,13 @@ help: assign the `CString` to a variable to extend its lifetime
 687 |     CString::new("foo").unwrap().as_ptr();
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+warning: called `cloned().collect()` on a slice to create a `Vec`. This is more succinctly expressed by calling `to_owned(x)`
+   --> $DIR/methods.rs:695:27
+    |
+695 |     let v2 : Vec<isize> = v.iter().cloned().collect();
+    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: #[warn(iter_cloned_collect)] on by default
+
 error: aborting due to 88 previous errors
 

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -950,13 +950,18 @@ help: assign the `CString` to a variable to extend its lifetime
 687 |     CString::new("foo").unwrap().as_ptr();
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: called `cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
+error: called `cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
    --> $DIR/methods.rs:695:27
     |
 695 |     let v2 : Vec<isize> = v.iter().cloned().collect();
     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-    = note: #[warn(iter_cloned_collect)] on by default
+    = note: #[deny(iter_cloned_collect)] implied by #[deny(clippy)]
+note: lint level defined here
+   --> $DIR/methods.rs:5:9
+    |
+5   | #![deny(clippy, clippy_pedantic)]
+    |         ^^^^^^
 
-error: aborting due to 88 previous errors
+error: aborting due to 89 previous errors
 


### PR DESCRIPTION
If one uses `slice.iter().cloned().collect()` to create a new `Vec`,
it should be `slice.to_owned()`.

Fix #1292