### PR TITLE
Fix a false positive around mutable references and .cloned() iterators

### DIFF
--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -97,4 +97,7 @@ fn map_clone_deref() {
     let _: Option<i32> = x.as_ref().map(|y| **y);
 }
 
-fn main() { }
+fn main() {
+    // used to be a false positive
+    vec![1].iter_mut().map(|x| *x);
+}

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -97,7 +97,9 @@ fn map_clone_deref() {
     let _: Option<i32> = x.as_ref().map(|y| **y);
 }
 
-fn main() {
-    // used to be a false positive
-    vec![1].iter_mut().map(|x| *x);
+// stuff that used to be a false positive
+fn former_false_positive() {
+    vec![1].iter_mut().map(|x| *x); // #443
 }
+
+fn main() { }


### PR DESCRIPTION
I don't think there can be other false positives, because we only suggest this on `*t`, which kind of requires a `Clone` impl on the dereferenced type (because it obviously implements `Copy` for the deref to work)