### PR TITLE
correct message for `option_map_unwrap_or_else` lint

### DIFF
--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -1101,7 +1101,7 @@ fn lint_map_unwrap_or_else(cx: &LateContext, expr: &hir::Expr, map_args: &[hir::
                                expr.span,
                                msg,
                                expr.span,
-                               &format!("replace `map({0}).unwrap_or_else({1})` with `with map_or_else({1}, {0})`",
+                               &format!("replace `map({0}).unwrap_or_else({1})` with `map_or_else({1}, {0})`",
                                         map_snippet,
                                         unwrap_snippet));
         } else if same_span && multiline {

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -117,7 +117,7 @@ note: lint level defined here
     |
 5   | #![deny(clippy, clippy_pedantic)]
     |                 ^^^^^^^^^^^^^^^
-    = note: replace `map(|x| x + 1).unwrap_or_else(|| 0)` with `with map_or_else(|| 0, |x| x + 1)`
+    = note: replace `map(|x| x + 1).unwrap_or_else(|| 0)` with `map_or_else(|| 0, |x| x + 1)`
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
    --> $DIR/methods.rs:120:13


### PR DESCRIPTION
Remove erroneous "with " in suggested alternative call.