### PR TITLE
Rustup to 1.18.0-nightly (d5cf1cb64 2017-04-15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.0.124 — 2017-04-16
+* Update to *rustc 1.18.0-nightly (d5cf1cb64 2017-04-15)*
+
 ## 0.0.123 — 2017-04-07
 * Fix various false positives
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.123"
+version = "0.0.124"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -30,7 +30,7 @@ test = false
 
 [dependencies]
 # begin automatic update
-clippy_lints = { version = "0.0.123", path = "clippy_lints" }
+clippy_lints = { version = "0.0.124", path = "clippy_lints" }
 # end automatic update
 cargo_metadata = "0.1.1"
 

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.123"
+version = "0.0.124"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -122,6 +122,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDoc {
             hir::ItemStatic(..) => "a static",
             hir::ItemStruct(..) => "a struct",
             hir::ItemTrait(..) => "a trait",
+            hir::ItemGlobalAsm(..) => "an assembly blob",
             hir::ItemTy(..) => "a type alias",
             hir::ItemUnion(..) => "a union",
             hir::ItemDefaultImpl(..) |

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -372,6 +372,7 @@ fn print_item(cx: &LateContext, item: &hir::Item) {
         },
         hir::ItemMod(..) => println!("module"),
         hir::ItemForeignMod(ref fm) => println!("foreign module with abi: {}", fm.abi),
+        hir::ItemGlobalAsm(ref asm) => println!("global asm: {:?}", asm),
         hir::ItemTy(..) => {
             println!("type alias for {:?}", cx.tcx.item_type(did));
         },

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -904,7 +904,8 @@ pub fn opt_def_id(def: Def) -> Option<DefId> {
         Def::AssociatedConst(id) |
         Def::Local(id) |
         Def::Upvar(id, ..) |
-        Def::Macro(id, _) => Some(id),
+        Def::Macro(id, ..) |
+        Def::GlobalAsm(id) => Some(id),
 
         Def::Label(..) | Def::PrimTy(..) | Def::SelfTy(..) | Def::Err => None,
     }


### PR DESCRIPTION
Relevant `rustc` change: [Implement global_asm!() (RFC 1548)](https://github.com/rust-lang/rust/pull/40702)
Closes https://github.com/Manishearth/rust-clippy/issues/1676.