### PR TITLE
don't lint while_let_on_iterator on nested loops

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -250,7 +250,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box shadow::Pass);
     reg.register_late_lint_pass(box types::LetPass);
     reg.register_late_lint_pass(box types::UnitCmp);
-    reg.register_late_lint_pass(box loops::Pass);
+    reg.register_late_lint_pass(box loops::Pass::default());
     reg.register_late_lint_pass(box lifetimes::LifetimePass);
     reg.register_late_lint_pass(box entry::HashMapLint);
     reg.register_late_lint_pass(box ranges::StepByZero);

--- a/clippy_tests/examples/while_loop.rs
+++ b/clippy_tests/examples/while_loop.rs
@@ -166,15 +166,15 @@ fn refutable() {
     for &Option::None in b.next() {}
     // */
 
-    let x = a.iter();
+    let mut y = a.iter();
     loop { // x is reused, so don't lint here
-        while let Some(v) = x.next() {
+        while let Some(v) = y.next() {
         }
     }
 
-    let y = a.iter();
+    let mut y = a.iter();
     for _ in 0..2 {
-        while let Some(v) = x.next() {
+        while let Some(v) = y.next() {
         }
     }
 }

--- a/clippy_tests/examples/while_loop.rs
+++ b/clippy_tests/examples/while_loop.rs
@@ -165,4 +165,16 @@ fn refutable() {
     for &(1, 2, 3) in b {}
     for &Option::None in b.next() {}
     // */
+
+    let x = a.iter();
+    loop { // x is reused, so don't lint here
+        while let Some(v) = x.next() {
+        }
+    }
+
+    let y = a.iter();
+    for _ in 0..2 {
+        while let Some(v) = x.next() {
+        }
+    }
 }


### PR DESCRIPTION
The problem is with a nested loop, the iterator may well be reused. This changeset introduces a false negative, when the iterator is initialized within the outer loop. A further PR could get rid of this false negative
by checking if the iterator is indeed initialized within the outer loop.