### PR TITLE
Rustup: Add ExprKind::Catch

### DIFF
--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -99,6 +99,7 @@ impl<'a> Sugg<'a> {
             ast::ExprKind::Block(..) |
             ast::ExprKind::Break(..) |
             ast::ExprKind::Call(..) |
+            ast::ExprKind::Catch(..) |
             ast::ExprKind::Continue(..) |
             ast::ExprKind::Field(..) |
             ast::ExprKind::ForLoop(..) |


### PR DESCRIPTION
Recently the AST gained a `ExprKind::Catch(..)`, which tripped up a match in `utils/sugg.rs`. Adding it to make clippy work again. This needs a version bump + publish, too. 