### PR TITLE
Fix two doc comments (one broke `cargo doc`)

### DIFF
--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -371,7 +371,7 @@ fn check_and_warn<'a>(ctx: &EarlyContext, expr: &'a ast::Expr) {
 ///
 /// ```
 ///     {
-///         let x = 5;"
+///         let x = 5;
 /// ```
 ///
 /// NOTE: when there is no closing brace in `s`, `s` is _not_ preserved, i.e.,
@@ -405,7 +405,6 @@ pub fn erode_from_back(s: &str) -> String {
 ///             something();
 ///             inside_a_block();
 ///         }
-///     
 /// ```
 ///
 pub fn erode_from_front(s: &str) -> String {


### PR DESCRIPTION
The first doc comment actually caused `cargo doc` to fail with:
```
error: unterminated double quote string
 --> <stdin>:2:19
  |
2 |         let x = 5;"
  |                   ^

error: Could not document `clippy_lints`.
```