### PR TITLE
Rustup publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.118 — 2017-03-05
+* Rustup to *rustc 1.17.0-nightly (b1e31766d 2017-03-03)*
+
 ## 0.0.117 — 2017-03-01
 * Rustup to *rustc 1.17.0-nightly (be760566c 2017-02-28)*
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.117"
+version = "0.0.118"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -30,7 +30,7 @@ test = false
 
 [dependencies]
 # begin automatic update
-clippy_lints = { version = "0.0.117", path = "clippy_lints" }
+clippy_lints = { version = "0.0.118", path = "clippy_lints" }
 # end automatic update
 cargo_metadata = "0.1.1"
 

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.117"
+version = "0.0.118"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",

--- a/clippy_lints/src/array_indexing.rs
+++ b/clippy_lints/src/array_indexing.rs
@@ -2,7 +2,7 @@ use rustc::lint::*;
 use rustc::middle::const_val::ConstVal;
 use rustc::ty;
 use rustc_const_eval::ConstContext;
-use rustc_const_math::{ConstUsize,ConstIsize,ConstInt};
+use rustc_const_math::{ConstUsize, ConstIsize, ConstInt};
 use rustc::hir;
 use syntax::ast::RangeLimits;
 use utils::{self, higher};
@@ -60,7 +60,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ArrayIndexing {
             // Array with known size can be checked statically
             let ty = cx.tables.expr_ty(array);
             if let ty::TyArray(_, size) = ty.sty {
-                let size = ConstInt::Usize(ConstUsize::new(size as u64, cx.sess().target.uint_type).expect("array size is invalid"));
+                let size = ConstInt::Usize(ConstUsize::new(size as u64, cx.sess().target.uint_type)
+                    .expect("array size is invalid"));
                 let constcx = ConstContext::with_tables(cx.tcx, cx.tables);
 
                 // Index is a constant uint
@@ -123,23 +124,24 @@ fn to_const_range(
         Some(Some(ConstVal::Integral(x))) => {
             if limits == RangeLimits::Closed {
                 match x {
-                    ConstInt::U8(_) => (x + ConstInt::U8(1)),
-                    ConstInt::U16(_) => (x + ConstInt::U16(1)),
-                    ConstInt::U32(_) => (x + ConstInt::U32(1)),
-                    ConstInt::U64(_) => (x + ConstInt::U64(1)),
-                    ConstInt::U128(_) => (x + ConstInt::U128(1)),
-                    ConstInt::Usize(ConstUsize::Us16(_)) => (x + ConstInt::Usize(ConstUsize::Us16(1))),
-                    ConstInt::Usize(ConstUsize::Us32(_)) => (x + ConstInt::Usize(ConstUsize::Us32(1))),
-                    ConstInt::Usize(ConstUsize::Us64(_)) => (x + ConstInt::Usize(ConstUsize::Us64(1))),
-                    ConstInt::I8(_) => (x + ConstInt::I8(1)),
-                    ConstInt::I16(_) => (x + ConstInt::I16(1)),
-                    ConstInt::I32(_) => (x + ConstInt::I32(1)),
-                    ConstInt::I64(_) => (x + ConstInt::I64(1)),
-                    ConstInt::I128(_) => (x + ConstInt::I128(1)),
-                    ConstInt::Isize(ConstIsize::Is16(_)) => (x + ConstInt::Isize(ConstIsize::Is16(1))),
-                    ConstInt::Isize(ConstIsize::Is32(_)) => (x + ConstInt::Isize(ConstIsize::Is32(1))),
-                    ConstInt::Isize(ConstIsize::Is64(_)) => (x + ConstInt::Isize(ConstIsize::Is64(1))),
-                }.expect("such a big array is not realistic")
+                        ConstInt::U8(_) => (x + ConstInt::U8(1)),
+                        ConstInt::U16(_) => (x + ConstInt::U16(1)),
+                        ConstInt::U32(_) => (x + ConstInt::U32(1)),
+                        ConstInt::U64(_) => (x + ConstInt::U64(1)),
+                        ConstInt::U128(_) => (x + ConstInt::U128(1)),
+                        ConstInt::Usize(ConstUsize::Us16(_)) => (x + ConstInt::Usize(ConstUsize::Us16(1))),
+                        ConstInt::Usize(ConstUsize::Us32(_)) => (x + ConstInt::Usize(ConstUsize::Us32(1))),
+                        ConstInt::Usize(ConstUsize::Us64(_)) => (x + ConstInt::Usize(ConstUsize::Us64(1))),
+                        ConstInt::I8(_) => (x + ConstInt::I8(1)),
+                        ConstInt::I16(_) => (x + ConstInt::I16(1)),
+                        ConstInt::I32(_) => (x + ConstInt::I32(1)),
+                        ConstInt::I64(_) => (x + ConstInt::I64(1)),
+                        ConstInt::I128(_) => (x + ConstInt::I128(1)),
+                        ConstInt::Isize(ConstIsize::Is16(_)) => (x + ConstInt::Isize(ConstIsize::Is16(1))),
+                        ConstInt::Isize(ConstIsize::Is32(_)) => (x + ConstInt::Isize(ConstIsize::Is32(1))),
+                        ConstInt::Isize(ConstIsize::Is64(_)) => (x + ConstInt::Isize(ConstIsize::Is64(1))),
+                    }
+                    .expect("such a big array is not realistic")
             } else {
                 x
             }

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -5,7 +5,7 @@ use rustc::hir::def::Def;
 use rustc_const_eval::lookup_const_by_id;
 use rustc_const_math::ConstInt;
 use rustc::hir::*;
-use rustc::ty::{TyCtxt, self};
+use rustc::ty::{self, TyCtxt};
 use std::cmp::Ordering::{self, Equal};
 use std::cmp::PartialOrd;
 use std::hash::{Hash, Hasher};
@@ -179,17 +179,15 @@ pub fn lit_to_constant<'a, 'tcx>(lit: &LitKind, tcx: TyCtxt<'a, 'tcx, 'tcx>, mut
             match (&ty.sty, hint) {
                 (&ty::TyInt(ity), _) |
                 (_, Signed(ity)) => {
-                    Constant::Int(ConstInt::new_signed_truncating(n as i128,
-                        ity, tcx.sess.target.int_type))
-                }
+                    Constant::Int(ConstInt::new_signed_truncating(n as i128, ity, tcx.sess.target.int_type))
+                },
                 (&ty::TyUint(uty), _) |
                 (_, Unsigned(uty)) => {
-                    Constant::Int(ConstInt::new_unsigned_truncating(n as u128,
-                        uty, tcx.sess.target.uint_type))
-                }
-                _ => bug!()
+                    Constant::Int(ConstInt::new_unsigned_truncating(n as u128, uty, tcx.sess.target.uint_type))
+                },
+                _ => bug!(),
             }
-        }
+        },
         LitKind::Float(ref is, ty) => Constant::Float(is.to_string(), ty.into()),
         LitKind::FloatUnsuffixed(ref is) => Constant::Float(is.to_string(), FloatWidth::Any),
         LitKind::Bool(b) => Constant::Bool(b),
@@ -291,7 +289,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
                 if let Some((const_expr, tables)) = lookup_const_by_id(self.tcx, def_id, substs) {
                     let mut cx = ConstEvalLateContext {
                         tcx: self.tcx,
-                        tables,
+                        tables: tables,
                         needed_resolution: false,
                     };
                     let ret = cx.expr(const_expr);

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -66,7 +66,8 @@ fn check_closure(cx: &LateContext, expr: &Expr) {
                 // Is it an unsafe function? They don't implement the closure traits
                 ty::TyFnDef(_, _, fn_ty) |
                 ty::TyFnPtr(fn_ty) => {
-                    if fn_ty.skip_binder().unsafety == Unsafety::Unsafe || fn_ty.skip_binder().output().sty == ty::TyNever {
+                    if fn_ty.skip_binder().unsafety == Unsafety::Unsafe ||
+                       fn_ty.skip_binder().output().sty == ty::TyNever {
                         return;
                     }
                 },

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -211,14 +211,14 @@ fn report_single_match_single_pattern(cx: &LateContext, ex: &Expr, arms: &[Arm],
     };
     let els_str = els.map_or(String::new(), |els| format!(" else {}", expr_block(cx, els, None, "..")));
     span_lint_and_then(cx,
-                        lint,
-                        expr.span,
-                        "you seem to be trying to use match for destructuring a single pattern. \
-                        Consider using `if let`",
-                        |db| {
+                       lint,
+                       expr.span,
+                       "you seem to be trying to use match for destructuring a single pattern. Consider using `if \
+                        let`",
+                       |db| {
         db.span_suggestion(expr.span,
-                            "try this",
-                            format!("if let {} = {} {}{}",
+                           "try this",
+                           format!("if let {} = {} {}{}",
                                     snippet(cx, arms[0].pats[0].span, ".."),
                                     snippet(cx, ex.span, ".."),
                                     expr_block(cx, &arms[0].body, None, ".."),

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -382,7 +382,7 @@ fn is_allowed(cx: &LateContext, expr: &Expr) -> bool {
 
                 val.try_cmp(zero) == Ok(Ordering::Equal) || val.try_cmp(infinity) == Ok(Ordering::Equal) ||
                 val.try_cmp(neg_infinity) == Ok(Ordering::Equal)
-            }
+            },
         }
     } else {
         false

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -975,7 +975,7 @@ pub fn is_try(expr: &Expr) -> Option<&Expr> {
 }
 
 pub fn type_size<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: ty::Ty<'tcx>) -> Option<u64> {
-    cx.tcx.infer_ctxt((), Reveal::All).enter(|infcx|
-        ty.layout(&infcx).ok().map(|lay| lay.size(&TargetDataLayout::parse(cx.sess())).bytes())
-    )
+    cx.tcx
+        .infer_ctxt((), Reveal::All)
+        .enter(|infcx| ty.layout(&infcx).ok().map(|lay| lay.size(&TargetDataLayout::parse(cx.sess())).bytes()))
 }


### PR DESCRIPTION
rustfmt removes attributes on expressions, seems like a wontfix: https://github.com/rust-lang-nursery/rustfmt/issues/1346

~~I'll remove the feature from clippy so we don't use it~~ It's a combined feature for expressions and statements. Oh well... we'll just have to be careful with rustfmt for a while.