### PR TITLE
Fix various needless_range_loop false positives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ test = false
 [[bin]]
 name = "cargo-clippy"
 test = false
+path = "src/main.rs"
 
 [dependencies]
 # begin automatic update

--- a/clippy_tests/examples/booleans.stderr
+++ b/clippy_tests/examples/booleans.stderr
@@ -74,8 +74,11 @@ error: this boolean expression can be simplified
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try
-   |     let _ = a == b && c == 5;
-   |     let _ = !(c != 5 || a != b);
+   |
+34 |     let _ = a == b && c == 5;
+   |             ^^^^^^^^^^^^^^^^
+34 |     let _ = !(c != 5 || a != b);
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: this boolean expression can be simplified
   --> booleans.rs:35:13
@@ -84,8 +87,11 @@ error: this boolean expression can be simplified
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try
-   |     let _ = a == b && c == 5;
-   |     let _ = !(c != 5 || a != b);
+   |
+35 |     let _ = a == b && c == 5;
+   |             ^^^^^^^^^^^^^^^^
+35 |     let _ = !(c != 5 || a != b);
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: this boolean expression contains a logic bug
   --> booleans.rs:36:13
@@ -118,8 +124,11 @@ error: this boolean expression can be simplified
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try
-   |     let _ = c != d || a != b;
-   |     let _ = !(a == b && c == d);
+   |
+39 |     let _ = c != d || a != b;
+   |             ^^^^^^^^^^^^^^^^
+39 |     let _ = !(a == b && c == d);
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 13 previous errors
 

--- a/clippy_tests/examples/collapsible_if.stderr
+++ b/clippy_tests/examples/collapsible_if.stderr
@@ -10,9 +10,11 @@ error: this if statement can be collapsed
    |
    = note: `-D collapsible-if` implied by `-D warnings`
 help: try
-   |     if x == "hello" && y == "world" {
-   |     println!("Hello world!");
-   | }
+   |
+8  |     if x == "hello" && y == "world" {
+9  |     println!("Hello world!");
+10 | }
+   |
 
 error: this if statement can be collapsed
   --> collapsible_if.rs:14:5
@@ -25,9 +27,11 @@ error: this if statement can be collapsed
    | |_____^
    |
 help: try
-   |     if (x == "hello" || x == "world") && (y == "world" || y == "hello") {
-   |     println!("Hello world!");
-   | }
+   |
+14 |     if (x == "hello" || x == "world") && (y == "world" || y == "hello") {
+15 |     println!("Hello world!");
+16 | }
+   |
 
 error: this if statement can be collapsed
   --> collapsible_if.rs:20:5
@@ -40,9 +44,11 @@ error: this if statement can be collapsed
    | |_____^
    |
 help: try
-   |     if x == "hello" && x == "world" && (y == "world" || y == "hello") {
-   |     println!("Hello world!");
-   | }
+   |
+20 |     if x == "hello" && x == "world" && (y == "world" || y == "hello") {
+21 |     println!("Hello world!");
+22 | }
+   |
 
 error: this if statement can be collapsed
   --> collapsible_if.rs:26:5
@@ -55,9 +61,11 @@ error: this if statement can be collapsed
    | |_____^
    |
 help: try
-   |     if (x == "hello" || x == "world") && y == "world" && y == "hello" {
-   |     println!("Hello world!");
-   | }
+   |
+26 |     if (x == "hello" || x == "world") && y == "world" && y == "hello" {
+27 |     println!("Hello world!");
+28 | }
+   |
 
 error: this if statement can be collapsed
   --> collapsible_if.rs:32:5
@@ -70,9 +78,11 @@ error: this if statement can be collapsed
    | |_____^
    |
 help: try
-   |     if x == "hello" && x == "world" && y == "world" && y == "hello" {
-   |     println!("Hello world!");
-   | }
+   |
+32 |     if x == "hello" && x == "world" && y == "world" && y == "hello" {
+33 |     println!("Hello world!");
+34 | }
+   |
 
 error: this if statement can be collapsed
   --> collapsible_if.rs:38:5
@@ -85,9 +95,11 @@ error: this if statement can be collapsed
    | |_____^
    |
 help: try
-   |     if 42 == 1337 && 'a' != 'A' {
-   |     println!("world!")
-   | }
+   |
+38 |     if 42 == 1337 && 'a' != 'A' {
+39 |     println!("world!")
+40 | }
+   |
 
 error: this `else { if .. }` block can be collapsed
   --> collapsible_if.rs:47:12
@@ -101,9 +113,11 @@ error: this `else { if .. }` block can be collapsed
    | |_____^
    |
 help: try
-   |     } else if y == "world" {
-   |     println!("world!")
-   | }
+   |
+47 |     } else if y == "world" {
+48 |     println!("world!")
+49 | }
+   |
 
 error: this `else { if .. }` block can be collapsed
   --> collapsible_if.rs:55:12
@@ -117,9 +131,11 @@ error: this `else { if .. }` block can be collapsed
    | |_____^
    |
 help: try
-   |     } else if let Some(42) = Some(42) {
-   |     println!("world!")
-   | }
+   |
+55 |     } else if let Some(42) = Some(42) {
+56 |     println!("world!")
+57 | }
+   |
 
 error: this `else { if .. }` block can be collapsed
   --> collapsible_if.rs:63:12
@@ -135,12 +151,14 @@ error: this `else { if .. }` block can be collapsed
    | |_____^
    |
 help: try
-   |     } else if y == "world" {
-   |     println!("world")
-   | }
-   | else {
-   |     println!("!")
-   | }
+   |
+63 |     } else if y == "world" {
+64 |     println!("world")
+65 | }
+66 | else {
+67 |     println!("!")
+68 | }
+   |
 
 error: this `else { if .. }` block can be collapsed
   --> collapsible_if.rs:74:12
@@ -156,12 +174,14 @@ error: this `else { if .. }` block can be collapsed
    | |_____^
    |
 help: try
-   |     } else if let Some(42) = Some(42) {
-   |     println!("world")
-   | }
-   | else {
-   |     println!("!")
-   | }
+   |
+74 |     } else if let Some(42) = Some(42) {
+75 |     println!("world")
+76 | }
+77 | else {
+78 |     println!("!")
+79 | }
+   |
 
 error: this `else { if .. }` block can be collapsed
   --> collapsible_if.rs:85:12
@@ -177,12 +197,14 @@ error: this `else { if .. }` block can be collapsed
    | |_____^
    |
 help: try
-   |     } else if let Some(42) = Some(42) {
-   |     println!("world")
-   | }
-   | else {
-   |     println!("!")
-   | }
+   |
+85 |     } else if let Some(42) = Some(42) {
+86 |     println!("world")
+87 | }
+88 | else {
+89 |     println!("!")
+90 | }
+   |
 
 error: this `else { if .. }` block can be collapsed
    --> collapsible_if.rs:96:12
@@ -198,12 +220,14 @@ error: this `else { if .. }` block can be collapsed
     | |_____^
     |
 help: try
-    |     } else if x == "hello" {
-    |     println!("world")
-    | }
-    | else {
-    |     println!("!")
-    | }
+    |
+96  |     } else if x == "hello" {
+97  |     println!("world")
+98  | }
+99  | else {
+100 |     println!("!")
+101 | }
+    |
 
 error: this `else { if .. }` block can be collapsed
    --> collapsible_if.rs:107:12
@@ -219,12 +243,14 @@ error: this `else { if .. }` block can be collapsed
     | |_____^
     |
 help: try
-    |     } else if let Some(42) = Some(42) {
-    |     println!("world")
-    | }
-    | else {
-    |     println!("!")
-    | }
+    |
+107 |     } else if let Some(42) = Some(42) {
+108 |     println!("world")
+109 | }
+110 | else {
+111 |     println!("!")
+112 | }
+    |
 
 error: aborting due to 13 previous errors
 

--- a/clippy_tests/examples/complex_types.rs
+++ b/clippy_tests/examples/complex_types.rs
@@ -2,7 +2,7 @@
 #![plugin(clippy)]
 #![warn(clippy)]
 #![allow(unused, needless_pass_by_value)]
-#![feature(associated_consts, associated_type_defaults)]
+#![feature(associated_type_defaults)]
 
 type Alias = Vec<Vec<Box<(u32, u32, u32, u32)>>>; // no warning here
 

--- a/clippy_tests/examples/dlist.rs
+++ b/clippy_tests/examples/dlist.rs
@@ -1,6 +1,5 @@
 #![feature(plugin, alloc)]
 #![feature(associated_type_defaults)]
-#![feature(associated_consts)]
 
 #![plugin(clippy)]
 #![warn(clippy)]

--- a/clippy_tests/examples/dlist.stderr
+++ b/clippy_tests/examples/dlist.stderr
@@ -1,48 +1,48 @@
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
-  --> dlist.rs:13:16
+  --> dlist.rs:12:16
    |
-13 |     type Baz = LinkedList<u8>;
+12 |     type Baz = LinkedList<u8>;
    |                ^^^^^^^^^^^^^^
    |
    = note: `-D linkedlist` implied by `-D warnings`
    = help: a VecDeque might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
-  --> dlist.rs:14:12
+  --> dlist.rs:13:12
    |
-14 |     fn foo(LinkedList<u8>);
+13 |     fn foo(LinkedList<u8>);
    |            ^^^^^^^^^^^^^^
    |
    = help: a VecDeque might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
-  --> dlist.rs:15:24
+  --> dlist.rs:14:24
    |
-15 |     const BAR : Option<LinkedList<u8>>;
+14 |     const BAR : Option<LinkedList<u8>>;
    |                        ^^^^^^^^^^^^^^
    |
    = help: a VecDeque might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
-  --> dlist.rs:26:15
+  --> dlist.rs:25:15
    |
-26 |     fn foo(_: LinkedList<u8>) {}
+25 |     fn foo(_: LinkedList<u8>) {}
    |               ^^^^^^^^^^^^^^
    |
    = help: a VecDeque might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
-  --> dlist.rs:29:39
+  --> dlist.rs:28:39
    |
-29 | pub fn test(my_favourite_linked_list: LinkedList<u8>) {
+28 | pub fn test(my_favourite_linked_list: LinkedList<u8>) {
    |                                       ^^^^^^^^^^^^^^
    |
    = help: a VecDeque might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
-  --> dlist.rs:33:29
+  --> dlist.rs:32:29
    |
-33 | pub fn test_ret() -> Option<LinkedList<u8>> {
+32 | pub fn test_ret() -> Option<LinkedList<u8>> {
    |                             ^^^^^^^^^^^^^^
    |
    = help: a VecDeque might work

--- a/clippy_tests/examples/enums_clike.rs
+++ b/clippy_tests/examples/enums_clike.rs
@@ -1,5 +1,5 @@
 // ignore-x86
-#![feature(plugin, associated_consts)]
+#![feature(plugin)]
 #![plugin(clippy)]
 #![warn(clippy)]
 

--- a/clippy_tests/examples/for_loop.rs
+++ b/clippy_tests/examples/for_loop.rs
@@ -249,8 +249,8 @@ fn main() {
     for _v in u.iter() { } // no error
 
     let mut out = vec![];
-    vec.iter().map(|x| out.push(x)).collect::<Vec<_>>();
-    let _y = vec.iter().map(|x| out.push(x)).collect::<Vec<_>>(); // this is fine
+    vec.iter().cloned().map(|x| out.push(x)).collect::<Vec<_>>();
+    let _y = vec.iter().cloned().map(|x| out.push(x)).collect::<Vec<_>>(); // this is fine
 
     // Loop with explicit counter variable
     let mut _index = 0;
@@ -346,6 +346,18 @@ fn main() {
     }
 
     test_for_kv_map();
+
+    fn f<T>(_: &T, _: &T) -> bool { unimplemented!() }
+    fn g<T>(_: &mut [T], _: usize, _: usize) { unimplemented!() }
+    for i in 1..vec.len() {
+        if f(&vec[i - 1], &vec[i]) {
+            g(&mut vec, i - 1, i);
+        }
+    }
+
+    for mid in 1..vec.len() {
+        let (_, _) = vec.split_at(mid);
+    }
 }
 
 #[allow(used_underscore_binding)]
@@ -357,4 +369,18 @@ fn test_for_kv_map() {
         let _ = _value;
         let _k = k;
     }
+}
+
+#[allow(dead_code)]
+fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {
+    let pivot = v.len() - 1;
+    let mut i = 0;
+    for j in 0..pivot {
+        if v[j] <= v[pivot] {
+            v.swap(i, j);
+            i += 1;
+        }
+    }
+    v.swap(i, pivot);
+    i
 }

--- a/clippy_tests/examples/for_loop.stderr
+++ b/clippy_tests/examples/for_loop.stderr
@@ -419,8 +419,8 @@ error: you are iterating over `Iterator::next()` which is an Option; this will c
 error: you are collect()ing an iterator and throwing away the result. Consider using an explicit for loop to exhaust the iterator
    --> for_loop.rs:252:5
     |
-252 |     vec.iter().map(|x| out.push(x)).collect::<Vec<_>>();
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+252 |     vec.iter().cloned().map(|x| out.push(x)).collect::<Vec<_>>();
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `-D unused-collect` implied by `-D warnings`
 

--- a/clippy_tests/examples/for_loop.stderr
+++ b/clippy_tests/examples/for_loop.stderr
@@ -80,7 +80,9 @@ error: the loop variable `i` is only used to index `vec`.
    |
    = note: `-D needless-range-loop` implied by `-D warnings`
 help: consider using an iterator
-   |     for <item> in &vec {
+   |
+84 |     for <item> in &vec {
+   |         ^^^^^^
 
 error: unused variable: `i`
   --> for_loop.rs:88:9
@@ -97,7 +99,9 @@ error: the loop variable `i` is only used to index `vec`.
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider using an iterator
-   |     for <item> in &vec { let _ = vec[i]; }
+   |
+93 |     for <item> in &vec { let _ = vec[i]; }
+   |         ^^^^^^
 
 error: the loop variable `j` is only used to index `STATIC`.
   --> for_loop.rs:96:5
@@ -108,7 +112,9 @@ error: the loop variable `j` is only used to index `STATIC`.
    | |_____^
    |
 help: consider using an iterator
-   |     for <item> in STATIC.iter().take(4) {
+   |
+96 |     for <item> in STATIC.iter().take(4) {
+   |         ^^^^^^
 
 error: the loop variable `j` is only used to index `CONST`.
    --> for_loop.rs:100:5
@@ -119,7 +125,9 @@ error: the loop variable `j` is only used to index `CONST`.
     | |_____^
     |
 help: consider using an iterator
-    |     for <item> in CONST.iter().take(4) {
+    |
+100 |     for <item> in CONST.iter().take(4) {
+    |         ^^^^^^
 
 error: the loop variable `i` is used to index `vec`
    --> for_loop.rs:104:5
@@ -130,7 +138,9 @@ error: the loop variable `i` is used to index `vec`
     | |_____^
     |
 help: consider using an iterator
-    |     for (i, <item>) in vec.iter().enumerate() {
+    |
+104 |     for (i, <item>) in vec.iter().enumerate() {
+    |         ^^^^^^^^^^^
 
 error: the loop variable `i` is only used to index `vec2`.
    --> for_loop.rs:111:5
@@ -141,7 +151,9 @@ error: the loop variable `i` is only used to index `vec2`.
     | |_____^
     |
 help: consider using an iterator
-    |     for <item> in vec2.iter().take(vec.len()) {
+    |
+111 |     for <item> in vec2.iter().take(vec.len()) {
+    |         ^^^^^^
 
 error: the loop variable `i` is only used to index `vec`.
    --> for_loop.rs:115:5
@@ -152,7 +164,9 @@ error: the loop variable `i` is only used to index `vec`.
     | |_____^
     |
 help: consider using an iterator
-    |     for <item> in vec.iter().skip(5) {
+    |
+115 |     for <item> in vec.iter().skip(5) {
+    |         ^^^^^^
 
 error: the loop variable `i` is only used to index `vec`.
    --> for_loop.rs:119:5
@@ -163,7 +177,9 @@ error: the loop variable `i` is only used to index `vec`.
     | |_____^
     |
 help: consider using an iterator
-    |     for <item> in vec.iter().take(MAX_LEN) {
+    |
+119 |     for <item> in vec.iter().take(MAX_LEN) {
+    |         ^^^^^^
 
 error: the loop variable `i` is only used to index `vec`.
    --> for_loop.rs:123:5
@@ -174,7 +190,9 @@ error: the loop variable `i` is only used to index `vec`.
     | |_____^
     |
 help: consider using an iterator
-    |     for <item> in vec.iter().take(MAX_LEN + 1) {
+    |
+123 |     for <item> in vec.iter().take(MAX_LEN + 1) {
+    |         ^^^^^^
 
 error: the loop variable `i` is only used to index `vec`.
    --> for_loop.rs:127:5
@@ -185,7 +203,9 @@ error: the loop variable `i` is only used to index `vec`.
     | |_____^
     |
 help: consider using an iterator
-    |     for <item> in vec.iter().take(10).skip(5) {
+    |
+127 |     for <item> in vec.iter().take(10).skip(5) {
+    |         ^^^^^^
 
 error: the loop variable `i` is only used to index `vec`.
    --> for_loop.rs:131:5
@@ -196,7 +216,9 @@ error: the loop variable `i` is only used to index `vec`.
     | |_____^
     |
 help: consider using an iterator
-    |     for <item> in vec.iter().take(10 + 1).skip(5) {
+    |
+131 |     for <item> in vec.iter().take(10 + 1).skip(5) {
+    |         ^^^^^^
 
 error: the loop variable `i` is used to index `vec`
    --> for_loop.rs:135:5
@@ -207,7 +229,9 @@ error: the loop variable `i` is used to index `vec`
     | |_____^
     |
 help: consider using an iterator
-    |     for (i, <item>) in vec.iter().enumerate().skip(5) {
+    |
+135 |     for (i, <item>) in vec.iter().enumerate().skip(5) {
+    |         ^^^^^^^^^^^
 
 error: the loop variable `i` is used to index `vec`
    --> for_loop.rs:139:5
@@ -218,7 +242,9 @@ error: the loop variable `i` is used to index `vec`
     | |_____^
     |
 help: consider using an iterator
-    |     for (i, <item>) in vec.iter().enumerate().take(10).skip(5) {
+    |
+139 |     for (i, <item>) in vec.iter().enumerate().take(10).skip(5) {
+    |         ^^^^^^^^^^^
 
 error: this range is empty so this for loop will never run
    --> for_loop.rs:143:5
@@ -230,7 +256,9 @@ error: this range is empty so this for loop will never run
     |
     = note: `-D reverse-range-loop` implied by `-D warnings`
 help: consider using the following if you are attempting to iterate over this range in reverse
-    |     for i in (0..10).rev() {
+    |
+143 |     for i in (0..10).rev() {
+    |              ^^^^^^^^^^^^^
 
 error: this range is empty so this for loop will never run
    --> for_loop.rs:147:5
@@ -241,7 +269,9 @@ error: this range is empty so this for loop will never run
     | |_____^
     |
 help: consider using the following if you are attempting to iterate over this range in reverse
-    |     for i in (0...10).rev() {
+    |
+147 |     for i in (0...10).rev() {
+    |              ^^^^^^^^^^^^^^
 
 error: this range is empty so this for loop will never run
    --> for_loop.rs:151:5
@@ -252,7 +282,9 @@ error: this range is empty so this for loop will never run
     | |_____^
     |
 help: consider using the following if you are attempting to iterate over this range in reverse
-    |     for i in (0..MAX_LEN).rev() {
+    |
+151 |     for i in (0..MAX_LEN).rev() {
+    |              ^^^^^^^^^^^^^^^^^^
 
 error: this range is empty so this for loop will never run
    --> for_loop.rs:155:5
@@ -271,7 +303,9 @@ error: this range is empty so this for loop will never run
     | |_____^
     |
 help: consider using the following if you are attempting to iterate over this range in reverse
-    |     for i in (5+4..10).rev() {
+    |
+176 |     for i in (5+4..10).rev() {
+    |              ^^^^^^^^^^^^^^^
 
 error: this range is empty so this for loop will never run
    --> for_loop.rs:180:5
@@ -282,7 +316,9 @@ error: this range is empty so this for loop will never run
     | |_____^
     |
 help: consider using the following if you are attempting to iterate over this range in reverse
-    |     for i in ((3-1)..(5+2)).rev() {
+    |
+180 |     for i in ((3-1)..(5+2)).rev() {
+    |              ^^^^^^^^^^^^^^^^^^^^
 
 error: this range is empty so this for loop will never run
    --> for_loop.rs:184:5
@@ -412,7 +448,9 @@ error: you seem to want to iterate on a map's values
     |
     = note: `-D for-kv-map` implied by `-D warnings`
 help: use the corresponding method
-    |     for v in m.values() {
+    |
+321 |     for v in m.values() {
+    |         ^
 
 error: you seem to want to iterate on a map's values
    --> for_loop.rs:326:5
@@ -425,7 +463,9 @@ error: you seem to want to iterate on a map's values
     | |_____^
     |
 help: use the corresponding method
-    |     for v in (*m).values() {
+    |
+326 |     for v in (*m).values() {
+    |         ^
 
 error: you seem to want to iterate on a map's values
    --> for_loop.rs:333:5
@@ -436,7 +476,9 @@ error: you seem to want to iterate on a map's values
     | |_____^
     |
 help: use the corresponding method
-    |     for v in m.values_mut() {
+    |
+333 |     for v in m.values_mut() {
+    |         ^
 
 error: you seem to want to iterate on a map's values
    --> for_loop.rs:338:5
@@ -447,7 +489,9 @@ error: you seem to want to iterate on a map's values
     | |_____^
     |
 help: use the corresponding method
-    |     for v in (*m).values_mut() {
+    |
+338 |     for v in (*m).values_mut() {
+    |         ^
 
 error: you seem to want to iterate on a map's keys
    --> for_loop.rs:344:5
@@ -458,7 +502,9 @@ error: you seem to want to iterate on a map's keys
     | |_____^
     |
 help: use the corresponding method
-    |     for k in rm.keys() {
+    |
+344 |     for k in rm.keys() {
+    |         ^
 
 error: aborting due to 51 previous errors
 

--- a/clippy_tests/examples/large_enum_variant.stderr
+++ b/clippy_tests/examples/large_enum_variant.stderr
@@ -6,7 +6,9 @@ error: large size difference between variants
    |
    = note: `-D large-enum-variant` implied by `-D warnings`
 help: consider boxing the large fields to reduce the total size of the enum
-   |     B(Box<[i32; 8000]>),
+   |
+10 |     B(Box<[i32; 8000]>),
+   |       ^^^^^^^^^^^^^^^^
 
 error: large size difference between variants
   --> large_enum_variant.rs:21:5
@@ -27,7 +29,9 @@ error: large size difference between variants
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider boxing the large fields to reduce the total size of the enum
-   |     ContainingLargeEnum(Box<LargeEnum>),
+   |
+34 |     ContainingLargeEnum(Box<LargeEnum>),
+   |                         ^^^^^^^^^^^^^^
 
 error: large size difference between variants
   --> large_enum_variant.rs:37:5
@@ -60,7 +64,9 @@ error: large size difference between variants
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider boxing the large fields to reduce the total size of the enum
-   |     StructLikeLarge2 { x: Box<[i32; 8000]> },
+   |
+49 |     StructLikeLarge2 { x: Box<[i32; 8000]> },
+   |                           ^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/clippy_tests/examples/literals.stderr
+++ b/clippy_tests/examples/literals.stderr
@@ -34,9 +34,13 @@ error: this is a decimal constant
    |
    = note: `-D zero-prefixed-literal` implied by `-D warnings`
 help: if you mean to use a decimal constant, remove the `0` to remove confusion:
-   |     let fail_multi_zero = 123usize;
+   |
+17 |     let fail_multi_zero = 123usize;
+   |                           ^^^^^^^^
 help: if you mean to use an octal constant, use `0o`:
-   |     let fail_multi_zero = 0o123usize;
+   |
+17 |     let fail_multi_zero = 0o123usize;
+   |                           ^^^^^^^^^^
 
 error: integer type suffix should be separated by an underscore
   --> literals.rs:22:17
@@ -75,9 +79,13 @@ error: this is a decimal constant
    |                 ^^^^
    |
 help: if you mean to use a decimal constant, remove the `0` to remove confusion:
-   |     let fail8 = 123;
+   |
+30 |     let fail8 = 123;
+   |                 ^^^
 help: if you mean to use an octal constant, use `0o`:
-   |     let fail8 = 0o123;
+   |
+30 |     let fail8 = 0o123;
+   |                 ^^^^^
 
 error: aborting due to 11 previous errors
 

--- a/clippy_tests/examples/matches.stderr
+++ b/clippy_tests/examples/matches.stderr
@@ -131,7 +131,9 @@ error: you don't need to add `&` to all patterns
     |
     = note: `-D match-ref-pats` implied by `-D warnings`
 help: instead of prefixing all patterns with `&`, you can dereference the expression
-    |         match *v { .. }
+    |
+138 |         match *v { .. }
+    |         ^^^^^^^^^^^^^^^
 
 error: you don't need to add `&` to all patterns
    --> matches.rs:148:5
@@ -143,7 +145,9 @@ error: you don't need to add `&` to all patterns
     | |_____^
     |
 help: instead of prefixing all patterns with `&`, you can dereference the expression
-    |     match *tup { .. }
+    |
+148 |     match *tup { .. }
+    |     ^^^^^^^^^^^^^^^^^
 
 error: you don't need to add `&` to both the expression and the patterns
    --> matches.rs:154:5
@@ -163,7 +167,9 @@ error: you don't need to add `&` to all patterns
     | |_____^
     |
 help: instead of prefixing all patterns with `&`, you can dereference the expression
-    |     if let .. = *a { .. }
+    |
+165 |     if let .. = *a { .. }
+    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: you don't need to add `&` to both the expression and the patterns
    --> matches.rs:170:5

--- a/clippy_tests/examples/needless_pass_by_value.stderr
+++ b/clippy_tests/examples/needless_pass_by_value.stderr
@@ -31,8 +31,10 @@ error: this argument is passed by value, but not consumed in the function body
    |                  ^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider taking a reference instead
-   | fn test_match(x: &Option<Option<String>>, y: Option<Option<String>>) {
-   |     match *x {
+   |
+40 | fn test_match(x: &Option<Option<String>>, y: Option<Option<String>>) {
+41 |     match *x {
+   |
 
 error: this argument is passed by value, but not consumed in the function body
   --> needless_pass_by_value.rs:53:24
@@ -47,10 +49,12 @@ error: this argument is passed by value, but not consumed in the function body
    |                                    ^^^^^^^
    |
 help: consider taking a reference instead
-   | fn test_destructure(x: Wrapper, y: &Wrapper, z: Wrapper) {
-   |     let Wrapper(s) = z; // moved
-   |     let Wrapper(ref t) = *y; // not moved
-   |     let Wrapper(_) = *y; // still not moved
+   |
+53 | fn test_destructure(x: Wrapper, y: &Wrapper, z: Wrapper) {
+54 |     let Wrapper(s) = z; // moved
+55 |     let Wrapper(ref t) = *y; // not moved
+56 |     let Wrapper(_) = *y; // still not moved
+   |
 
 error: aborting due to 7 previous errors
 

--- a/clippy_tests/examples/new_without_default.stderr
+++ b/clippy_tests/examples/new_without_default.stderr
@@ -6,7 +6,9 @@ error: you should consider deriving a `Default` implementation for `Foo`
    |
    = note: `-D new-without-default-derive` implied by `-D warnings`
 help: try this
-   | #[derive(Default)]
+   |
+7  | #[derive(Default)]
+   |
 
 error: you should consider deriving a `Default` implementation for `Bar`
   --> new_without_default.rs:16:5
@@ -15,7 +17,9 @@ error: you should consider deriving a `Default` implementation for `Bar`
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try this
-   | #[derive(Default)]
+   |
+13 | #[derive(Default)]
+   |
 
 error: you should consider adding a `Default` implementation for `LtKo<'c>`
   --> new_without_default.rs:64:5
@@ -25,13 +29,14 @@ error: you should consider adding a `Default` implementation for `LtKo<'c>`
    |
    = note: `-D new-without-default` implied by `-D warnings`
 help: try this
-   |     impl Default for LtKo<'c> {
-   |         fn default() -> Self {
-   |             Self::new()
-   |         }
-   |     }
-   | 
-...
+   |
+64 |     impl Default for LtKo<'c> {
+65 |         fn default() -> Self {
+66 |             Self::new()
+67 |         }
+68 |     }
+69 | 
+ ...
 
 error: aborting due to 3 previous errors
 

--- a/clippy_tests/examples/op_ref.stderr
+++ b/clippy_tests/examples/op_ref.stderr
@@ -6,7 +6,9 @@ error: needlessly taken reference of both operands
    |
    = note: `-D op-ref` implied by `-D warnings`
 help: use the values directly
-   |     let foo = 5 - 6;
+   |
+13 |     let foo = 5 - 6;
+   |               ^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
fixes #1105
fixes #1803
fixes #1879

I changed the code to only lint if the loop body contains `v[i]`, but no other mentions of `i` or `v`. All existing unit tests keep linting, so no new false negatives.

Travis fails due to #1877