### PR TITLE
Fix "`Catch(_)` not covered"

### DIFF
--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -72,6 +72,7 @@ impl<'a> Sugg<'a> {
                 hir::ExprBinary(op, ..) => Sugg::BinOp(AssocOp::from_ast_binop(higher::binop(op.node)), snippet),
                 hir::ExprCast(..) => Sugg::BinOp(AssocOp::As, snippet),
                 hir::ExprType(..) => Sugg::BinOp(AssocOp::Colon, snippet),
+                _ => unreachable!(),
             }
         })
     }
@@ -127,6 +128,7 @@ impl<'a> Sugg<'a> {
             ast::ExprKind::Binary(op, ..) => Sugg::BinOp(AssocOp::from_ast_binop(op.node), snippet),
             ast::ExprKind::Cast(..) => Sugg::BinOp(AssocOp::As, snippet),
             ast::ExprKind::Type(..) => Sugg::BinOp(AssocOp::Colon, snippet),
+            _ => unreachable!(),
         }
     }
 


### PR DESCRIPTION
I encountered a compilation error on the latest nightly because of this.