### PR TITLE
Fix build failure on rustc 1.19.0-nightly (557967766 2017-05-26)

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -288,7 +288,7 @@ pub fn path_to_def(cx: &LateContext, path: &[&str]) -> Option<def::Def> {
             };
 
             for item in &mem::replace(&mut items, vec![]) {
-                if item.name == *segment {
+                if item.ident.name == *segment {
                     if path_it.peek().is_none() {
                         return Some(item.def);
                     }


### PR DESCRIPTION
Try to fix:
```
error: no field `name` on type `&rustc::hir::def::Export`
   --> clippy_lints/src/utils/mod.rs:291:25
    |
291 |                 if item.name == *segment {
    |                         ^^^^

error: aborting due to previous error(s)

error: Could not compile `clippy_lints`.

To learn more, run the command again with --verbose.
```
See https://github.com/Manishearth/rust-clippy/issues/1785
Causing by https://github.com/rust-lang/rust/commit/3eb235b45ef085858cd1c2fad1cf538ba93f81a2 on the rustc side.
Signed-off-by: Cholerae Hu <choleraehyq@gmail.com>