### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,9 @@ T-middle issues can be more involved and require verifying types. The
 lot of methods that are useful, though one of the most useful would be `expr_ty` (gives the type of
 an AST expression). `match_def_path()` in Clippy's `utils` module can also be useful.
 
-Should you add a lint, try it on clippy itself using `util/dogfood.sh`. You may find that clippy
-contains some questionable code itself! Also before making a pull request, please run
-`util/update_lints.py`, which will update `lib.rs` and `README.md` with the lint declarations. Our
-travis build actually checks for this.
+Compiling clippy can take almost a minute or more depending on your machine.
+You can set the environment flag `CARGO_INCREMENTAL=1` to cut down that time to
+almost a third on average, depending on the influence your change has.
 
 Clippy uses UI tests. UI tests check that the output of the compiler is exactly as expected.
 Of course there's little sense in writing the output yourself or copying it around.


### PR DESCRIPTION
We don't require update_lints and dogfood anymore, since the latter is part of `cargo test` anyway.

Also :tada: incremental compilation :tada: