### PR TITLE
Suggest `assert_ne` for `assert!(x != y)`

### DIFF
--- a/tests/ui/should_assert_eq.rs
+++ b/tests/ui/should_assert_eq.rs
@@ -14,6 +14,8 @@ fn main() {
     assert!(1 == 2);
     assert!(Debug(1) == Debug(2));
     assert!(NonDebug(1) == NonDebug(1)); // ok
+    assert!(Debug(1) != Debug(2));
+    assert!(NonDebug(1) != NonDebug(2)); // ok
 
     test_generic(1, 2, 3, 4);
 }
@@ -21,4 +23,7 @@ fn main() {
 fn test_generic<T: std::fmt::Debug + Eq, U: Eq>(x: T, y: T, z: U, w: U) {
     assert!(x == y);
     assert!(z == w); // ok
+
+    assert!(x != y);
+    assert!(z != w); // ok
 }

--- a/tests/ui/should_assert_eq.stderr
+++ b/tests/ui/should_assert_eq.stderr
@@ -19,13 +19,29 @@ error: use `assert_eq` for better reporting
    |
    = note: this error originates in a macro outside of the current crate
 
-error: use `assert_eq` for better reporting
-  --> $DIR/should_assert_eq.rs:22:5
+error: use `assert_ne` for better reporting
+  --> $DIR/should_assert_eq.rs:17:5
    |
-22 |     assert!(x == y);
+17 |     assert!(Debug(1) != Debug(2));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate
+
+error: use `assert_eq` for better reporting
+  --> $DIR/should_assert_eq.rs:24:5
+   |
+24 |     assert!(x == y);
    |     ^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to 3 previous errors
+error: use `assert_ne` for better reporting
+  --> $DIR/should_assert_eq.rs:27:5
+   |
+27 |     assert!(x != y);
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Expands `should_assert_eq` lint to suggest `assert_ne`.