### PR TITLE
clean tests/ui/assign_ops.rs

### DIFF
--- a/tests/ui/assign_ops.rs
+++ b/tests/ui/assign_ops.rs
@@ -6,46 +6,18 @@
 fn main() {
     let mut i = 1i32;
     i += 2;
-
-
     i += 2 + 17;
-
-
     i -= 6;
-
-
     i -= 2 - 1;
-
-
-
     i *= 5;
-
-
     i *= 1+5;
-
-
     i /= 32;
-
-
     i /= 32 | 5;
-
-
     i /= 32 / 5;
-
-
     i %= 42;
-
-
     i >>= i;
-
-
     i <<= 9 + 6 - 7;
-
-
     i += 1 << 5;
-
-
-
 }
 
 #[allow(dead_code, unused_assignments)]
@@ -53,29 +25,13 @@ fn main() {
 fn bla() {
     let mut a = 5;
     a = a + 1;
-
-
     a = 1 + a;
-
-
     a = a - 1;
-
-
     a = a * 99;
-
-
     a = 42 * a;
-
-
     a = a / 2;
-
-
     a = a % 5;
-
-
     a = a & 1;
-
-
     a = 1 - a;
     a = 5 / a;
     a = 42 % a;

--- a/tests/ui/assign_ops.stderr
+++ b/tests/ui/assign_ops.stderr
@@ -11,129 +11,129 @@ note: lint level defined here
   |        ^^^^^^^^^^
 
 error: assign operation detected
+ --> $DIR/assign_ops.rs:9:5
+  |
+9 |     i += 2 + 17;
+  |     ^^^^^^^^^^^ help: replace it with `i = i + 2 + 17`
+
+error: assign operation detected
+  --> $DIR/assign_ops.rs:10:5
+   |
+10 |     i -= 6;
+   |     ^^^^^^ help: replace it with `i = i - 6`
+
+error: assign operation detected
   --> $DIR/assign_ops.rs:11:5
    |
-11 |     i += 2 + 17;
-   |     ^^^^^^^^^^^ help: replace it with `i = i + 2 + 17`
+11 |     i -= 2 - 1;
+   |     ^^^^^^^^^^ help: replace it with `i = i - (2 - 1)`
+
+error: assign operation detected
+  --> $DIR/assign_ops.rs:12:5
+   |
+12 |     i *= 5;
+   |     ^^^^^^ help: replace it with `i = i * 5`
+
+error: assign operation detected
+  --> $DIR/assign_ops.rs:13:5
+   |
+13 |     i *= 1+5;
+   |     ^^^^^^^^ help: replace it with `i = i * (1+5)`
 
 error: assign operation detected
   --> $DIR/assign_ops.rs:14:5
    |
-14 |     i -= 6;
-   |     ^^^^^^ help: replace it with `i = i - 6`
+14 |     i /= 32;
+   |     ^^^^^^^ help: replace it with `i = i / 32`
+
+error: assign operation detected
+  --> $DIR/assign_ops.rs:15:5
+   |
+15 |     i /= 32 | 5;
+   |     ^^^^^^^^^^^ help: replace it with `i = i / (32 | 5)`
+
+error: assign operation detected
+  --> $DIR/assign_ops.rs:16:5
+   |
+16 |     i /= 32 / 5;
+   |     ^^^^^^^^^^^ help: replace it with `i = i / (32 / 5)`
 
 error: assign operation detected
   --> $DIR/assign_ops.rs:17:5
    |
-17 |     i -= 2 - 1;
-   |     ^^^^^^^^^^ help: replace it with `i = i - (2 - 1)`
-
-error: assign operation detected
-  --> $DIR/assign_ops.rs:21:5
-   |
-21 |     i *= 5;
-   |     ^^^^^^ help: replace it with `i = i * 5`
-
-error: assign operation detected
-  --> $DIR/assign_ops.rs:24:5
-   |
-24 |     i *= 1+5;
-   |     ^^^^^^^^ help: replace it with `i = i * (1+5)`
-
-error: assign operation detected
-  --> $DIR/assign_ops.rs:27:5
-   |
-27 |     i /= 32;
-   |     ^^^^^^^ help: replace it with `i = i / 32`
-
-error: assign operation detected
-  --> $DIR/assign_ops.rs:30:5
-   |
-30 |     i /= 32 | 5;
-   |     ^^^^^^^^^^^ help: replace it with `i = i / (32 | 5)`
-
-error: assign operation detected
-  --> $DIR/assign_ops.rs:33:5
-   |
-33 |     i /= 32 / 5;
-   |     ^^^^^^^^^^^ help: replace it with `i = i / (32 / 5)`
-
-error: assign operation detected
-  --> $DIR/assign_ops.rs:36:5
-   |
-36 |     i %= 42;
+17 |     i %= 42;
    |     ^^^^^^^ help: replace it with `i = i % 42`
 
 error: assign operation detected
-  --> $DIR/assign_ops.rs:39:5
+  --> $DIR/assign_ops.rs:18:5
    |
-39 |     i >>= i;
+18 |     i >>= i;
    |     ^^^^^^^ help: replace it with `i = i >> i`
 
 error: assign operation detected
-  --> $DIR/assign_ops.rs:42:5
+  --> $DIR/assign_ops.rs:19:5
    |
-42 |     i <<= 9 + 6 - 7;
+19 |     i <<= 9 + 6 - 7;
    |     ^^^^^^^^^^^^^^^ help: replace it with `i = i << (9 + 6 - 7)`
 
 error: assign operation detected
-  --> $DIR/assign_ops.rs:45:5
+  --> $DIR/assign_ops.rs:20:5
    |
-45 |     i += 1 << 5;
+20 |     i += 1 << 5;
    |     ^^^^^^^^^^^ help: replace it with `i = i + (1 << 5)`
 
 error: manual implementation of an assign operation
-  --> $DIR/assign_ops.rs:55:5
+  --> $DIR/assign_ops.rs:27:5
    |
-55 |     a = a + 1;
+27 |     a = a + 1;
    |     ^^^^^^^^^ help: replace it with `a += 1`
    |
 note: lint level defined here
-  --> $DIR/assign_ops.rs:52:8
+  --> $DIR/assign_ops.rs:24:8
    |
-52 | #[deny(assign_op_pattern)]
+24 | #[deny(assign_op_pattern)]
    |        ^^^^^^^^^^^^^^^^^
 
 error: manual implementation of an assign operation
-  --> $DIR/assign_ops.rs:58:5
+  --> $DIR/assign_ops.rs:28:5
    |
-58 |     a = 1 + a;
+28 |     a = 1 + a;
    |     ^^^^^^^^^ help: replace it with `a += 1`
 
 error: manual implementation of an assign operation
-  --> $DIR/assign_ops.rs:61:5
+  --> $DIR/assign_ops.rs:29:5
    |
-61 |     a = a - 1;
+29 |     a = a - 1;
    |     ^^^^^^^^^ help: replace it with `a -= 1`
 
 error: manual implementation of an assign operation
-  --> $DIR/assign_ops.rs:64:5
+  --> $DIR/assign_ops.rs:30:5
    |
-64 |     a = a * 99;
+30 |     a = a * 99;
    |     ^^^^^^^^^^ help: replace it with `a *= 99`
 
 error: manual implementation of an assign operation
-  --> $DIR/assign_ops.rs:67:5
+  --> $DIR/assign_ops.rs:31:5
    |
-67 |     a = 42 * a;
+31 |     a = 42 * a;
    |     ^^^^^^^^^^ help: replace it with `a *= 42`
 
 error: manual implementation of an assign operation
-  --> $DIR/assign_ops.rs:70:5
+  --> $DIR/assign_ops.rs:32:5
    |
-70 |     a = a / 2;
+32 |     a = a / 2;
    |     ^^^^^^^^^ help: replace it with `a /= 2`
 
 error: manual implementation of an assign operation
-  --> $DIR/assign_ops.rs:73:5
+  --> $DIR/assign_ops.rs:33:5
    |
-73 |     a = a % 5;
+33 |     a = a % 5;
    |     ^^^^^^^^^ help: replace it with `a %= 5`
 
 error: manual implementation of an assign operation
-  --> $DIR/assign_ops.rs:76:5
+  --> $DIR/assign_ops.rs:34:5
    |
-76 |     a = a & 1;
+34 |     a = a & 1;
    |     ^^^^^^^^^ help: replace it with `a &= 1`
 
 error: aborting due to 21 previous errors


### PR DESCRIPTION
When all //~ were removed from tests, these were replaced with empty
lines to leave the numbers in the expected stderr untouched.

Cleaning the empty lines for clarity.

If there is interest, I could slowly do the rest of the test files that have weird looking empty files. Happy to do so :smile:, the clone() lint I have assigned is taking me a bit more time of research.