### PR TITLE
Add ‘ECMAScript’ to default `doc-valid-idents`

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -166,6 +166,7 @@ define_Conf! {
     ("doc-valid-idents", doc_valid_idents, [
         "MiB", "GiB", "TiB", "PiB", "EiB",
         "DirectX",
+        "ECMAScript",
         "GPLv2", "GPLv3",
         "GitHub",
         "IPv4", "IPv6",


### PR DESCRIPTION
FYI, https://en.wikipedia.org/wiki/ECMAScript .