### PR TITLE
Ignore new-without-default lint when `new` method has generic types

### DIFF
--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -108,6 +108,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
                 // can't be implemented by default
                 return;
             }
+            if !sig.generics.ty_params.is_empty() {
+                // when the result of `new()` depends on a type parameter we should not require an
+                // impl of `Default`
+                return;
+            }
             if decl.inputs.is_empty() && name == "new" && cx.access_levels.is_reachable(id) {
                 let self_ty = cx.tcx
                     .type_of(cx.tcx.hir.local_def_id(cx.tcx.hir.get_parent(id)));

--- a/clippy_tests/examples/new_without_default.rs
+++ b/clippy_tests/examples/new_without_default.rs
@@ -76,4 +76,11 @@ struct Const;
 impl Const {
     pub const fn new() -> Const { Const } // const fns can't be implemented via Default
 }
+
+pub struct IgnoreGenericNew;
+
+impl IgnoreGenericNew {
+    pub fn new<T>() -> Self { IgnoreGenericNew } // the derived Default does not make sense here as the result depends on T
+}
+
 fn main() {}


### PR DESCRIPTION
There may be no sensible `Default` impl if the result of `new` depends
on a type parameter.

Close #1809.