### PR TITLE
Fix compilation on latest nightly

### DIFF
--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -58,6 +58,10 @@ impl EarlyLintPass for ItemsAfterStatements {
                 if in_macro(cx, it.span) {
                     return;
                 }
+                if let ItemKind::MacroDef(..) = it.node {
+                    // do not lint `macro_rules`, but continue processing further statements
+                    continue;
+                }
                 span_lint(cx,
                           ITEMS_AFTER_STATEMENTS,
                           it.span,

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,6 @@ impl<'a> CompilerCalls<'a> for ClippyCompilerCalls {
                                                            lint_groups,
                                                            llvm_passes,
                                                            attributes,
-                                                           mir_passes,
                                                            .. } = registry;
                     let sess = &state.session;
                     let mut ls = sess.lint_store.borrow_mut();
@@ -105,7 +104,6 @@ impl<'a> CompilerCalls<'a> for ClippyCompilerCalls {
                     }
 
                     sess.plugin_llvm_passes.borrow_mut().extend(llvm_passes);
-                    sess.mir_passes.borrow_mut().extend(mir_passes);
                     sess.plugin_attributes.borrow_mut().extend(attributes);
                 }
                 old(state);

--- a/tests/ui/item_after_statement.rs
+++ b/tests/ui/item_after_statement.rs
@@ -17,3 +17,14 @@ fn main() {
     fn foo() { println!("foo"); }
     foo();
 }
+
+fn mac() {
+    let mut a = 5;
+    println!("{}", a);
+    // do not lint this, because it needs to be after `a`
+    macro_rules! b {
+        () => {{ a = 6 }}
+    }
+    b!();
+    println!("{}", a);
+}


### PR DESCRIPTION
The ability for plugins to add MIR passes was removed as of 4ca9c97ac.
Luckily, we don't use this feature at all and can safely ignore it.

Fixes #1618

Although it successfully lints itself and several other projects, it doesn't pass the tests because the compiler keeps panicking 🙄 